### PR TITLE
ci: add API reference staleness check to codegen verification

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,14 +55,15 @@ jobs:
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.3.0
         with:
           go-version-file: go.mod
-      - name: Generate manifests and sync Helm CRDs
+      - name: Generate manifests, sync Helm CRDs, and generate API docs
         run: |
           make manifests generate
           cp config/crd/bases/*.yaml charts/superset-operator/crds/
+          make docs-api
       - name: Check for uncommitted changes
         run: |
           if [ -n "$(git status --porcelain)" ]; then
-            echo "Generated files are not up to date. Run 'make manifests generate', sync Helm CRDs, and commit the changes."
+            echo "Generated files are not up to date. Run 'make manifests generate', sync Helm CRDs, run 'make docs-api', and commit the changes."
             git diff
             exit 1
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,15 +55,12 @@ jobs:
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.3.0
         with:
           go-version-file: go.mod
-      - name: Generate manifests, sync Helm CRDs, and generate API docs
-        run: |
-          make manifests generate
-          cp config/crd/bases/*.yaml charts/superset-operator/crds/
-          make docs-api
+      - name: Regenerate all generated artifacts
+        run: make codegen
       - name: Check for uncommitted changes
         run: |
           if [ -n "$(git status --porcelain)" ]; then
-            echo "Generated files are not up to date. Run 'make manifests generate', sync Helm CRDs, run 'make docs-api', and commit the changes."
+            echo "Generated files are not up to date. Run 'make codegen' and commit the changes."
             git diff
             exit 1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,3 +154,5 @@ All CRD names (parent and child) are validated via CEL to be valid DNS labels (l
 - **docs/user-guide.md** is the full configuration reference. Here it's appropriate to name specific fields, presets, env vars, and show concrete YAML examples.
 - **docs/architecture.md** explains design decisions and internal structure for contributors and advanced users.
 - General principles: be concise and objective, avoid overselling or verbose language, reserve code blocks for real code (not ASCII art), minimize duplication between README and docs (README links to docs for details).
+- **API reference** (`docs/api-reference.md`) is generated from Go types via `make codegen`. Only operator-defined types are rendered; built-in Kubernetes types (e.g., `Affinity`, `Container`, `Volume`) are linked to [pkg.go.dev](https://pkg.go.dev) via `knownTypes` in `hack/api-ref-config.yaml`. When adding a field that references a new K8s type, add a `knownTypes` entry so it renders as a link rather than being inlined.
+- **`make codegen`** regenerates all generated artifacts (CRDs, DeepCopy, Helm CRDs, API docs). Run it after modifying types in `api/v1alpha1/`. CI verifies nothing is stale.

--- a/Makefile
+++ b/Makefile
@@ -125,25 +125,29 @@ docs-build: ## Build documentation site.
 
 .PHONY: docs-api
 docs-api: crd-ref-docs ## Generate API reference documentation from Go types.
-	$(CRD_REF_DOCS) --source-path=api/v1alpha1 --config=hack/api-ref-config.yaml --renderer=markdown --output-path=docs/api-reference.md
+	$(CRD_REF_DOCS) --source-path=api/v1alpha1 --config=hack/api-ref-config.yaml --renderer=markdown --max-depth=15 --output-path=docs/api-reference.md
 
 ##@ Helm
 
 HELM_CHART_DIR ?= charts/superset-operator
 
-.PHONY: helm
-helm: manifests ## Sync CRDs into Helm chart and package it.
+.PHONY: helm-sync-crds
+helm-sync-crds: ## Sync generated CRDs into the Helm chart.
 	mkdir -p $(HELM_CHART_DIR)/crds
 	cp config/crd/bases/*.yaml $(HELM_CHART_DIR)/crds/
+
+.PHONY: helm
+helm: manifests helm-sync-crds ## Sync CRDs into Helm chart and package it.
 	helm package $(HELM_CHART_DIR)
 
 .PHONY: helm-lint
-helm-lint: ## Lint the Helm chart (syncs CRDs first).
-	mkdir -p $(HELM_CHART_DIR)/crds
-	cp config/crd/bases/*.yaml $(HELM_CHART_DIR)/crds/
+helm-lint: helm-sync-crds ## Lint the Helm chart (syncs CRDs first).
 	helm lint $(HELM_CHART_DIR)
 
 ##@ Development
+
+.PHONY: codegen
+codegen: manifests generate helm-sync-crds docs-api ## Regenerate all generated artifacts (CRDs, DeepCopy, Helm CRDs, API docs).
 
 .PHONY: clean
 clean: ## Remove build artifacts, downloaded tools, and test cache.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -90,6 +90,7 @@ _Appears in:_
 | `podTemplate` _[PodTemplate](#podtemplate)_ | Pod and container template for Celery beat pods. |  | Optional: \{\} <br /> |
 | `image` _[ImageOverrideSpec](#imageoverridespec)_ | Image tag and/or repository overrides; inherits from spec.image if unset. |  | Optional: \{\} <br /> |
 | `config` _string_ | Per-component raw Python appended after top-level config. |  | Optional: \{\} <br /> |
+| `sqlaEngineOptions` _[SQLAlchemyEngineOptionsSpec](#sqlalchemyengineoptionsspec)_ | Per-component SQLAlchemy engine options (overrides spec.sqlaEngineOptions entirely). |  | Optional: \{\} <br /> |
 
 
 #### CeleryFlowerComponentSpec
@@ -135,6 +136,34 @@ _Appears in:_
 | `podDisruptionBudget` _[PDBSpec](#pdbspec)_ | PodDisruptionBudget for protecting availability during voluntary disruptions. Overrides spec.podDisruptionBudget. |  | Optional: \{\} <br /> |
 | `image` _[ImageOverrideSpec](#imageoverridespec)_ | Image tag and/or repository overrides; inherits from spec.image if unset. |  | Optional: \{\} <br /> |
 | `config` _string_ | Per-component raw Python appended after top-level config. |  | Optional: \{\} <br /> |
+| `celery` _[CeleryWorkerProcessSpec](#celeryworkerprocessspec)_ | Celery worker execution configuration. Controls concurrency, pool type, and related parameters. |  | Optional: \{\} <br /> |
+| `sqlaEngineOptions` _[SQLAlchemyEngineOptionsSpec](#sqlalchemyengineoptionsspec)_ | Per-component SQLAlchemy engine options (overrides spec.sqlaEngineOptions entirely). |  | Optional: \{\} <br /> |
+
+
+#### CeleryWorkerProcessSpec
+
+
+
+CeleryWorkerProcessSpec configures Celery worker execution parameters.
+Fields controlled by presets: concurrency, pool.
+All other fields have static defaults independent of preset.
+
+
+
+_Appears in:_
+- [CeleryWorkerComponentSpec](#celeryworkercomponentspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `preset` _string_ | Preset controlling concurrency and pool defaults.<br />Individual fields override preset-computed values. |  | Enum: [disabled conservative balanced performance aggressive] <br />Optional: \{\} <br /> |
+| `concurrency` _integer_ | Number of concurrent task workers (maps to celery -c flag). |  | Minimum: 1 <br />Optional: \{\} <br /> |
+| `pool` _string_ | Celery pool implementation. |  | Enum: [prefork threads gevent eventlet solo] <br />Optional: \{\} <br /> |
+| `optimization` _string_ | Task distribution optimization strategy. |  | Enum: [default fair] <br />Optional: \{\} <br /> |
+| `maxTasksPerChild` _integer_ | Maximum tasks a worker process handles before being replaced (prefork only; 0 = unlimited). |  | Minimum: 0 <br />Optional: \{\} <br /> |
+| `maxMemoryPerChild` _integer_ | Maximum resident memory in bytes per worker before being replaced (prefork only; 0 = disabled). |  | Minimum: 0 <br />Optional: \{\} <br /> |
+| `prefetchMultiplier` _integer_ | Task prefetch multiplier — number of tasks prefetched per worker. |  | Minimum: 0 <br />Optional: \{\} <br /> |
+| `softTimeLimit` _integer_ | Soft time limit in seconds — raises SoftTimeLimitExceeded (0 = disabled). |  | Minimum: 0 <br />Optional: \{\} <br /> |
+| `timeLimit` _integer_ | Hard time limit in seconds — kills the task (0 = disabled). |  | Minimum: 0 <br />Optional: \{\} <br /> |
 
 
 #### ChildComponentStatus
@@ -360,6 +389,34 @@ _Appears in:_
 | `labels` _object (keys:string, values:string)_ | HTTPRoute labels. |  | Optional: \{\} <br /> |
 
 
+#### GunicornSpec
+
+
+
+GunicornSpec configures Gunicorn worker parameters for the web server.
+Fields controlled by presets: workers, threads, workerClass.
+All other fields have static defaults independent of preset.
+
+
+
+_Appears in:_
+- [WebServerComponentSpec](#webservercomponentspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `preset` _string_ | Preset controlling workers, threads, and workerClass defaults.<br />Individual fields override preset-computed values. |  | Enum: [disabled conservative balanced performance aggressive] <br />Optional: \{\} <br /> |
+| `workers` _integer_ | Number of Gunicorn worker processes. |  | Minimum: 1 <br />Optional: \{\} <br /> |
+| `threads` _integer_ | Number of threads per worker (only effective with gthread worker class). |  | Minimum: 1 <br />Optional: \{\} <br /> |
+| `workerClass` _string_ | Gunicorn worker class. |  | Enum: [sync gthread gevent eventlet] <br />Optional: \{\} <br /> |
+| `timeout` _integer_ | Request timeout in seconds. |  | Minimum: 1 <br />Optional: \{\} <br /> |
+| `keepAlive` _integer_ | Keep-alive timeout in seconds for waiting for requests on a connection. |  | Minimum: 0 <br />Optional: \{\} <br /> |
+| `maxRequests` _integer_ | Maximum requests per worker before recycling (0 = disabled). |  | Minimum: 0 <br />Optional: \{\} <br /> |
+| `maxRequestsJitter` _integer_ | Random jitter added to maxRequests to prevent thundering herd on worker recycling. |  | Minimum: 0 <br />Optional: \{\} <br /> |
+| `limitRequestLine` _integer_ | Maximum size of HTTP request line in bytes (0 = unlimited). |  | Minimum: 0 <br />Optional: \{\} <br /> |
+| `limitRequestFieldSize` _integer_ | Maximum size of HTTP request header field in bytes (0 = unlimited). |  | Minimum: 0 <br />Optional: \{\} <br /> |
+| `logLevel` _string_ | Gunicorn log level. |  | Enum: [debug info warning error critical] <br />Optional: \{\} <br /> |
+
+
 #### ImageOverrideSpec
 
 
@@ -489,6 +546,7 @@ _Appears in:_
 | `disabled` _boolean_ | Set to true to skip initialization entirely. |  | Optional: \{\} <br /> |
 | `adminUser` _[AdminUserSpec](#adminuserspec)_ | Admin user to create during initialization. Only allowed in dev mode.<br />When set, the operator appends a superset fab create-admin step to the init command. |  | Optional: \{\} <br /> |
 | `loadExamples` _boolean_ | Load example dashboards and data during initialization. Only allowed in dev mode.<br />When true, the operator appends a superset load-examples step to the init command. |  | Optional: \{\} <br /> |
+| `sqlaEngineOptions` _[SQLAlchemyEngineOptionsSpec](#sqlalchemyengineoptionsspec)_ | Per-component SQLAlchemy engine options (overrides spec.sqlaEngineOptions entirely). |  | Optional: \{\} <br /> |
 | `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#duration-v1-meta)_ | Maximum timeout for the init pod. Default: 300s. |  | Optional: \{\} <br /> |
 | `maxRetries` _integer_ | Maximum number of retries before permanent failure. Default: 3. | 3 | Minimum: 1 <br />Optional: \{\} <br /> |
 | `podRetention` _[PodRetentionSpec](#podretentionspec)_ | Pod retention policy for completed init pods. |  | Optional: \{\} <br /> |
@@ -540,6 +598,7 @@ _Appears in:_
 | `image` _[ImageOverrideSpec](#imageoverridespec)_ | Image tag and/or repository overrides; inherits from spec.image if unset. |  | Optional: \{\} <br /> |
 | `config` _string_ | Per-component raw Python appended after top-level config. |  | Optional: \{\} <br /> |
 | `service` _[ComponentServiceSpec](#componentservicespec)_ | Service configuration (type, port, annotations). |  | Optional: \{\} <br /> |
+| `sqlaEngineOptions` _[SQLAlchemyEngineOptionsSpec](#sqlalchemyengineoptionsspec)_ | Per-component SQLAlchemy engine options (overrides spec.sqlaEngineOptions entirely). |  | Optional: \{\} <br /> |
 
 
 #### MetastoreSpec
@@ -714,6 +773,34 @@ _Appears in:_
 | `shareProcessNamespace` _boolean_ | Share a single process namespace between all containers in a pod. |  | Optional: \{\} <br /> |
 | `enableServiceLinks` _boolean_ | Controls whether service environment variables are injected into pods. |  | Optional: \{\} <br /> |
 | `container` _[ContainerTemplate](#containertemplate)_ | Main container configuration. |  | Optional: \{\} <br /> |
+
+
+#### SQLAlchemyEngineOptionsSpec
+
+
+
+SQLAlchemyEngineOptionsSpec configures the SQLAlchemy connection pool.
+Fields controlled by presets: poolClass (NullPool vs QueuePool), poolSize, maxOverflow.
+Static defaults: poolRecycle=3600, poolPrePing=false.
+
+
+
+_Appears in:_
+- [CeleryBeatComponentSpec](#celerybeatcomponentspec)
+- [CeleryWorkerComponentSpec](#celeryworkercomponentspec)
+- [InitSpec](#initspec)
+- [McpServerComponentSpec](#mcpservercomponentspec)
+- [SupersetSpec](#supersetspec)
+- [WebServerComponentSpec](#webservercomponentspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `preset` _string_ | Preset for connection pool behavior. "disabled" suppresses rendering entirely.<br />"conservative" uses NullPool (no persistent connections).<br />"balanced" through "aggressive" use QueuePool with increasing pool sizes.<br />Individual fields override preset-computed values. |  | Enum: [disabled conservative balanced performance aggressive] <br />Optional: \{\} <br /> |
+| `poolSize` _integer_ | Number of persistent connections in the pool. Overrides preset calculation. |  | Minimum: 0 <br />Optional: \{\} <br /> |
+| `maxOverflow` _integer_ | Maximum overflow connections beyond poolSize (-1 = unlimited). |  | Optional: \{\} <br /> |
+| `poolRecycle` _integer_ | Connection max-age in seconds before recycling. |  | Minimum: 0 <br />Optional: \{\} <br /> |
+| `poolPrePing` _boolean_ | Verify connections are alive before use. |  | Optional: \{\} <br /> |
+| `poolTimeout` _integer_ | Seconds to wait for a connection from the pool before giving up. |  | Minimum: 0 <br />Optional: \{\} <br /> |
 
 
 #### ScalableComponentSpec
@@ -1147,6 +1234,7 @@ _Appears in:_
 | `metastore` _[MetastoreSpec](#metastorespec)_ | Metastore database connection configuration. |  | Optional: \{\} <br /> |
 | `valkey` _[ValkeySpec](#valkeyspec)_ | Valkey cache, broker, and results backend configuration. |  | Optional: \{\} <br /> |
 | `config` _string_ | Raw Python appended after operator-generated superset_config.py. |  | Optional: \{\} <br /> |
+| `sqlaEngineOptions` _[SQLAlchemyEngineOptionsSpec](#sqlalchemyengineoptionsspec)_ | SQLAlchemy engine options for connection pooling. Inherited by all Python<br />components; per-component sqlaEngineOptions overrides this entirely.<br />When unset, the operator computes balanced defaults per component. |  | Optional: \{\} <br /> |
 | `webServer` _[WebServerComponentSpec](#webservercomponentspec)_ | Web server (gunicorn) component. Presence enables it; absence disables. |  | Optional: \{\} <br /> |
 | `celeryWorker` _[CeleryWorkerComponentSpec](#celeryworkercomponentspec)_ | Celery async task worker component. Requires Valkey for broker/backend. |  | Optional: \{\} <br /> |
 | `celeryBeat` _[CeleryBeatComponentSpec](#celerybeatcomponentspec)_ | Celery periodic task scheduler (singleton, always 1 replica). Requires Valkey. |  | Optional: \{\} <br /> |
@@ -1434,6 +1522,8 @@ _Appears in:_
 | `image` _[ImageOverrideSpec](#imageoverridespec)_ | Image tag and/or repository overrides; inherits from spec.image if unset. |  | Optional: \{\} <br /> |
 | `config` _string_ | Per-component raw Python appended after top-level config. |  | Optional: \{\} <br /> |
 | `service` _[ComponentServiceSpec](#componentservicespec)_ | Service configuration (type, port, annotations). |  | Optional: \{\} <br /> |
+| `gunicorn` _[GunicornSpec](#gunicornspec)_ | Gunicorn worker configuration. Controls worker processes, threads, and related parameters. |  | Optional: \{\} <br /> |
+| `sqlaEngineOptions` _[SQLAlchemyEngineOptionsSpec](#sqlalchemyengineoptionsspec)_ | Per-component SQLAlchemy engine options (overrides spec.sqlaEngineOptions entirely). |  | Optional: \{\} <br /> |
 
 
 #### WebsocketServerComponentSpec

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -133,6 +133,7 @@ kind delete cluster --name superset
 | `make uninstall` | Remove CRDs only |
 | `make manifests` | Regenerate CRD YAML and RBAC from kubebuilder markers |
 | `make generate` | Regenerate DeepCopy methods |
+| `make codegen` | Regenerate all generated artifacts (CRDs, DeepCopy, Helm CRDs, API docs) |
 | `make build` | Build the operator binary |
 | `make docker-build IMG=<image>` | Build container image for the local platform |
 | `make docker-buildx IMG=<image>` | Build and push multi-platform image (linux/arm64, linux/amd64) |
@@ -184,6 +185,12 @@ To verify the docs build cleanly (same check that runs in CI):
 ```sh
 make docs-build
 ```
+
+### API Reference
+
+The [API reference](api-reference.md) is generated from Go type definitions using [`crd-ref-docs`](https://github.com/elastic/crd-ref-docs). After modifying types in `api/v1alpha1/`, run `make codegen` to regenerate all generated artifacts (CRDs, DeepCopy, Helm CRDs, API docs). CI verifies nothing is stale.
+
+The API reference only documents operator-defined types. Built-in Kubernetes types (e.g., `Affinity`, `Container`, `Volume`) are linked out to [pkg.go.dev](https://pkg.go.dev) rather than rendered inline. When adding new fields that reference a K8s type, add a corresponding `knownTypes` entry in `hack/api-ref-config.yaml` so it renders as a link.
 
 ## Architecture
 

--- a/hack/api-ref-config.yaml
+++ b/hack/api-ref-config.yaml
@@ -22,9 +22,87 @@ processor:
 render:
   kubernetesVersion: 1.31
   knownTypes:
+    # Gateway API
     - name: ParentReference
       package: sigs.k8s.io/gateway-api/apis/v1
       link: https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.ParentReference
     - name: Hostname
       package: sigs.k8s.io/gateway-api/apis/v1
       link: https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Hostname
+
+    # k8s.io/api/core/v1
+    - name: Affinity
+      package: k8s.io/api/core/v1
+      link: https://pkg.go.dev/k8s.io/api/core/v1#Affinity
+    - name: Container
+      package: k8s.io/api/core/v1
+      link: https://pkg.go.dev/k8s.io/api/core/v1#Container
+    - name: ContainerPort
+      package: k8s.io/api/core/v1
+      link: https://pkg.go.dev/k8s.io/api/core/v1#ContainerPort
+    - name: EnvFromSource
+      package: k8s.io/api/core/v1
+      link: https://pkg.go.dev/k8s.io/api/core/v1#EnvFromSource
+    - name: EnvVar
+      package: k8s.io/api/core/v1
+      link: https://pkg.go.dev/k8s.io/api/core/v1#EnvVar
+    - name: HostAlias
+      package: k8s.io/api/core/v1
+      link: https://pkg.go.dev/k8s.io/api/core/v1#HostAlias
+    - name: Lifecycle
+      package: k8s.io/api/core/v1
+      link: https://pkg.go.dev/k8s.io/api/core/v1#Lifecycle
+    - name: LocalObjectReference
+      package: k8s.io/api/core/v1
+      link: https://pkg.go.dev/k8s.io/api/core/v1#LocalObjectReference
+    - name: PodDNSConfig
+      package: k8s.io/api/core/v1
+      link: https://pkg.go.dev/k8s.io/api/core/v1#PodDNSConfig
+    - name: PodSecurityContext
+      package: k8s.io/api/core/v1
+      link: https://pkg.go.dev/k8s.io/api/core/v1#PodSecurityContext
+    - name: Probe
+      package: k8s.io/api/core/v1
+      link: https://pkg.go.dev/k8s.io/api/core/v1#Probe
+    - name: ResourceRequirements
+      package: k8s.io/api/core/v1
+      link: https://pkg.go.dev/k8s.io/api/core/v1#ResourceRequirements
+    - name: SecretKeySelector
+      package: k8s.io/api/core/v1
+      link: https://pkg.go.dev/k8s.io/api/core/v1#SecretKeySelector
+    - name: SecurityContext
+      package: k8s.io/api/core/v1
+      link: https://pkg.go.dev/k8s.io/api/core/v1#SecurityContext
+    - name: Toleration
+      package: k8s.io/api/core/v1
+      link: https://pkg.go.dev/k8s.io/api/core/v1#Toleration
+    - name: TopologySpreadConstraint
+      package: k8s.io/api/core/v1
+      link: https://pkg.go.dev/k8s.io/api/core/v1#TopologySpreadConstraint
+    - name: Volume
+      package: k8s.io/api/core/v1
+      link: https://pkg.go.dev/k8s.io/api/core/v1#Volume
+    - name: VolumeMount
+      package: k8s.io/api/core/v1
+      link: https://pkg.go.dev/k8s.io/api/core/v1#VolumeMount
+
+    # k8s.io/api/apps/v1
+    - name: DeploymentStrategy
+      package: k8s.io/api/apps/v1
+      link: https://pkg.go.dev/k8s.io/api/apps/v1#DeploymentStrategy
+
+    # k8s.io/api/autoscaling/v2
+    - name: MetricSpec
+      package: k8s.io/api/autoscaling/v2
+      link: https://pkg.go.dev/k8s.io/api/autoscaling/v2#MetricSpec
+
+    # k8s.io/apimachinery/pkg/apis/meta/v1
+    - name: Condition
+      package: k8s.io/apimachinery/pkg/apis/meta/v1
+      link: https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Condition
+    - name: Duration
+      package: k8s.io/apimachinery/pkg/apis/meta/v1
+      link: https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration
+    - name: Time
+      package: k8s.io/apimachinery/pkg/apis/meta/v1
+      link: https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Time


### PR DESCRIPTION
## Summary

The API reference (`docs/api-reference.md`) was not included in CI's codegen verification, so changes to API types could land without updating the generated docs. This PR adds `make docs-api` to the verification pipeline via a new consolidated `make codegen` target, and configures the doc generator to link out to `pkg.go.dev` for built-in Kubernetes types instead of rendering them inline.

### Changes

- New `make codegen` target that runs all generation steps (CRDs, DeepCopy, Helm CRD sync, API docs): replaces the ad-hoc commands in CI
- Extracted make `helm-sync-crds` from duplicated logic in `helm` and `helm-lint`
- Added all referenced K8s types as knownTypes in `hack/api-ref-config.yaml`, linking to `pkg.go.dev` instead of rendering inline (also eliminates `crd-ref-docs` max-depth warnings)
- Documented the convention in the developer guide and `AGENTS.md`

## Test plan

- Run `make codegen` and verify no warnings from `crd-ref-docs`
- Confirm `docs/api-reference.md` links to `pkg.go.dev` for K8s types like `Affinity`, `Container`, `Volume`
- Verify CI fails when `docs/api-reference.md` is stale by checking `git diff --exit-code` after `make codegen`
