### PR TITLE
fix(ci): strip oci:// prefix from cosign sign for Helm chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,4 +107,5 @@ jobs:
       - name: Sign Helm chart with cosign
         run: |
           CHART_VERSION="$(grep '^version:' charts/superset-operator/Chart.yaml | awk '{print $2}')"
-          cosign sign --yes "${{ env.HELM_REGISTRY }}/superset-operator:${CHART_VERSION}"
+          CHART_REF="${{ env.HELM_REGISTRY }}/superset-operator:${CHART_VERSION}"
+          cosign sign --yes "${CHART_REF#oci://}"


### PR DESCRIPTION
## Summary

The Helm chart signing step in the release workflow was passing the `oci://` prefixed registry URL to cosign sign. The `oci://` scheme is a Helm convention understood by helm push, but cosign interprets it as a hostname, causing DNS resolution failure (`dial tcp: lookup oci`). Fix strips the prefix via bash parameter expansion so cosign receives a plain registry reference.
