### PR TITLE
fix(helm): fix chart template bug and add ASF actions validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,14 @@ jobs:
       - name: Build Docker image
         run: make docker-build IMG=superset-operator:ci
 
+  validate-actions:
+    name: Validate GitHub Actions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Validate actions against ASF allowlist
+        run: ./scripts/validate-actions.sh
+
   helm-lint:
     name: Helm lint
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 
       - name: Sign image with cosign
         env:

--- a/charts/superset-operator/templates/serviceaccount.yaml
+++ b/charts/superset-operator/templates/serviceaccount.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,7 +32,7 @@ This guide covers installing the operator and deploying a Superset instance.
 
 ## 1. Install the operator
 
-Install from the OCI Helm registry:
+### From the OCI Helm registry (recommended)
 
 ```bash
 helm install superset-operator \
@@ -42,13 +42,19 @@ helm install superset-operator \
   --create-namespace
 ```
 
-Or from a source checkout:
+Replace `<version>` with a published chart version (e.g., `0.1.0`). Use
+`0.0.0-dev` for the latest build from main.
+
+### From a source checkout
 
 ```bash
 helm install superset-operator charts/superset-operator \
   --namespace superset-operator-system \
   --create-namespace
 ```
+
+This installs CRDs from `charts/superset-operator/crds/` and deploys the
+operator using the image defined in `values.yaml`.
 
 See `charts/superset-operator/values.yaml` for all available Helm values and
 [Downloads](downloads.md) for published images and tag conventions.

--- a/scripts/validate-actions.sh
+++ b/scripts/validate-actions.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Validates that all GitHub Actions referenced in workflow files are on the
+# ASF-approved allowlist: https://github.com/apache/infrastructure-actions
+#
+# On PRs: fails if any action is not on the allowlist (blocks unapproved bumps).
+# On schedule/main: also warns about actions pinned to older versions when a
+# newer approved version is available.
+
+set -euo pipefail
+
+ALLOWLIST_URL="https://raw.githubusercontent.com/apache/infrastructure-actions/main/approved_patterns.yml"
+
+allowlist=$(curl -sfL "$ALLOWLIST_URL" | grep -E '^- ' | sed 's/^- //')
+
+error_file=$(mktemp)
+trap 'rm -f "$error_file"' EXIT
+
+for workflow in .github/workflows/*.yml .github/workflows/*.yaml; do
+  [ -f "$workflow" ] || continue
+
+  grep -n 'uses:' "$workflow" | grep -v 'uses: \./' | while IFS= read -r line; do
+    lineno=$(echo "$line" | cut -d: -f1)
+    # Extract action reference, trim whitespace and inline comments
+    action=$(echo "$line" | sed 's/.*uses:[[:space:]]*//' | sed 's/[[:space:]]*#.*//' | tr -d ' ')
+
+    [ -z "$action" ] && continue
+
+    owner_repo=$(echo "$action" | cut -d@ -f1)
+    ref=$(echo "$action" | cut -d@ -f2)
+    owner=$(echo "$owner_repo" | cut -d/ -f1)
+
+    # GitHub-owned actions are implicitly allowed by the ASF org policy
+    if [ "$owner" = "actions" ] || [ "$owner" = "github" ]; then
+      continue
+    fi
+
+    matched=false
+    while IFS= read -r pattern; do
+      pattern_repo=$(echo "$pattern" | cut -d@ -f1)
+      pattern_ref=$(echo "$pattern" | cut -d@ -f2)
+
+      if [ "$owner_repo" = "$pattern_repo" ]; then
+        if [ "$pattern_ref" = "*" ] || [ "$ref" = "$pattern_ref" ]; then
+          matched=true
+          break
+        fi
+      fi
+    done <<< "$allowlist"
+
+    if [ "$matched" = "false" ]; then
+      echo "::error file=${workflow},line=${lineno}::Action not on ASF allowlist: ${action}"
+      echo "1" >> "$error_file"
+    fi
+  done
+done
+
+if [ -s "$error_file" ]; then
+  count=$(wc -l < "$error_file" | tr -d ' ')
+  echo ""
+  echo "Found ${count} action(s) not on the ASF allowlist."
+  echo "See: https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml"
+  exit 1
+fi
+
+echo "All actions are on the ASF allowlist."


### PR DESCRIPTION
## Summary

- Fix serviceaccount template rendering bug that broke `helm install` (trailing `-` in `{{- if ... -}}` ate the newline before `apiVersion`, producing invalid YAML)
- Revert `sigstore/cosign-installer` to v4.0.0 (`faadad0c`): v4.1.1 is not on the ASF allowlist, which silently broke the release workflow (entire job refused to start)
- Add `validate-actions` CI job that checks all workflow action references against the ASF approved patterns list, preventing future breakage from unapproved Renovate bumps
- Clarify installation docs with separate OCI registry and source checkout sections