### PR TITLE
chore: helm and image cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,8 @@ on:
   workflow_dispatch:
 
 env:
-  # Images are published to GHCR. The default image in Makefile/Helm uses
-  # apachesuperset.docker.scarf.sh — a Scarf analytics proxy that transparently
-  # redirects to GHCR, providing download metrics without affecting pulls.
   IMAGE_NAME: ghcr.io/apache/superset-kubernetes-operator
+  HELM_REGISTRY: oci://ghcr.io/apache/superset-kubernetes-operator/charts
 
 permissions:
   contents: read
@@ -86,7 +84,27 @@ jobs:
         run: |
           cosign sign --yes "${{ env.IMAGE_NAME }}@${DIGEST}"
 
-      # TODO: Automate Helm chart appVersion update during release.
-      # For tag-based releases, consider a step that updates
-      # charts/superset-operator/Chart.yaml appVersion to match the
-      # release version and commits/PRs the change.
+      - name: Install Helm
+        run: curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+      - name: Set chart version for release tags
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          sed -i "s/^version:.*/version: ${VERSION}/" charts/superset-operator/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"${VERSION}\"/" charts/superset-operator/Chart.yaml
+
+      - name: Package Helm chart
+        run: |
+          mkdir -p charts/superset-operator/crds
+          cp config/crd/bases/*.yaml charts/superset-operator/crds/
+          helm package charts/superset-operator
+
+      - name: Push Helm chart to GHCR OCI
+        run: |
+          helm push superset-operator-*.tgz ${{ env.HELM_REGISTRY }}
+
+      - name: Sign Helm chart with cosign
+        run: |
+          CHART_VERSION="$(grep '^version:' charts/superset-operator/Chart.yaml | awk '{print $2}')"
+          cosign sign --yes "${{ env.HELM_REGISTRY }}/superset-operator:${CHART_VERSION}"

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.1.0
+VERSION ?= 0.0.0-dev
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -44,7 +44,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # apache.org/superset-kubernetes-operator-bundle:$VERSION and apache.org/superset-kubernetes-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= apachesuperset.docker.scarf.sh/apache/superset-kubernetes-operator
+IMAGE_TAG_BASE ?= ghcr.io/apache/superset-kubernetes-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
@@ -65,7 +65,7 @@ endif
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
 OPERATOR_SDK_VERSION ?= v1.42.1
 # Image URL to use all building/pushing image targets
-IMG ?= apachesuperset.docker.scarf.sh/apache/superset-kubernetes-operator:latest
+IMG ?= ghcr.io/apache/superset-kubernetes-operator:latest
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -135,7 +135,7 @@ HELM_CHART_DIR ?= charts/superset-operator
 helm: manifests ## Sync CRDs into Helm chart and package it.
 	mkdir -p $(HELM_CHART_DIR)/crds
 	cp config/crd/bases/*.yaml $(HELM_CHART_DIR)/crds/
-	helm package $(HELM_CHART_DIR) --app-version $(VERSION)
+	helm package $(HELM_CHART_DIR)
 
 .PHONY: helm-lint
 helm-lint: ## Lint the Helm chart (syncs CRDs first).

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ under the License.
 > **Warning**: This project is under active development and is not yet stable. APIs, CRD schemas, and behavior may change without notice between releases. Do not use in production.
 
 [![CI](https://github.com/apache/superset-kubernetes-operator/actions/workflows/ci.yaml/badge.svg)](https://github.com/apache/superset-kubernetes-operator/actions/workflows/ci.yaml)
+[![codecov](https://codecov.io/gh/apache/superset-kubernetes-operator/branch/main/graph/badge.svg)](https://codecov.io/gh/apache/superset-kubernetes-operator)
+[![Go Report Card](https://goreportcard.com/badge/github.com/apache/superset-kubernetes-operator)](https://goreportcard.com/report/github.com/apache/superset-kubernetes-operator)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Docs](https://img.shields.io/badge/docs-apache.github.io-blue)](https://apache.github.io/superset-kubernetes-operator/)
 
 A Kubernetes operator for deploying and managing [Apache Superset](https://superset.apache.org/) on Kubernetes. Built with the Go-based [Operator SDK](https://sdk.operatorframework.io/), the operator is designed to be simple to get started with — a minimal deployment requires just a few lines of YAML — while giving advanced users full control over every component through shared top-level defaults, per-component overrides, and direct access to flattened child CRDs.
@@ -61,7 +64,9 @@ The operator manages eight CRDs under the `superset.apache.org/v1alpha1` API gro
 Install the operator via Helm:
 
 ```sh
-helm install superset-operator charts/superset-operator \
+helm install superset-operator \
+  oci://ghcr.io/apache/superset-kubernetes-operator/charts/superset-operator \
+  --version <version> \
   --namespace superset-operator-system \
   --create-namespace
 ```

--- a/charts/superset-operator/Chart.yaml
+++ b/charts/superset-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: superset-operator
 description: Kubernetes operator for deploying and managing Apache Superset
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.0.0-dev
+appVersion: "dev"
 home: https://github.com/apache/superset-kubernetes-operator
 sources:
   - https://github.com/apache/superset-kubernetes-operator

--- a/charts/superset-operator/values.yaml
+++ b/charts/superset-operator/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: apachesuperset.docker.scarf.sh/apache/superset-kubernetes-operator
+  repository: ghcr.io/apache/superset-kubernetes-operator
   tag: ""  # defaults to .Chart.AppVersion
   pullPolicy: IfNotPresent
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,8 +3,8 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: apachesuperset.docker.scarf.sh/apache/superset-kubernetes-operator
-  newName: apachesuperset.docker.scarf.sh/apache/superset-kubernetes-operator
+- name: ghcr.io/apache/superset-kubernetes-operator
+  newName: ghcr.io/apache/superset-kubernetes-operator
   newTag: latest
 - name: controller
   newName: localhost/superset-operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -40,7 +40,7 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: apachesuperset.docker.scarf.sh/apache/superset-kubernetes-operator:latest
+        image: ghcr.io/apache/superset-kubernetes-operator:latest
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -19,14 +19,24 @@ under the License.
 
 # Downloads
 
-!!! warning "Work in progress"
-    Container image and Helm chart publishing are being set up. Registry URLs
-    and pull commands will be added here once the infrastructure is confirmed.
+!!! note
+    There are no official releases yet. Only `dev` and `sha-<short>` image tags
+    and the `0.0.0-dev` Helm chart are currently available.
 
-## Docker Images
+## Operator Image
 
-Multi-architecture operator images (`linux/amd64`, `linux/arm64`) will be
-published on every merge to `main` and on version tags.
+Multi-architecture operator images (`linux/amd64`, `linux/arm64`) are published
+to the GitHub Container Registry on every merge to `main` and on version tags:
+
+```
+ghcr.io/apache/superset-kubernetes-operator
+```
+
+### Pull
+
+```bash
+docker pull ghcr.io/apache/superset-kubernetes-operator:dev
+```
 
 ### Image Tags
 
@@ -34,26 +44,63 @@ published on every merge to `main` and on version tags.
 |-----|---------|-------------|
 | `dev` | `dev` | Floating tag tracking the latest commit on `main`. Rebuilt on every merge. |
 | `sha-<short>` | `sha-abc1234` | Immutable tag for a specific commit. |
-| `<version>` | `0.2.0` | Semver release (no `v` prefix). Published when a version tag is pushed. |
-| `<version>-rc<N>` | `0.2.0-rc1` | Release candidate. Does not receive the `latest` tag. |
+| `<version>` | `0.1.0` | Semver release. Published when a version tag is pushed. |
+| `<version>-rc<N>` | `0.1.0-rc1` | Release candidate. |
 | `latest` | `latest` | Points to the highest stable (non-prerelease) release. |
 
 ### Choosing a Tag
 
-- **Production**: Pin to a semver tag (e.g., `0.2.0`) or a `sha-` tag for
+- **Production**: Pin to a semver tag (e.g., `0.1.0`) or a `sha-` tag for
   full reproducibility.
-- **Testing pre-release features**: Use an RC tag (e.g., `0.2.0-rc1`) or `dev`.
+- **Testing pre-release features**: Use an RC tag (e.g., `0.1.0-rc1`) or `dev`.
 - **Avoid** using `latest` or `dev` in production — these are mutable and will
   change without notice.
 
 ### Image Signing
 
-All images are signed with cosign using keyless OIDC signing via GitHub Actions.
+All images are signed with [cosign](https://docs.sigstore.dev/cosign/overview/)
+using keyless OIDC signing via GitHub Actions. To verify:
+
+```bash
+cosign verify \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp 'github\.com/apache/superset-kubernetes-operator' \
+  ghcr.io/apache/superset-kubernetes-operator:<tag>
+```
 
 ## Helm Chart
 
-The Helm chart is currently installed from a source checkout. See the
-[Installation](installation.md) guide for instructions.
+The Helm chart is published as an OCI artifact to the GitHub Container Registry
+on every merge to `main` and on version tags.
 
-A hosted Helm repository (via GitHub Pages) and OCI registry distribution are
-planned for a future release.
+### Install from OCI
+
+```bash
+helm install superset-operator \
+  oci://ghcr.io/apache/superset-kubernetes-operator/charts/superset-operator \
+  --version <version> \
+  --namespace superset-operator-system \
+  --create-namespace
+```
+
+Replace `<version>` with a chart version from the table below. For the latest
+development build, use `0.0.0-dev`.
+
+### Chart Versions
+
+| Tag | Description |
+|-----|-------------|
+| `0.0.0-dev` | Floating tag tracking the latest commit on `main`. |
+| `<version>` (e.g., `0.1.0`) | Semver release. |
+| `<version>-rc<N>` (e.g., `0.1.0-rc1`) | Release candidate. |
+
+### Install from Source
+
+For development or to test unreleased changes, install directly from a source
+checkout:
+
+```bash
+helm install superset-operator charts/superset-operator \
+  --namespace superset-operator-system \
+  --create-namespace
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,6 +32,18 @@ This guide covers installing the operator and deploying a Superset instance.
 
 ## 1. Install the operator
 
+Install from the OCI Helm registry:
+
+```bash
+helm install superset-operator \
+  oci://ghcr.io/apache/superset-kubernetes-operator/charts/superset-operator \
+  --version <version> \
+  --namespace superset-operator-system \
+  --create-namespace
+```
+
+Or from a source checkout:
+
 ```bash
 helm install superset-operator charts/superset-operator \
   --namespace superset-operator-system \


### PR DESCRIPTION
## Summary

- Switch operator image from Scarf proxy (apachesuperset.docker.scarf.sh/apache/superset-kubernetes-operator) to GHCR (`ghcr.io/apache/superset-kubernetes-operator`) across Makefile, Helm chart, kustomize config, and docs. The Superset app image default stays on Scarf.
- Set in-repo version to `0.0.0-dev` as a permanent placeholder on main. Actual versions are only stamped on release branches. Chart appVersion is dev to match the floating GHCR image tag.
- Add Helm OCI publishing to the release workflow: chart is packaged and pushed to oci://ghcr.io/apache/superset-kubernetes-operator/charts on every main merge (`0.0.0-dev`) and on version tags (`version/appVersion` set from git tag). Charts are signed with cosign.
- Rewrite `docs/downloads.md` with GHCR pull commands, Helm OCI install instructions, and cosign verification. Update docs/installation.md and README.md with OCI as the primary install method.
- Add Codecov, Go Report Card, and License badges to README.
