### PR TITLE
ci: re-enable e2e tests and fix test-infrastructure breakage

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,6 +50,22 @@ jobs:
           flags: integration
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  # TODO: enable E2E tests once test infrastructure is ready
-  # e2e:
-  #   ...
+  e2e:
+    name: E2E
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - name: Install kind
+        run: |
+          KIND_VERSION="v0.31.0"
+          KIND_CHECKSUM="eb244cbafcc157dff60cf68693c14c9a75c4e6e6fedaf9cd71c58117cb93e3fa"
+          curl -fsSLo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+          echo "${KIND_CHECKSUM}  ./kind" | sha256sum -c -
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+          kind version
+      - name: Run E2E tests
+        run: make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ docker-push: ## Push docker image with the manager.
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image ghcr.io/apache/superset-kubernetes-operator=${IMG}
 	$(KUSTOMIZE) build config/default > dist/install.yaml
 
 ##@ Deployment
@@ -272,7 +272,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image ghcr.io/apache/superset-kubernetes-operator=${IMG}
 	$(KUSTOMIZE) build config/default | $(KUBECTL) apply --server-side -f -
 
 .PHONY: undeploy
@@ -374,7 +374,7 @@ endif
 .PHONY: bundle
 bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests -q
-	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
+	cd config/manager && $(KUSTOMIZE) edit set image ghcr.io/apache/superset-kubernetes-operator=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	$(OPERATOR_SDK) bundle validate ./bundle
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -6,6 +6,3 @@ images:
 - name: ghcr.io/apache/superset-kubernetes-operator
   newName: ghcr.io/apache/superset-kubernetes-operator
   newTag: latest
-- name: controller
-  newName: localhost/superset-operator
-  newTag: dev

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -31,10 +31,19 @@ instance running on your laptop.
 
 | Tool | Version | Install |
 |---|---|---|
-| Docker (or Podman) | 20+ | [docs.docker.com](https://docs.docker.com/get-docker/) |
+| Docker daemon | 20+ | [Docker Desktop](https://docs.docker.com/get-docker/), [Colima](https://github.com/abiosoft/colima) (`brew install colima`), or [Podman](https://podman.io) |
 | kubectl | 1.27+ | [kubernetes.io](https://kubernetes.io/docs/tasks/tools/) |
-| Kind | 0.20+ | `go install sigs.k8s.io/kind@latest` or `brew install kind` |
-| Go | 1.26+ | [go.dev](https://go.dev/dl/) |
+| Kind | 0.30+ | `brew install kind` or `go install sigs.k8s.io/kind@latest` |
+| Go | 1.26+ | `brew install go` or [go.dev](https://go.dev/dl/) |
+
+#### macOS notes
+
+- **Colima** is a lightweight alternative to Docker Desktop. Start it with enough headroom for Kind plus a Superset deployment:
+  ```bash
+  colima start --cpu 4 --memory 8 --disk 50
+  ```
+  The Docker CLI auto-switches to the `colima` context.
+- If you previously ran Docker Desktop and have switched to Colima, the leftover `credsStore: desktop` in `~/.docker/config.json` will fail every `docker pull` with a keychain error in non-interactive shells. Remove the `credsStore` and `plugins`/`features.hooks` keys from that file (they only apply to Docker Desktop).
 
 ### 1. Create a Kind cluster
 
@@ -290,6 +299,16 @@ validation, CRD defaulting, multi-controller interaction).
 - Operator health: controller pod running, metrics endpoint serving
 - CR lifecycle: apply Superset CR → child CRs created → Deployments + ConfigMaps exist → status populated
 - Multi-component: all component types reconciled with correct sub-resources
+
+### Running E2E tests locally
+
+`make test-e2e` creates a throwaway Kind cluster (`superset-kubernetes-operator-test-e2e`), builds the operator image, loads it into the cluster, runs the Ginkgo specs, and tears the cluster down.
+
+```bash
+make test-e2e
+```
+
+The Kind node image is pinned in the Makefile (`KIND_NODE_IMAGE`) and matches the Kind binary version used in CI. Override `E2E_PROJECT_IMAGE` or `E2E_CURL_IMAGE` if your environment requires a mirror registry, or set `E2E_SKIP_BUILD_LOAD=1` to reuse an image you've already loaded into Kind during iteration.
 
 ### Writing a new unit test
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -37,13 +37,13 @@ import (
 const namespace = "superset-operator-system"
 
 // serviceAccountName created for the project
-const serviceAccountName = "superset-kubernetes-operator-controller-manager"
+const serviceAccountName = "superset-operator-controller-manager"
 
 // metricsServiceName is the name of the metrics service of the project
-const metricsServiceName = "superset-kubernetes-operator-controller-manager-metrics-service"
+const metricsServiceName = "superset-operator-controller-manager-metrics-service"
 
 // metricsRoleBindingName is the name of the RBAC that will be created to allow get the metrics data
-const metricsRoleBindingName = "superset-kubernetes-operator-metrics-binding"
+const metricsRoleBindingName = "superset-operator-metrics-binding"
 
 var _ = Describe("Manager", Ordered, func() {
 	var controllerPodName string
@@ -79,6 +79,10 @@ var _ = Describe("Manager", Ordered, func() {
 	AfterAll(func() {
 		By("cleaning up the curl pod for metrics")
 		cmd := exec.Command("kubectl", "delete", "pod", "curl-metrics", "-n", namespace)
+		_, _ = utils.Run(cmd)
+
+		By("cleaning up the metrics ClusterRoleBinding")
+		cmd = exec.Command("kubectl", "delete", "clusterrolebinding", metricsRoleBindingName, "--ignore-not-found")
 		_, _ = utils.Run(cmd)
 
 		By("undeploying the controller-manager")
@@ -175,8 +179,11 @@ var _ = Describe("Manager", Ordered, func() {
 
 		It("should ensure the metrics endpoint is serving metrics", func() {
 			By("creating a ClusterRoleBinding for the service account to allow access to metrics")
-			cmd := exec.Command("kubectl", "create", "clusterrolebinding", metricsRoleBindingName,
-				"--clusterrole=superset-kubernetes-operator-metrics-reader",
+			// Defensively delete any stale binding from a previous failed run before creating.
+			cmd := exec.Command("kubectl", "delete", "clusterrolebinding", metricsRoleBindingName, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+			cmd = exec.Command("kubectl", "create", "clusterrolebinding", metricsRoleBindingName,
+				"--clusterrole=superset-operator-metrics-reader",
 				fmt.Sprintf("--serviceaccount=%s:%s", namespace, serviceAccountName),
 			)
 			_, err := utils.Run(cmd)
@@ -206,7 +213,7 @@ var _ = Describe("Manager", Ordered, func() {
 				cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(ContainSubstring("controller-runtime.metrics\tServing metrics server"),
+				g.Expect(output).To(ContainSubstring(`"controller-runtime.metrics","msg":"Starting metrics server"`),
 					"Metrics server not yet started")
 			}
 			Eventually(verifyMetricsServerStarted).Should(Succeed())


### PR DESCRIPTION
## Summary

Re-enables the E2E job in `.github/workflows/test.yaml` (previously commented out as a TODO) and fixes the underlying breakage that had been preventing it from running. The suite now passes 4/4 specs on a fresh Kind cluster locally and is ready to gate PRs in CI. Along the way, this PR also corrects a silent rot in `make deploy` where the kustomize image override targeted a slot the manifest no longer referenced, so the operator Deployment had been ignoring the `IMG=` argument and always pulling `ghcr.io/apache/...:latest`.

## Details

**CI**: Adds an `e2e` job mirroring the `unit-integration` job's pinning style: SHA-pinned `actions/checkout` and `actions/setup-go`, kind v0.31.0 downloaded by URL and verified against an embedded sha256 (matches the `KIND_NODE_IMAGE` v1.35.1 pin in the Makefile).

**Kustomize image override (root cause of historical e2e failures)**: `config/manager/manager.yaml` references the image as `ghcr.io/apache/superset-kubernetes-operator:latest` directly, but the Makefile's `make deploy` / `make build-installer` / `make bundle` targets were running `kustomize edit set image controller=$(IMG)` against a no-longer-referenced `controller` slot. The override silently became a no-op, so e2e deployed the GHCR `:latest` image instead of the locally-built+kind-loaded image and the manager pod went into `ImagePullBackOff`. Switched all three call sites to override the real image name and removed the dead `controller` entry from `config/manager/kustomization.yaml`.

**E2E test fixes**:
- Test constants used the old `superset-kubernetes-operator-` namePrefix; the current kustomization uses `superset-operator-`. Updated `serviceAccountName`, `metricsServiceName`, `metricsRoleBindingName`, and the `--clusterrole=` flag passed to `kubectl create clusterrolebinding`.
- The metrics-server log assertion looked for the old logfmt-style `controller-runtime.metrics\tServing metrics server`; current controller-runtime emits JSON logs with `"msg":"Starting metrics server"`. Updated the substring.
- The metrics ClusterRoleBinding (cluster-scoped) survived namespace deletion, so re-runs after a failure tripped on "already exists". Added cleanup in `AfterAll` plus a defensive pre-delete in the spec itself.

**Developer guide**: Adds Colima as a documented Docker daemon option with the `--cpu 4 --memory 8 --disk 50` recipe needed to host Kind plus a Superset deployment, plus a macOS note about the `credsStore: desktop` + keychain failure mode that bites users who switch off Docker Desktop. Adds a "Running E2E tests locally" subsection under Testing Philosophy documenting `make test-e2e` and the `E2E_*` env overrides.

## Test Plan

- [x] Unit tests pass (`make test-unit`)
- [x] Integration tests pass (`make test-integration`)
- [x] E2E suite passes locally on a fresh Kind cluster (`make test-e2e`: 4 specs, ~60s after image build)
- [x] `make codegen` produces no diff (verifies no generated-artifact drift)
