### PR TITLE
chore: improve image building infrastructure

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -52,3 +52,17 @@ github:
   ghp_branch: gh-pages
   ghp_path: /
 
+  protected_branches:
+    main:
+      required_status_checks:
+        strict: false
+        contexts:
+          - Build
+          - Lint
+          - Verify codegen
+          - Docker build
+          - Helm lint
+          - Unit & Integration
+          - Apache Rat
+      required_signatures: false
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,11 @@
 
 name: Release
 
-# TODO: Enable once the repository is set up upstream with GHCR access and
-# cosign signing infrastructure.
-# on:
-#   push:
-#     branches: [main]
-#     tags: ['v*']
-on: workflow_dispatch
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
 
 env:
   # Images are published to GHCR. The default image in Makefile/Helm uses
@@ -41,6 +39,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
@@ -63,6 +63,8 @@ jobs:
           tags: |
             # On push to main: sha-<short-sha>
             type=sha,prefix=sha-,format=short,enable={{is_default_branch}}
+            # On push to main: floating dev tag (latest main build)
+            type=raw,value=dev,enable={{is_default_branch}}
             # On tag push: strip 'v' prefix (v0.1.0 -> 0.1.0, v0.1.0-rc1 -> 0.1.0-rc1)
             type=semver,pattern={{version}}
             # On non-prerelease tag push: latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ The operator uses a **two-tier CRD architecture** where the parent `Superset` re
 - `config/` — Kustomize manifests (CRDs, RBAC, manager, samples, prometheus)
 - `cmd/main.go` — entrypoint, registers all reconcilers + Gateway API scheme
 - `docs/` — installation, architecture overview, internals, user guide, developer guide
+- `scripts/` — release automation (`release-rc.sh`, `release-finalize.sh`)
 - `test/e2e/` — end-to-end tests (require Kind cluster)
 
 ## Key Patterns

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -1,0 +1,90 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Downloads
+
+## Docker Images
+
+Operator images are published to the GitHub Container Registry (GHCR) and
+available via a Scarf analytics proxy that provides download metrics.
+
+### Registries
+
+| Registry | URL | Notes |
+|----------|-----|-------|
+| **GHCR (direct)** | `ghcr.io/apache/superset-kubernetes-operator` | Primary registry |
+| **Scarf proxy** | `apachesuperset.docker.scarf.sh/apache/superset-kubernetes-operator` | Default in Helm chart. Transparently redirects to GHCR. |
+
+Both URLs serve the same images. The Scarf proxy is used by default in the
+Helm chart and kustomize manifests to provide anonymous download metrics.
+
+### Architectures
+
+All images are multi-architecture manifests supporting:
+
+- `linux/amd64`
+- `linux/arm64`
+
+### Image Tags
+
+| Tag | Example | Description |
+|-----|---------|-------------|
+| `dev` | `dev` | Floating tag tracking the latest commit on `main`. Rebuilt on every merge. |
+| `sha-<short>` | `sha-abc1234` | Immutable tag for a specific commit. |
+| `<version>` | `0.2.0` | Semver release (no `v` prefix). Published when a version tag is pushed. |
+| `<version>-rc<N>` | `0.2.0-rc1` | Release candidate. Does not receive the `latest` tag. |
+| `latest` | `latest` | Points to the highest stable (non-prerelease) release. |
+
+### Choosing a Tag
+
+- **Production**: Pin to a semver tag (e.g., `0.2.0`) or a `sha-` tag for
+  full reproducibility.
+- **Testing pre-release features**: Use an RC tag (e.g., `0.2.0-rc1`) or `dev`.
+- **Avoid** using `latest` or `dev` in production — these are mutable and will
+  change without notice.
+
+### Image Signing
+
+All images are signed with [cosign](https://docs.sigstore.dev/cosign/overview/)
+using keyless OIDC signing via GitHub Actions. To verify an image:
+
+```bash
+cosign verify \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp 'github\.com/apache/superset-kubernetes-operator' \
+  ghcr.io/apache/superset-kubernetes-operator:<tag>
+```
+
+### Pulling an Image
+
+```bash
+# Via GHCR directly
+docker pull ghcr.io/apache/superset-kubernetes-operator:dev
+
+# Via Scarf proxy (default in Helm chart)
+docker pull apachesuperset.docker.scarf.sh/apache/superset-kubernetes-operator:dev
+```
+
+## Helm Chart
+
+The Helm chart is currently installed from a source checkout. See the
+[Installation](installation.md) guide for instructions.
+
+A hosted Helm repository (via GitHub Pages) and OCI registry distribution are
+planned for a future release.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -585,60 +585,53 @@ While the project is pre-1.0, all versions use `0.x.y` to signal instability per
 
 ### Release checklist
 
-The release workflow (`.github/workflows/release.yml`) is configured to build
-multi-platform images and push them to GHCR, but is currently disabled
-(`workflow_dispatch` only) until the upstream repository is set up with GHCR
-access and signing infrastructure. Once enabled, it will be triggered by pushes
-to `main` and version tags.
+The release workflow (`.github/workflows/release.yml`) builds multi-platform
+images and pushes them to GHCR. It runs automatically on pushes to `main`
+(producing `dev` and `sha-<short>` tags) and on version tags (producing semver
+tags). It can also be triggered manually via `workflow_dispatch`.
 
 **Image tagging:**
 
 | Trigger | Image tag | Example |
 |---|---|---|
-| Push to `main` | `sha-<short-sha>` | `sha-abc1234` |
+| Push to `main` | `dev` + `sha-<short-sha>` | `dev`, `sha-abc1234` |
 | RC tag | Semver without `v` prefix | `0.1.0-rc1` |
 | Release tag | Semver without `v` prefix + `latest` | `0.1.0`, `latest` |
 
-**Release process:**
+See [Downloads](artifacts.md) for full details on published images and
+registries.
 
-1. **Update the operator version** in the Makefile:
-   ```sh
-   # Edit VERSION in Makefile
-   VERSION ?= 0.2.0
-   ```
+**Creating a release candidate:**
 
-2. **Bump the chart version** in `charts/superset-operator/Chart.yaml` if chart
-   templates or values changed. If only the operator code changed, the chart version
-   can stay the same — `appVersion` is injected automatically.
+The `scripts/release-rc.sh` script automates the full RC preparation: creates a
+release branch, bumps the operator version, regenerates manifests, runs tests
+and linting, commits, and tags.
 
-3. **Regenerate manifests** (CRDs, RBAC, DeepCopy):
-   ```sh
-   make manifests generate
-   ```
+```sh
+# First RC for 0.2.0 — creates release/0.2.0 branch and v0.2.0-rc1 tag
+scripts/release-rc.sh 0.2.0
 
-4. **Run tests**:
-   ```sh
-   make test
-   make helm-lint
-   make docs-build
-   ```
+# Optionally bump the Helm chart version too
+scripts/release-rc.sh 0.2.0 --chart-version 0.2.0
 
-5. **Package the Helm chart**:
-   ```sh
-   make helm
-   ```
+# Push branch + tag to trigger the release workflow
+git push origin release/0.2.0 v0.2.0-rc1
+```
 
-6. **Tag the release candidate**:
-   ```sh
-   git tag v0.2.0-rc1
-   git push origin v0.2.0-rc1
-   ```
-   Then trigger the release workflow manually via `workflow_dispatch` in the
-   GitHub Actions UI. This builds and pushes the `0.2.0-rc1` image to GHCR.
+Running the script again from the same release branch increments the RC number
+automatically (rc1, rc2, ...).
 
-7. **After the release vote passes**, tag the final release:
-   ```sh
-   git tag v0.2.0
-   git push origin v0.2.0
-   ```
-   Trigger the release workflow again to push the `0.2.0` and `latest` images.
+**Finalizing a release:**
+
+After the ASF vote passes, the `scripts/release-finalize.sh` script tags the final
+release on the release branch:
+
+```sh
+# From the release/0.2.0 branch
+scripts/release-finalize.sh 0.2.0
+
+# Push the tag to trigger the release workflow
+git push origin v0.2.0
+```
+
+The release workflow pushes the `0.2.0` and `latest` images to GHCR.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -598,7 +598,7 @@ tags). It can also be triggered manually via `workflow_dispatch`.
 | RC tag | Semver without `v` prefix | `0.1.0-rc1` |
 | Release tag | Semver without `v` prefix + `latest` | `0.1.0`, `latest` |
 
-See [Downloads](artifacts.md) for full details on published images and
+See [Downloads](downloads.md) for full details on published images and
 registries.
 
 **Creating a release candidate:**

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -19,27 +19,14 @@ under the License.
 
 # Downloads
 
+!!! warning "Work in progress"
+    Container image and Helm chart publishing are being set up. Registry URLs
+    and pull commands will be added here once the infrastructure is confirmed.
+
 ## Docker Images
 
-Operator images are published to the GitHub Container Registry (GHCR) and
-available via a Scarf analytics proxy that provides download metrics.
-
-### Registries
-
-| Registry | URL | Notes |
-|----------|-----|-------|
-| **GHCR (direct)** | `ghcr.io/apache/superset-kubernetes-operator` | Primary registry |
-| **Scarf proxy** | `apachesuperset.docker.scarf.sh/apache/superset-kubernetes-operator` | Default in Helm chart. Transparently redirects to GHCR. |
-
-Both URLs serve the same images. The Scarf proxy is used by default in the
-Helm chart and kustomize manifests to provide anonymous download metrics.
-
-### Architectures
-
-All images are multi-architecture manifests supporting:
-
-- `linux/amd64`
-- `linux/arm64`
+Multi-architecture operator images (`linux/amd64`, `linux/arm64`) will be
+published on every merge to `main` and on version tags.
 
 ### Image Tags
 
@@ -62,24 +49,7 @@ All images are multi-architecture manifests supporting:
 ### Image Signing
 
 All images are signed with [cosign](https://docs.sigstore.dev/cosign/overview/)
-using keyless OIDC signing via GitHub Actions. To verify an image:
-
-```bash
-cosign verify \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp 'github\.com/apache/superset-kubernetes-operator' \
-  ghcr.io/apache/superset-kubernetes-operator:<tag>
-```
-
-### Pulling an Image
-
-```bash
-# Via GHCR directly
-docker pull ghcr.io/apache/superset-kubernetes-operator:dev
-
-# Via Scarf proxy (default in Helm chart)
-docker pull apachesuperset.docker.scarf.sh/apache/superset-kubernetes-operator:dev
-```
+using keyless OIDC signing via GitHub Actions.
 
 ## Helm Chart
 

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -48,8 +48,7 @@ published on every merge to `main` and on version tags.
 
 ### Image Signing
 
-All images are signed with [cosign](https://docs.sigstore.dev/cosign/overview/)
-using keyless OIDC signing via GitHub Actions.
+All images are signed with cosign using keyless OIDC signing via GitHub Actions.
 
 ## Helm Chart
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -39,7 +39,7 @@ helm install superset-operator charts/superset-operator \
 ```
 
 See `charts/superset-operator/values.yaml` for all available Helm values and
-[Downloads](artifacts.md) for published images and tag conventions.
+[Downloads](downloads.md) for published images and tag conventions.
 
 ## 2. Create secrets
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,17 +32,14 @@ This guide covers installing the operator and deploying a Superset instance.
 
 ## 1. Install the operator
 
-!!! note
-    The Helm chart and container images are not yet published to a registry.
-    Until the first release, install from a source checkout:
-
 ```bash
 helm install superset-operator charts/superset-operator \
   --namespace superset-operator-system \
   --create-namespace
 ```
 
-See `charts/superset-operator/values.yaml` for all available Helm values.
+See `charts/superset-operator/values.yaml` for all available Helm values and
+[Downloads](artifacts.md) for published images and tag conventions.
 
 ## 2. Create secrets
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ theme:
 nav:
   - Home: index.md
   - Installation: installation.md
+  - Downloads: artifacts.md
   - User Guide: user-guide.md
   - Architecture: architecture.md
   - Internals: internals.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,7 @@ theme:
 nav:
   - Home: index.md
   - Installation: installation.md
-  - Downloads: artifacts.md
+  - Downloads: downloads.md
   - User Guide: user-guide.md
   - Architecture: architecture.md
   - Internals: internals.md

--- a/scripts/release-finalize.sh
+++ b/scripts/release-finalize.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Finalize a release after the ASF vote passes: tag the final version
+# on the release branch.
+#
+# Usage:
+#   scripts/release-finalize.sh <version>
+#
+# Example:
+#   scripts/release-finalize.sh 0.2.0    # creates tag v0.2.0
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+die()  { echo -e "${RED}error:${RESET} $*" >&2; exit 1; }
+info() { echo -e "${GREEN}==>${RESET} $*"; }
+
+VERSION="${1:-}"
+[[ -n "$VERSION" ]] || die "usage: $0 <version>"
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "version must be semver (e.g., 0.2.0), got: $VERSION"
+
+[[ -f Makefile ]] || die "must be run from the repository root"
+
+TAG="v${VERSION}"
+BRANCH="release/${VERSION}"
+
+# --- preflight checks ---
+if [[ -n "$(git status --porcelain)" ]]; then
+  die "working tree is not clean — commit or stash changes first"
+fi
+
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" != "$BRANCH" ]]; then
+  die "must be on branch ${BRANCH} (currently on ${CURRENT_BRANCH})"
+fi
+
+LAST_RC=$(git tag -l "v${VERSION}-rc*" | sort -V | tail -1 || true)
+if [[ -z "$LAST_RC" ]]; then
+  die "no RC tags found for v${VERSION} — run scripts/release-rc.sh first"
+fi
+
+if git rev-parse "${TAG}" >/dev/null 2>&1; then
+  die "tag ${TAG} already exists"
+fi
+
+MAKEFILE_VERSION=$(grep -E '^VERSION \?=' Makefile | head -1 | awk '{print $3}')
+if [[ "$MAKEFILE_VERSION" != "$VERSION" ]]; then
+  die "Makefile VERSION is ${MAKEFILE_VERSION}, expected ${VERSION}"
+fi
+
+# --- tag ---
+info "Last RC was ${LAST_RC}"
+info "Creating final release tag ${TAG} at HEAD ($(git rev-parse --short HEAD))"
+git tag -a "${TAG}" -m "Release ${TAG}"
+
+# --- done ---
+echo ""
+echo -e "${BOLD}Release ${TAG} is tagged.${RESET}"
+echo ""
+echo "Next steps:"
+echo "  1. Push the tag:  git push origin ${TAG}"
+echo ""
+echo "The release workflow will push the ${VERSION} and latest images to GHCR."

--- a/scripts/release-rc.sh
+++ b/scripts/release-rc.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Prepare a release candidate: create release branch, bump version,
+# regenerate manifests, run checks, commit, and tag.
+#
+# Usage:
+#   scripts/release-rc.sh <version> [--chart-version <chart-version>]
+#
+# Examples:
+#   scripts/release-rc.sh 0.2.0               # first RC → v0.2.0-rc1
+#   scripts/release-rc.sh 0.2.0               # again   → v0.2.0-rc2
+#   scripts/release-rc.sh 0.3.0 --chart-version 0.2.0
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+die()  { echo -e "${RED}error:${RESET} $*" >&2; exit 1; }
+info() { echo -e "${GREEN}==>${RESET} $*"; }
+warn() { echo -e "${YELLOW}warning:${RESET} $*"; }
+
+# --- parse args ---
+VERSION=""
+CHART_VERSION=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --chart-version) CHART_VERSION="$2"; shift 2 ;;
+    -h|--help)
+      echo "Usage: $0 <version> [--chart-version <chart-version>]"
+      exit 0
+      ;;
+    -*)  die "unknown flag: $1" ;;
+    *)   VERSION="$1"; shift ;;
+  esac
+done
+
+[[ -n "$VERSION" ]] || die "usage: $0 <version> [--chart-version <chart-version>]"
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "version must be semver (e.g., 0.2.0), got: $VERSION"
+if [[ -n "$CHART_VERSION" ]]; then
+  [[ "$CHART_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "chart version must be semver, got: $CHART_VERSION"
+fi
+
+# --- preflight checks ---
+command -v helm >/dev/null 2>&1 || die "helm is required but not installed"
+[[ -f Makefile ]] || die "must be run from the repository root"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  die "working tree is not clean — commit or stash changes first"
+fi
+
+BRANCH="release/${VERSION}"
+CURRENT_BRANCH=$(git branch --show-current)
+
+# --- create or switch to release branch ---
+if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+  info "Switching to existing branch ${BRANCH}"
+  git checkout "${BRANCH}"
+else
+  if [[ "$CURRENT_BRANCH" != "main" ]]; then
+    die "must be on main to create a new release branch (currently on ${CURRENT_BRANCH})"
+  fi
+  info "Creating release branch ${BRANCH} from main"
+  git checkout -b "${BRANCH}"
+fi
+
+# --- determine RC number ---
+LAST_RC=$(git tag -l "v${VERSION}-rc*" | sort -V | tail -1 || true)
+if [[ -n "$LAST_RC" ]]; then
+  LAST_N="${LAST_RC##*-rc}"
+  RC_N=$((LAST_N + 1))
+else
+  RC_N=1
+fi
+TAG="v${VERSION}-rc${RC_N}"
+info "Preparing ${TAG}"
+
+# --- bump operator version in Makefile ---
+CURRENT_VERSION=$(grep -E '^VERSION \?=' Makefile | head -1 | awk '{print $3}')
+if [[ "$CURRENT_VERSION" != "$VERSION" ]]; then
+  info "Updating Makefile VERSION: ${CURRENT_VERSION} → ${VERSION}"
+  sed -i '' "s/^VERSION ?= .*/VERSION ?= ${VERSION}/" Makefile
+else
+  info "Makefile VERSION already set to ${VERSION}"
+fi
+
+# --- optionally bump chart version ---
+if [[ -n "$CHART_VERSION" ]]; then
+  info "Updating Chart.yaml version: → ${CHART_VERSION}"
+  sed -i '' "s/^version: .*/version: ${CHART_VERSION}/" charts/superset-operator/Chart.yaml
+fi
+
+# --- regenerate manifests ---
+info "Regenerating manifests and code"
+make manifests generate
+
+# --- run checks ---
+info "Running tests"
+make test-unit test-integration
+
+info "Linting Helm chart"
+make helm-lint
+
+info "Building docs"
+make docs-build
+
+# --- package Helm chart ---
+info "Packaging Helm chart"
+make helm
+
+# --- commit ---
+CHANGED_FILES=$(git diff --name-only)
+if [[ -n "$CHANGED_FILES" ]]; then
+  info "Committing version bump and regenerated files"
+  git add -A
+  git commit -m "chore: prepare ${TAG}
+
+Update VERSION to ${VERSION} and regenerate manifests."
+else
+  info "No file changes to commit"
+fi
+
+# --- tag ---
+if git rev-parse "${TAG}" >/dev/null 2>&1; then
+  die "tag ${TAG} already exists"
+fi
+info "Creating tag ${TAG}"
+git tag -a "${TAG}" -m "Release candidate ${TAG}"
+
+# --- done ---
+echo ""
+echo -e "${BOLD}Release candidate ${TAG} is ready.${RESET}"
+echo ""
+echo "Next steps:"
+echo "  1. Review the commit:  git log --oneline -3"
+echo "  2. Push branch + tag:  git push origin ${BRANCH} ${TAG}"
+echo ""
+echo "The release workflow will build and push the ${VERSION}-rc${RC_N} image to GHCR."


### PR DESCRIPTION
Activate automated Docker image publishing to GHCR and add release tooling. Every merge to main now builds and pushes a multi-arch operator image tagged `dev` (floating) and `sha-<short>` (immutable), signed with cosign. Version tags produce semver images and latest. A new "Downloads" docs page gives users a single reference for all published artifacts, and two release scripts automate the RC and final release workflows end-to-end.

- Activate the release workflow (`.github/workflows/release.yml`): uncomment on.push trigger, add `dev` floating tag, add fetch-depth: 0 for full git history
- Add `docs/downloads.md` ("Downloads" page): registries, tag conventions, multi-arch support, cosign verification, Helm chart status
- Add `scripts/release-rc.sh`: creates release branch, bumps version, regenerates manifests, runs tests/lint/docs, commits, and tags the next RC
- Add `scripts/release-finalize.sh`: validates state and tags the final release after ASF vote
- Update `docs/installation.md`: remove "not yet published" admonition, link to Downloads
- Update `docs/developer-guide.md`: replace manual release checklist with script-based workflow, add dev tag to image tagging table
- Update `AGENTS.md`: add `scripts/` to directory layout
- Protect `main` branch and require CI to pass.