### PR TITLE
feat(lifecycle): add Drain upgrade strategy

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -47,6 +47,7 @@ jobs:
           scopes: |
             api
             controller
+            lifecycle
             resolution
             config
             helm

--- a/api/v1alpha1/superset_types.go
+++ b/api/v1alpha1/superset_types.go
@@ -244,6 +244,14 @@ type LifecycleSpec struct {
 	// +kubebuilder:default=Automatic
 	UpgradeMode *string `json:"upgradeMode,omitempty"`
 
+	// UpgradeStrategy controls component behavior during database migrations.
+	// Rolling (default): tasks run while existing components stay up.
+	// Drain: all components scale to 0 before tasks run, avoiding metastore deadlocks.
+	// +optional
+	// +kubebuilder:validation:Enum=Rolling;Drain
+	// +kubebuilder:default=Rolling
+	UpgradeStrategy *string `json:"upgradeStrategy,omitempty"`
+
 	// Set to true to skip all lifecycle tasks entirely.
 	// +optional
 	Disabled *bool `json:"disabled,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -852,6 +852,11 @@ func (in *LifecycleSpec) DeepCopyInto(out *LifecycleSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.UpgradeStrategy != nil {
+		in, out := &in.UpgradeStrategy, &out.UpgradeStrategy
+		*out = new(string)
+		**out = **in
+	}
 	if in.Disabled != nil {
 		in, out := &in.Disabled, &out.Disabled
 		*out = new(bool)

--- a/charts/superset-operator/crds/superset.apache.org_supersets.yaml
+++ b/charts/superset-operator/crds/superset.apache.org_supersets.yaml
@@ -15652,6 +15652,12 @@ spec:
                     - Automatic
                     - Supervised
                     type: string
+                  upgradeStrategy:
+                    default: Rolling
+                    enum:
+                    - Rolling
+                    - Drain
+                    type: string
                 type: object
                 x-kubernetes-validations:
                 - message: init.command is mutually exclusive with init.adminUser

--- a/config/crd/bases/superset.apache.org_supersets.yaml
+++ b/config/crd/bases/superset.apache.org_supersets.yaml
@@ -15652,6 +15652,12 @@ spec:
                     - Automatic
                     - Supervised
                     type: string
+                  upgradeStrategy:
+                    default: Rolling
+                    enum:
+                    - Rolling
+                    - Drain
+                    type: string
                 type: object
                 x-kubernetes-validations:
                 - message: init.command is mutually exclusive with init.adminUser

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -560,6 +560,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `upgradeMode` _string_ | UpgradeMode controls whether upgrades require manual approval.<br />Automatic runs immediately on image change; Supervised waits for an<br />approval annotation before proceeding. | Automatic | Enum: [Automatic Supervised] <br />Optional: \{\} <br /> |
+| `upgradeStrategy` _string_ | UpgradeStrategy controls component behavior during database migrations.<br />Rolling (default): tasks run while existing components stay up.<br />Drain: all components scale to 0 before tasks run, avoiding metastore deadlocks. | Rolling | Enum: [Rolling Drain] <br />Optional: \{\} <br /> |
 | `disabled` _boolean_ | Set to true to skip all lifecycle tasks entirely. |  | Optional: \{\} <br /> |
 | `image` _[ImageOverrideSpec](#imageoverridespec)_ | Image override for lifecycle task pods. |  | Optional: \{\} <br /> |
 | `podTemplate` _[PodTemplate](#podtemplate)_ | Pod and container template for lifecycle task pods. |  | Optional: \{\} <br /> |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -317,6 +317,39 @@ image is detected:
 - **Supervised** — tasks wait for an annotation-based approval before running,
   allowing operators to review and approve upgrades manually
 
+The `upgradeStrategy` controls component behavior during migrations:
+
+- **Rolling** (default) — components stay up while tasks run
+- **Drain** — all component child CRs are deleted before tasks run, eliminating
+  metastore deadlocks and ensuring components restart against the new schema
+
+### Lifecycle Flow
+
+The following diagram shows the lifecycle state machine. Optional steps activate
+based on `upgradeMode` and `upgradeStrategy` settings.
+
+```mermaid
+%%{init: {'theme': 'neutral', 'themeVariables': {'fontSize': '12px'}}}%%
+flowchart TD
+    A[Image changed] --> B{Downgrade?}
+    B -->|Yes| C[Blocked]
+    B -->|No| D{upgradeMode}
+    D -->|Automatic| F
+    D -->|Supervised| E[Await approval]
+    E --> F{migrate strategy}
+    F -->|Never| I
+    F -->|VersionChange / Always| G{upgradeStrategy}
+    G -->|Rolling| H[Migrate pod]
+    G -->|Drain| G1[Delete child CRs] --> G2[Wait for GC] --> H
+    H --> I{init strategy}
+    I -->|Never| K[Complete]
+    I -->|VersionChange / Always| J[Init pod]
+    J --> K
+```
+
+For first deployments (no previous image), the flow starts at the strategy check
+(no downgrade comparison or approval needed).
+
 ### Downgrade Blocking
 
 The operator performs semver comparison on image tags. If the new tag is lower

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -195,6 +195,26 @@ To verify the docs build cleanly (same check that runs in CI):
 make docs-build
 ```
 
+### Diagrams
+
+Use Mermaid for flow diagrams. Keep them compact with the following conventions:
+
+- Use `flowchart TD` (top-down) for state machines and lifecycle flows
+- Set font size to 12px via init config: `%%{init: {'theme': 'neutral', 'themeVariables': {'fontSize': '12px'}}}%%`
+- Use short node labels (abbreviate where clear from context)
+- Prefer single-letter node IDs (`A`, `B`, `C`) for readability of the source
+
+Example:
+````markdown
+```mermaid
+%%{init: {'theme': 'neutral', 'themeVariables': {'fontSize': '12px'}}}%%
+flowchart TD
+    A[Start] --> B{Decision}
+    B -->|Yes| C[Action]
+    B -->|No| D[Skip]
+```
+````
+
 ### API Reference
 
 The [API reference](api-reference.md) is generated from Go type definitions using [`crd-ref-docs`](https://github.com/elastic/crd-ref-docs). After modifying types in `api/v1alpha1/`, run `make codegen` to regenerate all generated artifacts (CRDs, DeepCopy, Helm CRDs, API docs). CI verifies nothing is stale.

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -66,6 +66,11 @@ Tasks run sequentially: migrate must complete before init starts. The task
 strategy (default: `VersionChange`) determines whether tasks are triggered —
 with the default strategy, tasks only run when the Superset image changes.
 
+When `upgradeStrategy: Drain` is set, the operator deletes all component child
+CRs before running tasks. This cascades to Deployments, Services, and HPAs via
+garbage collection, ensuring no application pods access the metastore during
+schema changes. After tasks complete, Phase 4 recreates all components fresh.
+
 Components do not deploy until both lifecycle tasks complete (or lifecycle is
 explicitly disabled via `spec.lifecycle.disabled: true`). If a task is in
 progress or has failed, `Reconcile()` returns early with a requeue, skipping

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -448,6 +448,35 @@ The `upgradeMode` field controls how image upgrades are handled:
 The operator also performs semver comparison on image tags and blocks downgrades
 to prevent accidental database corruption.
 
+#### Upgrade Strategy
+
+The `upgradeStrategy` field controls component behavior during database migrations:
+
+- **Rolling** (default) — lifecycle tasks run while existing components stay up. This works well for most minor/patch upgrades where migrations are additive and backward-compatible.
+- **Drain** — all component child CRs are deleted before tasks run, ensuring no application pods are connected to the metastore during schema changes. After tasks complete, components are recreated with the new image.
+
+Use `Drain` when:
+- Migrations alter or drop existing columns/tables (breaking backward compatibility)
+- You've experienced metastore deadlocks from concurrent access during migrations
+- You want to ensure components always start fresh against the new schema (no stale state or incompatible ORM mappings)
+
+```yaml
+spec:
+  lifecycle:
+    upgradeStrategy: Drain
+    migrate:
+      strategy: VersionChange
+    init:
+      strategy: VersionChange
+```
+
+During a drain, Ingress/HTTPRoute and NetworkPolicy resources are preserved (they
+are owned by the parent CR, not child CRs). Once lifecycle tasks complete,
+components are recreated and traffic resumes automatically.
+
+See the [lifecycle flow diagram](architecture.md#lifecycle-flow) for a visual
+overview of how upgrade mode, upgrade strategy, and task strategies interact.
+
 #### Custom Commands
 
 ```yaml

--- a/internal/controller/reconcile_test.go
+++ b/internal/controller/reconcile_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -55,6 +56,9 @@ func testScheme(t *testing.T) *runtime.Scheme {
 	}
 	if err := corev1.AddToScheme(s); err != nil {
 		t.Fatalf("AddToScheme(corev1): %v", err)
+	}
+	if err := appsv1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme(appsv1): %v", err)
 	}
 	if err := networkingv1.AddToScheme(s); err != nil {
 		t.Fatalf("AddToScheme(networkingv1): %v", err)
@@ -1377,5 +1381,257 @@ func TestReconcile_InitTerminalFailure_NoRequeue(t *testing.T) {
 
 	if result.RequeueAfter != 0 {
 		t.Errorf("expected no requeue for terminal init failure, got RequeueAfter=%v", result.RequeueAfter)
+	}
+}
+
+func TestReconcile_DowngradeBlocked(t *testing.T) {
+	scheme := testScheme(t)
+
+	spec := minimalSupersetSpec()
+	spec.Image.Tag = "4.0.0"
+	spec.Lifecycle = &supersetv1alpha1.LifecycleSpec{}
+
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       spec,
+		Status: supersetv1alpha1.SupersetStatus{
+			LastLifecycleImage: "apache/superset:4.1.0",
+		},
+	}
+
+	c := reconcileOnce(t, scheme, superset).
+		WithStatusSubresource(&supersetv1alpha1.SupersetTask{}).
+		Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Errorf("expected no requeue for blocked downgrade, got RequeueAfter=%v", result.RequeueAfter)
+	}
+
+	updated := &supersetv1alpha1.Superset{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, updated); err != nil {
+		t.Fatalf("get superset: %v", err)
+	}
+	if updated.Status.Phase != "Blocked" {
+		t.Errorf("expected phase Blocked, got %q", updated.Status.Phase)
+	}
+
+	tasks := &supersetv1alpha1.SupersetTaskList{}
+	if err := c.List(context.Background(), tasks); err != nil {
+		t.Fatalf("list tasks: %v", err)
+	}
+	if len(tasks.Items) != 0 {
+		t.Errorf("expected no task CRs for blocked downgrade, got %d", len(tasks.Items))
+	}
+}
+
+func TestReconcile_SupervisedMode_AwaitsApproval(t *testing.T) {
+	scheme := testScheme(t)
+
+	supervised := "Supervised"
+	spec := minimalSupersetSpec()
+	spec.Image.Tag = "4.1.0"
+	spec.Lifecycle = &supersetv1alpha1.LifecycleSpec{
+		UpgradeMode: &supervised,
+	}
+
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       spec,
+		Status: supersetv1alpha1.SupersetStatus{
+			LastLifecycleImage: "apache/superset:4.0.0",
+		},
+	}
+
+	c := reconcileOnce(t, scheme, superset).
+		WithStatusSubresource(&supersetv1alpha1.SupersetTask{}).
+		Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+	doReconcile(t, r, "test")
+
+	ctx := context.Background()
+	updated := &supersetv1alpha1.Superset{}
+	if err := c.Get(ctx, types.NamespacedName{Name: "test", Namespace: "default"}, updated); err != nil {
+		t.Fatalf("get superset: %v", err)
+	}
+	if updated.Status.Phase != "AwaitingApproval" {
+		t.Errorf("expected phase AwaitingApproval, got %q", updated.Status.Phase)
+	}
+
+	tasks := &supersetv1alpha1.SupersetTaskList{}
+	if err := c.List(ctx, tasks); err != nil {
+		t.Fatalf("list tasks: %v", err)
+	}
+	if len(tasks.Items) != 0 {
+		t.Errorf("expected no task CRs before approval, got %d", len(tasks.Items))
+	}
+
+	// Approve and reconcile again.
+	updated.Annotations = map[string]string{"superset.apache.org/approve-upgrade": "true"}
+	if err := c.Update(ctx, updated); err != nil {
+		t.Fatalf("update superset with approval: %v", err)
+	}
+	doReconcile(t, r, "test")
+
+	migrateCR := &supersetv1alpha1.SupersetTask{}
+	if err := c.Get(ctx, types.NamespacedName{Name: "test-migrate", Namespace: "default"}, migrateCR); err != nil {
+		t.Fatalf("expected migrate CR after approval: %v", err)
+	}
+}
+
+func TestReconcile_ImageUnchanged_SkipsLifecycleTasks(t *testing.T) {
+	scheme := testScheme(t)
+
+	spec := minimalSupersetSpec()
+	spec.Lifecycle = &supersetv1alpha1.LifecycleSpec{}
+
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       spec,
+		Status: supersetv1alpha1.SupersetStatus{
+			LastLifecycleImage: "apache/superset:latest",
+		},
+	}
+
+	c := reconcileOnce(t, scheme, superset).
+		WithStatusSubresource(&supersetv1alpha1.SupersetTask{}).
+		Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+	doReconcile(t, r, "test")
+
+	tasks := &supersetv1alpha1.SupersetTaskList{}
+	if err := c.List(context.Background(), tasks); err != nil {
+		t.Fatalf("list tasks: %v", err)
+	}
+	if len(tasks.Items) != 0 {
+		t.Errorf("expected no task CRs when image unchanged, got %d", len(tasks.Items))
+	}
+
+	ww := &supersetv1alpha1.SupersetWebServer{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, ww); err != nil {
+		t.Fatalf("expected web server when lifecycle already complete: %v", err)
+	}
+}
+
+func TestReconcile_StrategyNever_SkipsMigrateTask(t *testing.T) {
+	scheme := testScheme(t)
+
+	never := "Never"
+	spec := minimalSupersetSpec()
+	spec.Lifecycle = &supersetv1alpha1.LifecycleSpec{
+		Migrate: &supersetv1alpha1.MigrateTaskSpec{Strategy: &never},
+	}
+
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       spec,
+	}
+
+	c := reconcileOnce(t, scheme, superset).
+		WithStatusSubresource(&supersetv1alpha1.SupersetTask{}).
+		Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+	doReconcile(t, r, "test")
+
+	ctx := context.Background()
+
+	migrateCR := &supersetv1alpha1.SupersetTask{}
+	err := c.Get(ctx, types.NamespacedName{Name: "test-migrate", Namespace: "default"}, migrateCR)
+	if !errors.IsNotFound(err) {
+		t.Fatalf("expected migrate CR to not exist (strategy=Never), got err: %v", err)
+	}
+
+	initCR := &supersetv1alpha1.SupersetTask{}
+	if err := c.Get(ctx, types.NamespacedName{Name: "test-init", Namespace: "default"}, initCR); err != nil {
+		t.Fatalf("expected init CR to exist: %v", err)
+	}
+}
+
+func TestReconcile_StrategyAlways_RunsOnConfigChange(t *testing.T) {
+	scheme := testScheme(t)
+
+	always := "Always"
+	never := "Never"
+	spec := minimalSupersetSpec()
+	spec.Lifecycle = &supersetv1alpha1.LifecycleSpec{
+		Migrate: &supersetv1alpha1.MigrateTaskSpec{Strategy: &always},
+		Init:    &supersetv1alpha1.InitTaskSpec{Strategy: &never},
+	}
+
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       spec,
+		Status: supersetv1alpha1.SupersetStatus{
+			LastLifecycleImage: "apache/superset:latest",
+		},
+	}
+
+	c := reconcileOnce(t, scheme, superset).
+		WithStatusSubresource(&supersetv1alpha1.SupersetTask{}).
+		Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+	doReconcile(t, r, "test")
+
+	ctx := context.Background()
+
+	migrateCR := &supersetv1alpha1.SupersetTask{}
+	if err := c.Get(ctx, types.NamespacedName{Name: "test-migrate", Namespace: "default"}, migrateCR); err != nil {
+		t.Fatalf("expected migrate CR with strategy=Always even when image unchanged: %v", err)
+	}
+}
+
+func TestReconcile_DrainStrategy_DeletesChildCRs(t *testing.T) {
+	scheme := testScheme(t)
+
+	drain := "Drain"
+	spec := minimalSupersetSpec()
+	spec.Lifecycle = &supersetv1alpha1.LifecycleSpec{
+		UpgradeStrategy: &drain,
+	}
+
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       spec,
+	}
+
+	// Pre-create a WebServer child CR (simulating existing deployment).
+	webServer := &supersetv1alpha1.SupersetWebServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			Labels:    map[string]string{common.LabelKeyParent: "test"},
+		},
+	}
+
+	c := reconcileOnce(t, scheme, superset).
+		WithObjects(webServer).
+		WithStatusSubresource(&supersetv1alpha1.SupersetTask{}, &supersetv1alpha1.SupersetWebServer{}).
+		Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+	doReconcile(t, r, "test")
+
+	ctx := context.Background()
+
+	// WebServer child CR should be deleted (drain deletes children before migrate).
+	ws := &supersetv1alpha1.SupersetWebServer{}
+	err := c.Get(ctx, types.NamespacedName{Name: "test", Namespace: "default"}, ws)
+	if !errors.IsNotFound(err) {
+		t.Fatalf("expected WebServer child CR to be deleted during drain, got err: %v", err)
+	}
+
+	// Status should show lifecycle is in progress (drain completed immediately
+	// in fake client since no Deployments exist, so it moved to migrate phase).
+	updated := &supersetv1alpha1.Superset{}
+	if err := c.Get(ctx, types.NamespacedName{Name: "test", Namespace: "default"}, updated); err != nil {
+		t.Fatalf("get superset: %v", err)
+	}
+	if updated.Status.Phase != "Upgrading" && updated.Status.Phase != "Draining" {
+		t.Errorf("expected phase Upgrading or Draining, got %q", updated.Status.Phase)
 	}
 }

--- a/internal/controller/superset_controller.go
+++ b/internal/controller/superset_controller.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -74,6 +75,7 @@ type SupersetReconciler struct {
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch;update
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=list;watch
 
 func (r *SupersetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
@@ -293,6 +295,7 @@ const (
 	upgradeModeSupervsied = "Supervised"
 
 	lifecyclePhaseIdle             = "Idle"
+	lifecyclePhaseDraining         = "Draining"
 	lifecyclePhaseMigrating        = "Migrating"
 	lifecyclePhaseInitializing     = "Initializing"
 	lifecyclePhaseComplete         = "Complete"
@@ -301,7 +304,11 @@ const (
 
 	annotationApproveUpgrade = "superset.apache.org/approve-upgrade"
 
+	upgradeStrategyRolling = "Rolling"
+	upgradeStrategyDrain   = "Drain"
+
 	phaseUpgrading        = "Upgrading"
+	phaseDraining         = "Draining"
 	phaseBlocked          = "Blocked"
 	phaseAwaitingApproval = "AwaitingApproval"
 )
@@ -354,20 +361,10 @@ func (r *SupersetReconciler) reconcileLifecycle(
 		return gateResult, false, nil
 	}
 
-	// Determine which tasks need to run.
-	migrateNeeded := r.taskNeeded(superset, taskTypeMigrate, imageChanged)
-	initNeeded := r.taskNeeded(superset, taskTypeInit, imageChanged)
-
-	// Prune task CRs when strategy is Never.
-	if !migrateNeeded && r.taskStrategy(superset, taskTypeMigrate) == strategyNever {
-		if err := r.deleteTaskCR(ctx, superset.Name+suffixMigrate, superset.Namespace); err != nil {
-			return 0, false, fmt.Errorf("deleting migrate task CR: %w", err)
-		}
-	}
-	if !initNeeded && r.taskStrategy(superset, taskTypeInit) == strategyNever {
-		if err := r.deleteTaskCR(ctx, superset.Name+suffixInit, superset.Namespace); err != nil {
-			return 0, false, fmt.Errorf("deleting init task CR: %w", err)
-		}
+	// Determine which tasks need to run and prune disabled task CRs.
+	migrateNeeded, initNeeded, err := r.resolveTaskNeeds(ctx, superset, imageChanged)
+	if err != nil {
+		return 0, false, err
 	}
 
 	// If neither task is needed, lifecycle is complete.
@@ -376,6 +373,22 @@ func (r *SupersetReconciler) reconcileLifecycle(
 		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
 			metav1.ConditionTrue, "LifecycleComplete", "Lifecycle tasks completed successfully", superset.Generation)
 		return 0, true, nil
+	}
+
+	// Drain strategy: delete all component child CRs before running tasks.
+	// Only drain when migrate is needed — init alone doesn't alter the schema.
+	if migrateNeeded && getUpgradeStrategy(superset) == upgradeStrategyDrain {
+		superset.Status.Lifecycle.Phase = lifecyclePhaseDraining
+		superset.Status.Phase = phaseDraining
+		drained, err := r.drainComponents(ctx, superset)
+		if err != nil {
+			return 0, false, fmt.Errorf("draining components: %w", err)
+		}
+		if !drained {
+			setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
+				metav1.ConditionFalse, "Draining", "Scaling components to zero before migration", superset.Generation)
+			return taskRequeueInterval, false, nil
+		}
 	}
 
 	// Orchestrate: migrate first, then init.
@@ -675,6 +688,25 @@ func (r *SupersetReconciler) taskNeeded(superset *supersetv1alpha1.Superset, tas
 	}
 }
 
+// resolveTaskNeeds determines which tasks need to run and prunes CRs for disabled tasks.
+func (r *SupersetReconciler) resolveTaskNeeds(ctx context.Context, superset *supersetv1alpha1.Superset, imageChanged bool) (bool, bool, error) {
+	migrateNeeded := r.taskNeeded(superset, taskTypeMigrate, imageChanged)
+	initNeeded := r.taskNeeded(superset, taskTypeInit, imageChanged)
+
+	if !migrateNeeded && r.taskStrategy(superset, taskTypeMigrate) == strategyNever {
+		if err := r.deleteTaskCR(ctx, superset.Name+suffixMigrate, superset.Namespace); err != nil {
+			return false, false, fmt.Errorf("deleting migrate task CR: %w", err)
+		}
+	}
+	if !initNeeded && r.taskStrategy(superset, taskTypeInit) == strategyNever {
+		if err := r.deleteTaskCR(ctx, superset.Name+suffixInit, superset.Namespace); err != nil {
+			return false, false, fmt.Errorf("deleting init task CR: %w", err)
+		}
+	}
+
+	return migrateNeeded, initNeeded, nil
+}
+
 func (r *SupersetReconciler) taskStrategy(superset *supersetv1alpha1.Superset, taskType string) string {
 	if superset.Spec.Lifecycle == nil {
 		return strategyVersionChange
@@ -758,6 +790,13 @@ func getUpgradeMode(superset *supersetv1alpha1.Superset) string {
 	return upgradeModeAutomatic
 }
 
+func getUpgradeStrategy(superset *supersetv1alpha1.Superset) string {
+	if superset.Spec.Lifecycle != nil && superset.Spec.Lifecycle.UpgradeStrategy != nil {
+		return *superset.Spec.Lifecycle.UpgradeStrategy
+	}
+	return upgradeStrategyRolling
+}
+
 func isLifecycleDisabled(superset *supersetv1alpha1.Superset) bool {
 	return superset.Spec.Lifecycle != nil && superset.Spec.Lifecycle.Disabled != nil && *superset.Spec.Lifecycle.Disabled
 }
@@ -771,6 +810,48 @@ func (r *SupersetReconciler) deleteTaskCR(ctx context.Context, name, namespace s
 		return err
 	}
 	return r.Delete(ctx, task)
+}
+
+// drainComponents deletes all component child CRs, which cascades to their
+// Deployments, Services, and HPAs via ownerReference garbage collection.
+// Returns (drained, error) where drained=true means no component Deployments remain.
+func (r *SupersetReconciler) drainComponents(ctx context.Context, superset *supersetv1alpha1.Superset) (bool, error) {
+	log := logf.FromContext(ctx)
+
+	// Delete child CRs for each component type (not task CRs).
+	for _, desc := range componentDescriptors {
+		if desc.extract(&superset.Spec) == nil {
+			continue
+		}
+		childName := superset.Name
+		childObj := desc.newChild()
+		childObj.SetName(childName)
+		childObj.SetNamespace(superset.Namespace)
+		if err := r.Delete(ctx, childObj); err != nil {
+			if !errors.IsNotFound(err) {
+				return false, fmt.Errorf("deleting child CR %s/%s: %w", desc.componentType, childName, err)
+			}
+		} else {
+			log.Info("Deleted child CR for drain", "component", desc.componentType)
+		}
+	}
+
+	// Check if any component Deployments still exist (waiting for GC).
+	deployList := &appsv1.DeploymentList{}
+	if err := r.List(ctx, deployList,
+		client.InNamespace(superset.Namespace),
+		client.MatchingLabels{naming.LabelKeyParent: superset.Name},
+	); err != nil {
+		return false, fmt.Errorf("listing deployments: %w", err)
+	}
+
+	if len(deployList.Items) > 0 {
+		log.Info("Waiting for component Deployments to be garbage collected", "remaining", len(deployList.Items))
+		return false, nil
+	}
+
+	log.Info("All components drained")
+	return true, nil
 }
 
 func resolveLifecycleImage(parentImage *supersetv1alpha1.ImageSpec, override *supersetv1alpha1.ImageOverrideSpec) string {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,10 +41,17 @@ nav:
 extra_css:
   - stylesheets/extra.css
 
+extra_javascript:
+  - https://unpkg.com/mermaid@11/dist/mermaid.min.js
+
 markdown_extensions:
   - admonition
   - pymdownx.details
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.highlight:


### PR DESCRIPTION
## Summary

Adds a `Drain` upgrade strategy that deletes all component child CRs before running database migrations, ensuring no application pods access the metastore during schema changes. This eliminates deadlocks caused by concurrent DB access during superset db upgrade.

##  Changes

- New `field spec.lifecycle.upgradeStrategy: Rolling | Drain` (default: `Rolling`)
- Drain deletes component child CRs (cascading to Deployments, Services, HPAs) before the migrate task runs
- Drain only activates when migration is actually needed (`migrate.strategy != Never`)
- After lifecycle completes, normal component reconciliation recreates everything with the new image
- Ingress/HTTPRoute and NetworkPolicies are preserved during drain (owned by parent CR)
- Mermaid flow diagram added to architecture docs showing the full lifecycle state machine
- Mermaid rendering enabled in mkdocs config
- Developer guide documents Mermaid diagram conventions
- User guide documents when to use each strategy with cross-reference to flow diagram

## When to use Drain

- Metastore deadlocks from concurrent access during superset db upgrade
- Components should always start fresh against the new schema (no stale ORM state)
- Minimize issues caused by components expecting old metastore schema