### PR TITLE
ci: native cross compilation of docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 
 # Build the manager binary
 # To update the digest: docker pull golang:1.26 && docker inspect --format='{{index .RepoDigests 0}}' golang:1.26
-FROM golang:1.26@sha256:1e598ea5752ae26c093b746fd73c5095af97d6f2d679c43e83e0eac484a33dc3 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26@sha256:1e598ea5752ae26c093b746fd73c5095af97d6f2d679c43e83e0eac484a33dc3 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -32,11 +32,7 @@ COPY cmd/main.go cmd/main.go
 COPY api/ api/
 COPY internal/ internal/
 
-# Build
-# the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+# Cross-compile for the target platform (builder runs on BUILDPLATFORM, binary targets TARGETARCH)
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary

--- a/docs/security.md
+++ b/docs/security.md
@@ -20,8 +20,8 @@ under the License.
 # Security
 
 This document defines the security boundaries, assumptions, and scope for the
-Superset Kubernetes Operator. It covers the threat model, trust boundaries,
-RBAC justification, and vulnerability reporting process.
+Superset Kubernetes Operator. It covers trust boundaries, secret handling,
+RBAC justification, and vulnerability reporting.
 
 ## Trust Boundaries
 


### PR DESCRIPTION
## Summary

- Use native Go cross-compilation instead of QEMU emulation for multi-platform Docker builds, dramatically speeding up the arm64 image build on amd64 CI runners (from 10-20+ minutes down to ~2 minutes)
- Remove the QEMU setup step and unnecessary `fetch-depth: 0` from the release workflow since they are no longer needed
- Fix `security.md` opening paragraph that referenced a "threat model" section that doesn't exist in the document

## Details

The Operator SDK scaffolded Dockerfile ran the entire builder stage under QEMU emulation for each target platform. Since the operator is pure Go with `CGO_ENABLED=0`, adding `--platform=$BUILDPLATFORM` to the builder `FROM` line lets the Go toolchain run natively and cross-compile via `GOARCH=$TARGETARCH` without emulation.