### PR TITLE
ci: fix release workflow and clean up dead docker-buildx target

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,3 @@
-<!--
-Licensed to the Apache Software Foundation (ASF) under one or more
-contributor license agreements.  See the NOTICE file distributed with
-this work for additional information regarding copyright ownership.
-The ASF licenses this file to You under the Apache License, Version 2.0
-(the "License"); you may not use this file except in compliance with
-the License.  You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--->
-
 ## Summary
 
 <!--

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,13 +43,13 @@ jobs:
           fetch-depth: 0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -57,7 +57,7 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -72,7 +72,7 @@ jobs:
 
       - name: Build and push
         id: build-push
-        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -83,7 +83,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 
       - name: Sign image with cosign
         env:

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -42,6 +42,7 @@
 .*mkdocs\.yml
 
 # CI / tooling
+.*PULL_REQUEST_TEMPLATE\.md
 .*\.claude.*
 .*rat-results\.txt
 .*Dockerfile\.cross

--- a/Makefile
+++ b/Makefile
@@ -245,23 +245,6 @@ docker-build: ## Build docker image with the manager.
 docker-push: ## Push docker image with the manager.
 	$(CONTAINER_TOOL) push ${IMG}
 
-# PLATFORMS defines the target platforms for the manager image be built to provide support to multiple
-# architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
-# - be able to use docker buildx. More info: https://docs.docker.com/build/buildx/
-# - have enabled BuildKit. More info: https://docs.docker.com/develop/develop-images/build_enhancements/
-# - be able to push the image to your registry (i.e. if you do not set a valid value via IMG=<myregistry/image:<tag>> then the export will fail)
-# To adequately provide solutions that are compatible with multiple platforms, you should consider using this option.
-PLATFORMS ?= linux/arm64,linux/amd64
-.PHONY: docker-buildx
-docker-buildx: ## Build and push docker image for the manager for cross-platform support
-	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
-	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
-	- $(CONTAINER_TOOL) buildx create --name superset-kubernetes-operator-builder
-	$(CONTAINER_TOOL) buildx use superset-kubernetes-operator-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
-	- $(CONTAINER_TOOL) buildx rm superset-kubernetes-operator-builder
-	rm Dockerfile.cross
-
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist


### PR DESCRIPTION
## Summary

The release workflow has never run because the pinned SHA versions of the Docker and cosign GitHub Actions were not on the ASF org-wide allowlist. This bumps all six actions to the latest ASF-approved versions and removes the unused `docker-buildx` Makefile target.

## Details

Actions bumped to latest approved (non-expiring) SHAs:
- `docker/setup-qemu-action` v3.6.0 → v4.0.0
- `docker/setup-buildx-action` v3.10.0 → v4.0.0
- `docker/login-action` v3.4.0 → v4.1.0
- `docker/metadata-action` v5.7.0 → v6.0.0
- `docker/build-push-action` v6.16.0 → v7.1.0
- `sigstore/cosign-installer` v3.8.2 → v4.0.0

The Makefile `docker-buildx` target was dead code — it used a `Dockerfile.cross` sed hack, but the Dockerfile already has `TARGETOS`/`TARGETARCH` ARGs, and the release workflow uses `docker/build-push-action` directly.

Bycatch: remove ASF headers from PR template

## Test Plan

- [x] Manual testing (describe below)

Verify the Release workflow appears and runs in the Actions tab after merge.
Confirm multiplatform image is published to GHCR with `docker buildx imagetools inspect`.