### PR TITLE
chore: add codecov and pr templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,50 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+## Summary
+
+<!--
+Required: Write at least one paragraph explaining what this PR does and why.
+A reviewer should be able to understand the motivation and scope from this
+section alone, without reading the diff.
+-->
+
+## Details
+
+<!--
+Optional: Add implementation notes, design decisions, alternatives considered,
+migration steps, or anything else that helps reviewers understand the change.
+Delete this section if the summary is sufficient.
+-->
+
+## Test Plan
+
+<!--
+Describe how you verified this change. Check all that apply and add details
+for manual testing.
+-->
+
+- [ ] Unit tests added/updated (`make test-unit`)
+- [ ] Integration tests added/updated (`make test-integration`)
+- [ ] Manual testing (describe below)
+
+## Related Issues
+
+<!--
+Optional: Link related issues. Use keywords to auto-close:
+Fixes #123, Relates to #456
+-->

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: PR
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5f7536c0ea # v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+          requireScope: false
+          scopes: |
+            api
+            controller
+            resolution
+            config
+            helm
+            ci
+            docs
+            deps
+          subjectPattern: ^.+$
+          subjectPatternError: "PR title must have a description after the type prefix."

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,7 +27,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5f7536c0ea # v5.5.3
+      - uses: amannn/action-semantic-pull-request@24e6f016c1e110f5353026c0b6129a4118b9146c # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,6 +35,20 @@ jobs:
           go-version-file: go.mod
       - name: Test
         run: make test-unit test-integration
+      - name: Upload unit test coverage
+        if: always()
+        uses: codecov/codecov-action@0565863a31f35c3f4b6abce8e0e3cfa8a8489350 # v5.4.3
+        with:
+          files: cover_ut.out
+          flags: unit
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload integration test coverage
+        if: always()
+        uses: codecov/codecov-action@0565863a31f35c3f4b6abce8e0e3cfa8a8489350 # v5.4.3
+        with:
+          files: cover.out
+          flags: integration
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   # TODO: enable E2E tests once test infrastructure is ready
   # e2e:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,14 +37,14 @@ jobs:
         run: make test-unit test-integration
       - name: Upload unit test coverage
         if: always()
-        uses: codecov/codecov-action@0565863a31f35c3f4b6abce8e0e3cfa8a8489350 # v5.4.3
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           files: cover_ut.out
           flags: unit
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload integration test coverage
         if: always()
-        uses: codecov/codecov-action@0565863a31f35c3f4b6abce8e0e3cfa8a8489350 # v5.4.3
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           files: cover.out
           flags: integration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,3 +132,11 @@ The operator uses a **two-tier CRD architecture** where the parent `Superset` re
 All components use the reserved container name `superset` for the main container. Since each component runs in its own Pod, names never collide. This allows `kubectl exec -it <pod> -c superset` without needing to know the component type.
 
 All CRD names (parent and child) are validated via CEL to be valid DNS labels (lowercase alphanumeric and hyphens, `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`, max 63 characters). DNS-label syntax is required because the operator derives Service names from the parent name + component suffix. Per-component CEL rules enforce that the parent name is short enough for each enabled component's suffix to fit within the 63-char Service name limit (e.g., `-websocket-server` = 17 chars limits parent to 46).
+
+## PR Conventions
+
+- **Title format**: `type(scope): description` or `type: description` — enforced by CI (`amannn/action-semantic-pull-request`). Scope is optional but encouraged.
+- **Types**: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `ci`, `build`, `perf`, `style`, `revert`
+- **Scopes** (when used): `api`, `controller`, `resolution`, `config`, `helm`, `ci`, `docs`, `deps`
+- **Description**: Every PR must have a Summary section with at least one paragraph explaining what and why. Use the Details section for implementation notes. PR template pre-fills these sections.
+- **Code coverage**: Codecov reports patch coverage and project delta on every PR (informational, no enforced targets).

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,36 +13,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Note: Generated/scaffolded directories (config/) are removed from the
-# Rat workdir by scripts/check_license.sh before Rat runs. This file
-# handles remaining file-level exclusions.
+coverage:
+  status:
+    project: off
+    patch: off
 
-# Git
-.*\.gitignore
+comment:
+  layout: "condensed_header, condensed_files, condensed_footer"
+  behavior: default
+  require_changes: true
 
-# Go
-.*go\.mod
-.*go\.sum
+ignore:
+  - "api/v1alpha1/zz_generated.deepcopy.go"
+  - "config/**"
+  - "test/e2e/**"
+  - "cmd/main.go"
 
-# Generated code
-.*zz_generated\.deepcopy\.go
-
-# Kustomize structural files
-.*kustomization\.yaml
-.*kustomizeconfig\.yaml
-.*PROJECT
-
-# Helm chart metadata
-.*Chart\.yaml
-.*values\.yaml
-
-# Documentation
-.*api-reference\.md
-.*docs-requirements\.txt
-.*mkdocs\.yml
-
-# CI / tooling
-.*\.claude.*
-.*rat-results\.txt
-.*Dockerfile\.cross
-.*codecov\.yml
+flags:
+  unit:
+    paths:
+      - "internal/"
+      - "api/"
+    carryforward: true
+  integration:
+    paths:
+      - "internal/"
+      - "api/"
+    carryforward: true

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -518,6 +518,80 @@ See `internal/controller/monitoring.go` for the implementation.
 
 ---
 
+## Pull Requests
+
+### Title format
+
+PR titles must follow the conventional commits format:
+
+```
+type(scope): description
+type: description
+```
+
+Scope is optional but encouraged when the change is scoped to a single area.
+
+CI validates this on every PR via the `PR / Validate PR title` check.
+
+**Allowed types:**
+
+| Type | Use for |
+|------|---------|
+| `feat` | New functionality |
+| `fix` | Bug fixes |
+| `refactor` | Code restructuring without behavior change |
+| `docs` | Documentation only |
+| `test` | Adding or updating tests |
+| `chore` | Maintenance (config, tooling, dependencies) |
+| `ci` | CI/CD workflow changes |
+| `build` | Build system or external dependency changes |
+| `perf` | Performance improvements |
+| `style` | Formatting, whitespace, linting |
+| `revert` | Reverting a previous commit |
+
+**Allowed scopes:**
+
+| Scope | Covers |
+|-------|--------|
+| `api` | CRD type definitions (`api/v1alpha1/`) |
+| `controller` | Reconciler logic (`internal/controller/`) |
+| `resolution` | Spec resolution/merge engine (`internal/resolution/`) |
+| `config` | Config rendering (`internal/config/`) |
+| `helm` | Helm chart (`charts/`) |
+| `ci` | CI workflows, tooling (`.github/`, `Makefile`) |
+| `docs` | Documentation (`docs/`) |
+| `deps` | Dependency updates |
+
+**Examples:**
+
+```
+feat(api): add tolerations field to PodTemplate
+fix(controller): handle nil deployment template in scaling reconciler
+docs: add valkey configuration examples to user guide
+chore(deps): bump controller-runtime to v0.20.0
+```
+
+### Description
+
+Every PR must include a **Summary** section with at least one paragraph
+explaining what the change does and why. A reviewer should understand the
+motivation and scope from the summary alone, without reading the diff.
+
+Use the optional **Details** section for implementation notes, design decisions,
+alternatives considered, or migration steps.
+
+The PR template (`PULL_REQUEST_TEMPLATE.md`) pre-fills these sections.
+
+### Code coverage
+
+CI uploads test coverage to [Codecov](https://codecov.io) on every PR. The
+Codecov bot posts a comment showing:
+
+- **Patch coverage** — what percentage of new/changed lines are covered by tests
+- **Project coverage delta** — how overall coverage changed
+
+---
+
 ## CI & Supply Chain
 
 All CI workflows live in `.github/workflows/`. When adding or modifying


### PR DESCRIPTION
Introduces three PR quality improvements: Codecov integration for coverage reporting, conventional commit PR title validation, and a PR template that guides contributors toward writing useful descriptions. Together these bring the project in line with standard ASF practices and make PRs easier to review at a glance.

**Details**

**Code coverage**: The test workflow now uploads unit and integration coverage profiles to Codecov, which posts a comment on each PR showing patch coverage and project coverage delta. Coverage is informational only — no enforced thresholds or gates. Requires one-time admin setup: enable the Codecov GitHub App and add `CODECOV_TOKEN` as a repository secret.

**PR title validation**: A new pr.yaml workflow validates that PR titles follow the conventional commits format (type: description or type(scope): description). Scope is optional but validated against an allowed list when provided. Types and scopes are documented in the developer guide.

**PR template**: A new `PULL_REQUEST_TEMPLATE.md` pre-fills Summary, Details, Test Plan, and Related Issues sections. The Summary section instructs contributors to write at least one paragraph explaining what the PR does and why.

The developer guide and `CLAUDE.md` are updated to document all three conventions.