### PR TITLE
feat(api): add pod-level resources support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,33 +1,15 @@
 ## Summary
 
 <!--
-Required: Write at least one paragraph explaining what this PR does and why.
-A reviewer should be able to understand the motivation and scope from this
-section alone, without reading the diff.
+Required. A paragraph explaining what this PR does and why. A reviewer should
+understand the motivation and scope from this section alone, without reading
+the diff.
 -->
 
 ## Details
 
 <!--
-Optional: Add implementation notes, design decisions, alternatives considered,
-migration steps, or anything else that helps reviewers understand the change.
-Delete this section if the summary is sufficient.
--->
-
-## Test Plan
-
-<!--
-Describe how you verified this change. Check all that apply and add details
-for manual testing.
--->
-
-- [ ] Unit tests added/updated (`make test-unit`)
-- [ ] Integration tests added/updated (`make test-integration`)
-- [ ] Manual testing (describe below)
-
-## Related Issues
-
-<!--
-Optional: Link related issues. Use keywords to auto-close:
-Fixes #123, Relates to #456
+Optional. Implementation notes, design decisions, or a bullet list of individual
+changes for smaller PRs. For larger PRs, use a structured summary covering the
+key decisions and their rationale. Delete this section if the summary is sufficient.
 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ The operator uses a **two-tier CRD architecture** where the parent `Superset` re
 - `internal/common/` — Shared types (ComponentType, Ptr), naming functions (ChildName, ConfigMapName, ComponentLabels), constants (labels, suffixes, ports)
 - `internal/controller/` — Reconciler implementations
   - `child_reconciler.go` — generic `ChildReconciler` with `ChildCR` interface: shared sub-resource lifecycle (ConfigMap, Deployment, Service, Scaling) used by all 6 child controllers
+  - `child_controllers.go` — `ChildControllerDefs()`: registers all 6 generic child controllers with per-component DeploymentConfig (default commands, ports, scaling flags)
   - `component_descriptors.go` — table-driven component descriptors for parent→child conversion
   - `deployment_builder.go` — builds Deployment from FlatComponentSpec + DeploymentConfig
   - `initpod.go` — InitPod lifecycle helpers (backoff, retention, failure messages)

--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -486,6 +486,11 @@ type PodTemplate struct {
 	// Controls whether service environment variables are injected into pods.
 	// +optional
 	EnableServiceLinks *bool `json:"enableServiceLinks,omitempty"`
+	// Pod-level resource requirements (CPU, memory). When set, defines the total
+	// resources for the entire pod, enabling resource sharing among containers.
+	// Requires Kubernetes 1.34+ with the PodLevelResources feature gate.
+	// +optional
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 	// Main container configuration.
 	// +optional
 	Container *ContainerTemplate `json:"container,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1214,6 +1214,11 @@ func (in *PodTemplate) DeepCopyInto(out *PodTemplate) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Container != nil {
 		in, out := &in.Container, &out.Container
 		*out = new(ContainerTemplate)

--- a/charts/superset-operator/crds/superset.apache.org_supersetcelerybeats.yaml
+++ b/charts/superset-operator/crds/superset.apache.org_supersetcelerybeats.yaml
@@ -2325,6 +2325,39 @@ spec:
                     type: object
                   priorityClassName:
                     type: string
+                  resources:
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            request:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
                   runtimeClassName:
                     type: string
                   shareProcessNamespace:

--- a/charts/superset-operator/crds/superset.apache.org_supersetceleryflowers.yaml
+++ b/charts/superset-operator/crds/superset.apache.org_supersetceleryflowers.yaml
@@ -2325,6 +2325,39 @@ spec:
                     type: object
                   priorityClassName:
                     type: string
+                  resources:
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            request:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
                   runtimeClassName:
                     type: string
                   shareProcessNamespace:

--- a/charts/superset-operator/crds/superset.apache.org_supersetceleryworkers.yaml
+++ b/charts/superset-operator/crds/superset.apache.org_supersetceleryworkers.yaml
@@ -2325,6 +2325,39 @@ spec:
                     type: object
                   priorityClassName:
                     type: string
+                  resources:
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            request:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
                   runtimeClassName:
                     type: string
                   shareProcessNamespace:

--- a/charts/superset-operator/crds/superset.apache.org_supersetinits.yaml
+++ b/charts/superset-operator/crds/superset.apache.org_supersetinits.yaml
@@ -2340,6 +2340,39 @@ spec:
                     type: object
                   priorityClassName:
                     type: string
+                  resources:
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            request:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
                   runtimeClassName:
                     type: string
                   shareProcessNamespace:

--- a/charts/superset-operator/crds/superset.apache.org_supersetmcpservers.yaml
+++ b/charts/superset-operator/crds/superset.apache.org_supersetmcpservers.yaml
@@ -2325,6 +2325,39 @@ spec:
                     type: object
                   priorityClassName:
                     type: string
+                  resources:
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            request:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
                   runtimeClassName:
                     type: string
                   shareProcessNamespace:

--- a/charts/superset-operator/crds/superset.apache.org_supersets.yaml
+++ b/charts/superset-operator/crds/superset.apache.org_supersets.yaml
@@ -2296,6 +2296,39 @@ spec:
                         type: object
                       priorityClassName:
                         type: string
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                request:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
                       runtimeClassName:
                         type: string
                       shareProcessNamespace:
@@ -6202,6 +6235,39 @@ spec:
                         type: object
                       priorityClassName:
                         type: string
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                request:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
                       runtimeClassName:
                         type: string
                       shareProcessNamespace:
@@ -10165,6 +10231,39 @@ spec:
                         type: object
                       priorityClassName:
                         type: string
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                request:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
                       runtimeClassName:
                         type: string
                       shareProcessNamespace:
@@ -13848,6 +13947,39 @@ spec:
                         type: object
                       priorityClassName:
                         type: string
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                request:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
                       runtimeClassName:
                         type: string
                       shareProcessNamespace:
@@ -17760,6 +17892,39 @@ spec:
                         type: object
                       priorityClassName:
                         type: string
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                request:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
                       runtimeClassName:
                         type: string
                       shareProcessNamespace:
@@ -21744,6 +21909,39 @@ spec:
                     type: object
                   priorityClassName:
                     type: string
+                  resources:
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            request:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
                   runtimeClassName:
                     type: string
                   shareProcessNamespace:
@@ -25878,6 +26076,39 @@ spec:
                         type: object
                       priorityClassName:
                         type: string
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                request:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
                       runtimeClassName:
                         type: string
                       shareProcessNamespace:
@@ -29812,6 +30043,39 @@ spec:
                         type: object
                       priorityClassName:
                         type: string
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                request:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
                       runtimeClassName:
                         type: string
                       shareProcessNamespace:

--- a/charts/superset-operator/crds/superset.apache.org_supersetwebservers.yaml
+++ b/charts/superset-operator/crds/superset.apache.org_supersetwebservers.yaml
@@ -2325,6 +2325,39 @@ spec:
                     type: object
                   priorityClassName:
                     type: string
+                  resources:
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            request:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
                   runtimeClassName:
                     type: string
                   shareProcessNamespace:

--- a/charts/superset-operator/crds/superset.apache.org_supersetwebsocketservers.yaml
+++ b/charts/superset-operator/crds/superset.apache.org_supersetwebsocketservers.yaml
@@ -2321,6 +2321,39 @@ spec:
                     type: object
                   priorityClassName:
                     type: string
+                  resources:
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            request:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
                   runtimeClassName:
                     type: string
                   shareProcessNamespace:

--- a/config/crd/bases/superset.apache.org_supersetcelerybeats.yaml
+++ b/config/crd/bases/superset.apache.org_supersetcelerybeats.yaml
@@ -2325,6 +2325,39 @@ spec:
                     type: object
                   priorityClassName:
                     type: string
+                  resources:
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            request:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
                   runtimeClassName:
                     type: string
                   shareProcessNamespace:

--- a/config/crd/bases/superset.apache.org_supersetceleryflowers.yaml
+++ b/config/crd/bases/superset.apache.org_supersetceleryflowers.yaml
@@ -2325,6 +2325,39 @@ spec:
                     type: object
                   priorityClassName:
                     type: string
+                  resources:
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            request:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
                   runtimeClassName:
                     type: string
                   shareProcessNamespace:

--- a/config/crd/bases/superset.apache.org_supersetceleryworkers.yaml
+++ b/config/crd/bases/superset.apache.org_supersetceleryworkers.yaml
@@ -2325,6 +2325,39 @@ spec:
                     type: object
                   priorityClassName:
                     type: string
+                  resources:
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            request:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
                   runtimeClassName:
                     type: string
                   shareProcessNamespace:

--- a/config/crd/bases/superset.apache.org_supersetinits.yaml
+++ b/config/crd/bases/superset.apache.org_supersetinits.yaml
@@ -2340,6 +2340,39 @@ spec:
                     type: object
                   priorityClassName:
                     type: string
+                  resources:
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            request:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
                   runtimeClassName:
                     type: string
                   shareProcessNamespace:

--- a/config/crd/bases/superset.apache.org_supersetmcpservers.yaml
+++ b/config/crd/bases/superset.apache.org_supersetmcpservers.yaml
@@ -2325,6 +2325,39 @@ spec:
                     type: object
                   priorityClassName:
                     type: string
+                  resources:
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            request:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
                   runtimeClassName:
                     type: string
                   shareProcessNamespace:

--- a/config/crd/bases/superset.apache.org_supersets.yaml
+++ b/config/crd/bases/superset.apache.org_supersets.yaml
@@ -2296,6 +2296,39 @@ spec:
                         type: object
                       priorityClassName:
                         type: string
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                request:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
                       runtimeClassName:
                         type: string
                       shareProcessNamespace:
@@ -6202,6 +6235,39 @@ spec:
                         type: object
                       priorityClassName:
                         type: string
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                request:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
                       runtimeClassName:
                         type: string
                       shareProcessNamespace:
@@ -10165,6 +10231,39 @@ spec:
                         type: object
                       priorityClassName:
                         type: string
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                request:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
                       runtimeClassName:
                         type: string
                       shareProcessNamespace:
@@ -13848,6 +13947,39 @@ spec:
                         type: object
                       priorityClassName:
                         type: string
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                request:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
                       runtimeClassName:
                         type: string
                       shareProcessNamespace:
@@ -17760,6 +17892,39 @@ spec:
                         type: object
                       priorityClassName:
                         type: string
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                request:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
                       runtimeClassName:
                         type: string
                       shareProcessNamespace:
@@ -21744,6 +21909,39 @@ spec:
                     type: object
                   priorityClassName:
                     type: string
+                  resources:
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            request:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
                   runtimeClassName:
                     type: string
                   shareProcessNamespace:
@@ -25878,6 +26076,39 @@ spec:
                         type: object
                       priorityClassName:
                         type: string
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                request:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
                       runtimeClassName:
                         type: string
                       shareProcessNamespace:
@@ -29812,6 +30043,39 @@ spec:
                         type: object
                       priorityClassName:
                         type: string
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                request:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
                       runtimeClassName:
                         type: string
                       shareProcessNamespace:

--- a/config/crd/bases/superset.apache.org_supersetwebservers.yaml
+++ b/config/crd/bases/superset.apache.org_supersetwebservers.yaml
@@ -2325,6 +2325,39 @@ spec:
                     type: object
                   priorityClassName:
                     type: string
+                  resources:
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            request:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
                   runtimeClassName:
                     type: string
                   shareProcessNamespace:

--- a/config/crd/bases/superset.apache.org_supersetwebsocketservers.yaml
+++ b/config/crd/bases/superset.apache.org_supersetwebsocketservers.yaml
@@ -2321,6 +2321,39 @@ spec:
                     type: object
                   priorityClassName:
                     type: string
+                  resources:
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            request:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
                   runtimeClassName:
                     type: string
                   shareProcessNamespace:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -772,6 +772,7 @@ _Appears in:_
 | `runtimeClassName` _string_ | RuntimeClass for pods. |  | Optional: \{\} <br /> |
 | `shareProcessNamespace` _boolean_ | Share a single process namespace between all containers in a pod. |  | Optional: \{\} <br /> |
 | `enableServiceLinks` _boolean_ | Controls whether service environment variables are injected into pods. |  | Optional: \{\} <br /> |
+| `resources` _[ResourceRequirements](https://pkg.go.dev/k8s.io/api/core/v1#ResourceRequirements)_ | Pod-level resource requirements (CPU, memory). When set, defines the total<br />resources for the entire pod, enabling resource sharing among containers.<br />Requires Kubernetes 1.34+ with the PodLevelResources feature gate. |  | Optional: \{\} <br /> |
 | `container` _[ContainerTemplate](#containertemplate)_ | Main container configuration. |  | Optional: \{\} <br /> |
 
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -227,16 +227,22 @@ The parent controller orchestrates all reconciliation:
 
 ## Testing Philosophy
 
-### Guiding principle: test the way the software is used
+### Guiding principle: assert on observable outputs
 
-Inspired by the [React Testing Library](https://testing-library.com/docs/guiding-principles)
-philosophy, our tests should resemble the way the operator is used in
-practice. For a Kubernetes operator, the "user" is the person writing a CR
-and `kubectl apply`-ing it. Tests should therefore:
+For a Kubernetes operator, the "user" is the person writing a CR and
+`kubectl apply`-ing it. **Integration and e2e tests** should mirror this
+directly: apply a CR and assert on what the user observes — child CRs,
+Deployments, Services, ConfigMaps, status conditions.
 
-- **Start from a realistic CR** and assert on the **observable outputs** —
-  child CRs, Deployments, Services, ConfigMaps, status conditions — not
-  internal implementation details.
+**Unit tests** serve a different purpose: they provide rich permutation
+coverage of business logic (merge semantics, config rendering, preset
+resolution) that would be too slow or combinatorially expensive to exercise
+at higher tiers. They are inherently non-user-facing, but the same principle
+applies — assert on the *output* of a function (the resolved spec, the
+rendered config) rather than on *how* the function arrived at that output.
+
+Across all tiers:
+
 - **Avoid testing private functions in isolation** unless they contain
   genuinely complex logic (merge semantics, backoff math). If a behavior is
   only meaningful through reconciliation, test it through reconciliation.
@@ -245,28 +251,16 @@ and `kubectl apply`-ing it. Tests should therefore:
   to implementation, not behavior, and should be rewritten to assert on
   observable outputs or removed entirely.
 
-### Pyramid strategy
+### Test pyramid
 
 We use a **pyramid testing strategy** where the vast majority of logic is
 covered by fast, deterministic unit tests. Integration and e2e tests are
 reserved for verifying the system works end-to-end, not for testing
 individual behaviors.
 
-### Test granularity
-
-- **Prefer broad happy-path tests** that cover critical assertions in a single test function. For example, one comprehensive test that creates all components and verifies config, env vars, and status is better than 10 separate tests each checking one field.
-- **Use granular tests only for complex utilities** with many edge cases (e.g., merge functions, backoff calculation, condition management). These benefit from table-driven tests covering boundary conditions.
-- **Every assertion should protect against a plausible regression.** If you can't name the scenario where removing it would let a bug through, it doesn't belong. Avoid adding narrow standalone tests when the assertion fits naturally in an existing comprehensive test.
-- **When fixing a regression, always add a test that would have caught it.** Regressions that broke silently indicate a gap in test coverage — close the gap as part of the fix.
-- **Use subtests (`t.Run`)** to group related scenarios within a single test function instead of creating separate top-level tests.
-
-### Test Pyramid
-
-- **Unit tests** — Fast, deterministic, fake client or pure functions. Cover all business logic.
+- **Unit tests** — Fast, deterministic, fake client or pure functions. Cover all business logic and permutations.
 - **Integration tests** — Minimal envtest tests (real API server). Verify CRD registration, CEL validation, reconciler lifecycle.
 - **E2E tests** — 1-2 comprehensive scenarios on a Kind cluster. Verify full operator lifecycle.
-
-### Why unit tests over integration tests
 
 | Concern | Unit test | Integration test |
 |---|---|---|
@@ -279,6 +273,14 @@ individual behaviors.
 **Rule of thumb**: If you can test it with a fake client, do. Reserve
 envtest/e2e for things that genuinely need a real API server (CEL
 validation, CRD defaulting, multi-controller interaction).
+
+### Test granularity
+
+- **Prefer broad happy-path tests** that cover critical assertions in a single test function. For example, one comprehensive test that creates all components and verifies config, env vars, and status is better than 10 separate tests each checking one field.
+- **Use granular tests only for complex utilities** with many edge cases (e.g., merge functions, backoff calculation, condition management). These benefit from table-driven tests covering boundary conditions.
+- **Every assertion should protect against a plausible regression.** If you can't name the scenario where removing it would let a bug through, it doesn't belong. Avoid adding narrow standalone tests when the assertion fits naturally in an existing comprehensive test.
+- **When fixing a regression, always add a test that would have caught it.** Regressions that broke silently indicate a gap in test coverage — close the gap as part of the fix.
+- **Use subtests (`t.Run`)** to group related scenarios within a single test function instead of creating separate top-level tests.
 
 ### What goes where
 
@@ -473,21 +475,21 @@ New Deployment/Pod/Container fields go into the template hierarchy:
 
 2. Add component spec to parent in `superset_types.go`
 
-3. Create `internal/controller/supersetnewcomponent_controller.go`:
-   - Follow the pattern in `supersetceleryflower_controller.go`
-   - Define a `DeploymentConfig` with component-specific defaults
-   - Use shared helpers from `child_reconciler.go`
-   - Add RBAC markers
+3. Add a child controller definition in `internal/controller/child_controllers.go`:
+   - Add a `ChildControllerDef` entry to `ChildControllerDefs()` with component name,
+     `DeploymentConfig` (container name, default command, ports), `hasConfig`, `hasScaling`
+   - Ensure the child CRD type implements the `ChildCR` interface from `child_reconciler.go`
+   - Add RBAC markers at the top of the file
 
-4. Register in parent controller:
-   - Add `reconcileXxx` method and call in `Reconcile()`
-   - Add `convertXxxComponent` function
-   - Add status check in `updateStatus()`
-   - Add `Owns()` in `SetupWithManager()`
+4. Register in parent controller (`internal/controller/component_descriptors.go`):
+   - Add a `componentDescriptor` entry with `extract`, `newChild`, `newList`,
+     `applySpec`, and `setStatus` functions
+   - Add the descriptor to the `componentDescriptors` slice
+   - Add `Owns()` in parent `SetupWithManager()`
 
-5. Register in `cmd/main.go`
-6. Run `make manifests generate`
-7. Add sample CR and unit tests
+5. Run `make manifests generate` (child controller registration in `cmd/main.go`
+   is automatic via the `ChildControllerDefs()` loop)
+6. Add sample CR and unit tests
 
 ## Package Structure
 
@@ -517,6 +519,8 @@ internal/
 | `internal/resolution/resolver.go` | ResolveChildSpec — core flattening engine |
 | `internal/config/renderer.go` | RenderConfig — per-component Python generation |
 | `internal/controller/child_reconciler.go` | Shared helpers for all child controllers |
+| `internal/controller/child_controllers.go` | `ChildControllerDefs()` — table-driven child controller registration |
+| `internal/controller/component_descriptors.go` | Parent-side component descriptors for child CR creation |
 | `internal/controller/superset_controller.go` | Parent reconciler (orchestrates everything) |
 | `internal/controller/deployment_builder.go` | Deployment construction from flat spec |
 | `internal/controller/initpod.go` | InitPod lifecycle manager |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -734,7 +734,7 @@ merged** independently with the top-level — you only specify what's different.
 
 | Behavior | Fields |
 |----------|--------|
-| **Component wins if set** | `resources`, `affinity`, `securityContext`, `podSecurityContext`, `priorityClassName`, `strategy`, `revisionHistoryLimit`, probes, `lifecycle`, `dnsPolicy`, `dnsConfig`, `runtimeClassName`, `shareProcessNamespace`, `enableServiceLinks`, `terminationGracePeriodSeconds`, `minReadySeconds`, `progressDeadlineSeconds` |
+| **Component wins if set** | `resources` (both pod-level and container-level), `affinity`, `securityContext`, `podSecurityContext`, `priorityClassName`, `strategy`, `revisionHistoryLimit`, probes, `lifecycle`, `dnsPolicy`, `dnsConfig`, `runtimeClassName`, `shareProcessNamespace`, `enableServiceLinks`, `terminationGracePeriodSeconds`, `minReadySeconds`, `progressDeadlineSeconds` |
 | **Merge by name** | `env`, `volumes`, `volumeMounts`, `sidecars`, `initContainers` |
 | **Merge by key** | `annotations`, `labels`, `nodeSelector`, `hostAliases` (by IP) |
 | **Append** | `tolerations`, `topologySpreadConstraints`, `envFrom` |
@@ -778,6 +778,7 @@ top-level for shared entries and component-level for component-specific ones.
 | `runtimeClassName` | RuntimeClass (e.g., gVisor, Kata) |
 | `shareProcessNamespace` | Share PID namespace between containers |
 | `enableServiceLinks` | Inject service environment variables |
+| `resources` | Pod-level resource requirements (Kubernetes 1.34+, requires PodLevelResources feature gate) |
 
 **Container level** (`podTemplate.container.*`):
 
@@ -794,6 +795,28 @@ top-level for shared entries and component-level for component-specific ones.
 | `readinessProbe` | Readiness probe |
 | `startupProbe` | Startup probe |
 | `lifecycle` | preStop/postStart lifecycle hooks |
+
+**Pod-level resources** (Kubernetes 1.34+): When `podTemplate.resources` is set,
+it defines the total resource budget for the entire pod, enabling resource
+sharing among containers (main + sidecars). Container-level
+`podTemplate.container.resources` remains available for per-container limits.
+
+```yaml
+spec:
+  podTemplate:
+    resources:
+      requests:
+        cpu: "4"
+        memory: "8Gi"
+      limits:
+        cpu: "8"
+        memory: "16Gi"
+    container:
+      resources:
+        requests:
+          cpu: "2"
+          memory: "4Gi"
+```
 
 ### Init pod
 

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -144,6 +144,7 @@ func buildDeploymentSpec(
 		ShareProcessNamespace:         pt.ShareProcessNamespace,
 		EnableServiceLinks:            pt.EnableServiceLinks,
 		DNSConfig:                     pt.DNSConfig,
+		Resources:                     pt.Resources,
 	}
 	if pt.PriorityClassName != nil {
 		podSpec.PriorityClassName = *pt.PriorityClassName

--- a/internal/controller/deployment_builder_test.go
+++ b/internal/controller/deployment_builder_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	supersetv1alpha1 "github.com/apache/superset-kubernetes-operator/api/v1alpha1"
@@ -150,6 +151,46 @@ func TestBuildDeploymentSpec_HPAEnabled_NoReplicas(t *testing.T) {
 
 	if result.Replicas != nil {
 		t.Errorf("expected nil replicas when HPA is enabled, got %d", *result.Replicas)
+	}
+}
+
+func TestBuildDeploymentSpec_PodLevelResources(t *testing.T) {
+	spec := &supersetv1alpha1.FlatComponentSpec{
+		Image: supersetv1alpha1.ImageSpec{
+			Repository: "apache/superset",
+			Tag:        "latest",
+			PullPolicy: corev1.PullIfNotPresent,
+		},
+		PodTemplate: &supersetv1alpha1.PodTemplate{
+			Resources: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+		},
+	}
+	labels := map[string]string{"app": "test"}
+	cfg := DeploymentConfig{
+		ContainerName:  "test",
+		DefaultCommand: []string{"test"},
+	}
+
+	result := buildDeploymentSpec(spec, cfg, nil, labels)
+
+	podResources := result.Template.Spec.Resources
+	if podResources == nil {
+		t.Fatal("expected pod-level resources to be set")
+	}
+	if podResources.Requests.Cpu().String() != "2" {
+		t.Errorf("expected pod CPU request 2, got %s", podResources.Requests.Cpu())
+	}
+	if podResources.Limits.Memory().String() != "8Gi" {
+		t.Errorf("expected pod memory limit 8Gi, got %s", podResources.Limits.Memory())
 	}
 }
 

--- a/internal/controller/supersetinit_controller.go
+++ b/internal/controller/supersetinit_controller.go
@@ -372,6 +372,7 @@ func buildInitPod(spec *supersetv1alpha1.FlatComponentSpec) corev1.PodSpec {
 		ShareProcessNamespace:         pt.ShareProcessNamespace,
 		EnableServiceLinks:            pt.EnableServiceLinks,
 		DNSConfig:                     pt.DNSConfig,
+		Resources:                     pt.Resources,
 	}
 	if pt.PriorityClassName != nil {
 		podSpec.PriorityClassName = *pt.PriorityClassName

--- a/internal/resolution/merge.go
+++ b/internal/resolution/merge.go
@@ -205,6 +205,7 @@ func MergePodTemplate(comp, tl *supersetv1alpha1.PodTemplate, operatorLabels map
 		RuntimeClassName:              ResolveOverridableValue(c.RuntimeClassName, t.RuntimeClassName),
 		ShareProcessNamespace:         ResolveOverridableValue(c.ShareProcessNamespace, t.ShareProcessNamespace),
 		EnableServiceLinks:            ResolveOverridableValue(c.EnableServiceLinks, t.EnableServiceLinks),
+		Resources:                     ResolveOverridableValue(c.Resources, t.Resources),
 		Volumes:                       MergeVolumes(t.Volumes, c.Volumes, op.Volumes),
 		Sidecars:                      MergeContainers(t.Sidecars, c.Sidecars),
 		InitContainers:                MergeContainers(t.InitContainers, c.InitContainers, op.InitContainers),


### PR DESCRIPTION
## Summary

Add `resources` field to `PodTemplate` to support Kubernetes 1.34's pod-level resource requirements, enabling resource sharing among containers in a pod. Wired through the resolution layer (component-wins-if-set semantics) and both deployment and init pod builders.

## Details

- Pod-level `resources` on `PodTemplate` with full merge support (component wins if set)
- Wired in `buildDeploymentSpec()` and `buildInitPod()`
- Unit test, CRD regeneration, user guide documentation with example
- Docs cleanup: fix outdated "How to Add a New Component" guide, add missing `child_controllers.go` to directory layout, consolidate testing philosophy section
- Simplify PR template to just Summary + Details (remove checkboxes and boilerplate sections)