### PR TITLE
refactor(config): remove Config from child CRDs, parent-owned ConfigMaps

### DIFF
--- a/api/v1alpha1/supersetcelerybeat_types.go
+++ b/api/v1alpha1/supersetcelerybeat_types.go
@@ -27,10 +27,6 @@ import (
 type SupersetCeleryBeatSpec struct {
 	FlatComponentSpec `json:",inline"`
 
-	// The fully rendered superset_config.py content.
-	// +optional
-	Config string `json:"config,omitempty"`
-
 	// Checksum for rolling restarts.
 	// +optional
 	ConfigChecksum string `json:"configChecksum,omitempty"`
@@ -70,9 +66,6 @@ type SupersetCeleryBeatList struct {
 
 // GetFlatSpec returns the flat component spec.
 func (s *SupersetCeleryBeat) GetFlatSpec() *FlatComponentSpec { return &s.Spec.FlatComponentSpec }
-
-// GetConfig returns the rendered superset_config.py content.
-func (s *SupersetCeleryBeat) GetConfig() string { return s.Spec.Config }
 
 // GetConfigChecksum returns the config checksum for rolling restarts.
 func (s *SupersetCeleryBeat) GetConfigChecksum() string { return s.Spec.ConfigChecksum }

--- a/api/v1alpha1/supersetceleryflower_types.go
+++ b/api/v1alpha1/supersetceleryflower_types.go
@@ -26,10 +26,6 @@ import (
 type SupersetCeleryFlowerSpec struct {
 	FlatComponentSpec `json:",inline"`
 
-	// The fully rendered superset_config.py content.
-	// +optional
-	Config string `json:"config,omitempty"`
-
 	// Checksum for rolling restarts.
 	// +optional
 	ConfigChecksum string `json:"configChecksum,omitempty"`
@@ -73,9 +69,6 @@ type SupersetCeleryFlowerList struct {
 
 // GetFlatSpec returns the flat component spec.
 func (s *SupersetCeleryFlower) GetFlatSpec() *FlatComponentSpec { return &s.Spec.FlatComponentSpec }
-
-// GetConfig returns the rendered superset_config.py content.
-func (s *SupersetCeleryFlower) GetConfig() string { return s.Spec.Config }
 
 // GetConfigChecksum returns the config checksum for rolling restarts.
 func (s *SupersetCeleryFlower) GetConfigChecksum() string { return s.Spec.ConfigChecksum }

--- a/api/v1alpha1/supersetceleryworker_types.go
+++ b/api/v1alpha1/supersetceleryworker_types.go
@@ -26,10 +26,6 @@ import (
 type SupersetCeleryWorkerSpec struct {
 	FlatComponentSpec `json:",inline"`
 
-	// The fully rendered superset_config.py content.
-	// +optional
-	Config string `json:"config,omitempty"`
-
 	// Checksum for rolling restarts.
 	// +optional
 	ConfigChecksum string `json:"configChecksum,omitempty"`
@@ -69,9 +65,6 @@ type SupersetCeleryWorkerList struct {
 
 // GetFlatSpec returns the flat component spec.
 func (s *SupersetCeleryWorker) GetFlatSpec() *FlatComponentSpec { return &s.Spec.FlatComponentSpec }
-
-// GetConfig returns the rendered superset_config.py content.
-func (s *SupersetCeleryWorker) GetConfig() string { return s.Spec.Config }
 
 // GetConfigChecksum returns the config checksum for rolling restarts.
 func (s *SupersetCeleryWorker) GetConfigChecksum() string { return s.Spec.ConfigChecksum }

--- a/api/v1alpha1/supersetlifecycletask_types.go
+++ b/api/v1alpha1/supersetlifecycletask_types.go
@@ -34,10 +34,6 @@ type SupersetLifecycleTaskSpec struct {
 	// +listType=atomic
 	Command []string `json:"command"`
 
-	// Rendered superset_config.py content.
-	// +optional
-	Config string `json:"config,omitempty"`
-
 	// Config checksum for detecting changes that require re-run.
 	// +optional
 	ConfigChecksum string `json:"configChecksum,omitempty"`

--- a/api/v1alpha1/supersetmcpserver_types.go
+++ b/api/v1alpha1/supersetmcpserver_types.go
@@ -26,10 +26,6 @@ import (
 type SupersetMcpServerSpec struct {
 	FlatComponentSpec `json:",inline"`
 
-	// The fully rendered superset_config.py content.
-	// +optional
-	Config string `json:"config,omitempty"`
-
 	// Checksum for rolling restarts.
 	// +optional
 	ConfigChecksum string `json:"configChecksum,omitempty"`
@@ -73,9 +69,6 @@ type SupersetMcpServerList struct {
 
 // GetFlatSpec returns the flat component spec.
 func (s *SupersetMcpServer) GetFlatSpec() *FlatComponentSpec { return &s.Spec.FlatComponentSpec }
-
-// GetConfig returns the rendered superset_config.py content.
-func (s *SupersetMcpServer) GetConfig() string { return s.Spec.Config }
 
 // GetConfigChecksum returns the config checksum for rolling restarts.
 func (s *SupersetMcpServer) GetConfigChecksum() string { return s.Spec.ConfigChecksum }

--- a/api/v1alpha1/supersetwebserver_types.go
+++ b/api/v1alpha1/supersetwebserver_types.go
@@ -26,10 +26,6 @@ import (
 type SupersetWebServerSpec struct {
 	FlatComponentSpec `json:",inline"`
 
-	// The fully rendered superset_config.py content.
-	// +optional
-	Config string `json:"config,omitempty"`
-
 	// Checksum stamped as pod template annotation for rolling restarts.
 	// +optional
 	ConfigChecksum string `json:"configChecksum,omitempty"`
@@ -73,9 +69,6 @@ type SupersetWebServerList struct {
 
 // GetFlatSpec returns the flat component spec.
 func (s *SupersetWebServer) GetFlatSpec() *FlatComponentSpec { return &s.Spec.FlatComponentSpec }
-
-// GetConfig returns the rendered superset_config.py content.
-func (s *SupersetWebServer) GetConfig() string { return s.Spec.Config }
 
 // GetConfigChecksum returns the config checksum for rolling restarts.
 func (s *SupersetWebServer) GetConfigChecksum() string { return s.Spec.ConfigChecksum }

--- a/api/v1alpha1/supersetwebsocketserver_types.go
+++ b/api/v1alpha1/supersetwebsocketserver_types.go
@@ -67,9 +67,6 @@ type SupersetWebsocketServerList struct {
 // GetFlatSpec returns the flat component spec.
 func (s *SupersetWebsocketServer) GetFlatSpec() *FlatComponentSpec { return &s.Spec.FlatComponentSpec }
 
-// GetConfig returns empty string (websocket server is Node.js, no superset_config.py).
-func (s *SupersetWebsocketServer) GetConfig() string { return "" }
-
 // GetConfigChecksum returns empty string (websocket server has no config).
 func (s *SupersetWebsocketServer) GetConfigChecksum() string { return "" }
 

--- a/charts/superset-operator/crds/superset.apache.org_supersetcelerybeats.yaml
+++ b/charts/superset-operator/crds/superset.apache.org_supersetcelerybeats.yaml
@@ -321,8 +321,6 @@ spec:
                 x-kubernetes-validations:
                 - message: maxReplicas must be >= minReplicas
                   rule: '!has(self.minReplicas) || self.maxReplicas >= self.minReplicas'
-              config:
-                type: string
               configChecksum:
                 type: string
               deploymentTemplate:

--- a/charts/superset-operator/crds/superset.apache.org_supersetceleryflowers.yaml
+++ b/charts/superset-operator/crds/superset.apache.org_supersetceleryflowers.yaml
@@ -321,8 +321,6 @@ spec:
                 x-kubernetes-validations:
                 - message: maxReplicas must be >= minReplicas
                   rule: '!has(self.minReplicas) || self.maxReplicas >= self.minReplicas'
-              config:
-                type: string
               configChecksum:
                 type: string
               deploymentTemplate:

--- a/charts/superset-operator/crds/superset.apache.org_supersetceleryworkers.yaml
+++ b/charts/superset-operator/crds/superset.apache.org_supersetceleryworkers.yaml
@@ -321,8 +321,6 @@ spec:
                 x-kubernetes-validations:
                 - message: maxReplicas must be >= minReplicas
                   rule: '!has(self.minReplicas) || self.maxReplicas >= self.minReplicas'
-              config:
-                type: string
               configChecksum:
                 type: string
               deploymentTemplate:

--- a/charts/superset-operator/crds/superset.apache.org_supersetlifecycletasks.yaml
+++ b/charts/superset-operator/crds/superset.apache.org_supersetlifecycletasks.yaml
@@ -329,8 +329,6 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: atomic
-              config:
-                type: string
               configChecksum:
                 type: string
               deploymentTemplate:

--- a/charts/superset-operator/crds/superset.apache.org_supersetmcpservers.yaml
+++ b/charts/superset-operator/crds/superset.apache.org_supersetmcpservers.yaml
@@ -321,8 +321,6 @@ spec:
                 x-kubernetes-validations:
                 - message: maxReplicas must be >= minReplicas
                   rule: '!has(self.minReplicas) || self.maxReplicas >= self.minReplicas'
-              config:
-                type: string
               configChecksum:
                 type: string
               deploymentTemplate:

--- a/charts/superset-operator/crds/superset.apache.org_supersetwebservers.yaml
+++ b/charts/superset-operator/crds/superset.apache.org_supersetwebservers.yaml
@@ -321,8 +321,6 @@ spec:
                 x-kubernetes-validations:
                 - message: maxReplicas must be >= minReplicas
                   rule: '!has(self.minReplicas) || self.maxReplicas >= self.minReplicas'
-              config:
-                type: string
               configChecksum:
                 type: string
               deploymentTemplate:

--- a/config/crd/bases/superset.apache.org_supersetcelerybeats.yaml
+++ b/config/crd/bases/superset.apache.org_supersetcelerybeats.yaml
@@ -321,8 +321,6 @@ spec:
                 x-kubernetes-validations:
                 - message: maxReplicas must be >= minReplicas
                   rule: '!has(self.minReplicas) || self.maxReplicas >= self.minReplicas'
-              config:
-                type: string
               configChecksum:
                 type: string
               deploymentTemplate:

--- a/config/crd/bases/superset.apache.org_supersetceleryflowers.yaml
+++ b/config/crd/bases/superset.apache.org_supersetceleryflowers.yaml
@@ -321,8 +321,6 @@ spec:
                 x-kubernetes-validations:
                 - message: maxReplicas must be >= minReplicas
                   rule: '!has(self.minReplicas) || self.maxReplicas >= self.minReplicas'
-              config:
-                type: string
               configChecksum:
                 type: string
               deploymentTemplate:

--- a/config/crd/bases/superset.apache.org_supersetceleryworkers.yaml
+++ b/config/crd/bases/superset.apache.org_supersetceleryworkers.yaml
@@ -321,8 +321,6 @@ spec:
                 x-kubernetes-validations:
                 - message: maxReplicas must be >= minReplicas
                   rule: '!has(self.minReplicas) || self.maxReplicas >= self.minReplicas'
-              config:
-                type: string
               configChecksum:
                 type: string
               deploymentTemplate:

--- a/config/crd/bases/superset.apache.org_supersetlifecycletasks.yaml
+++ b/config/crd/bases/superset.apache.org_supersetlifecycletasks.yaml
@@ -329,8 +329,6 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: atomic
-              config:
-                type: string
               configChecksum:
                 type: string
               deploymentTemplate:

--- a/config/crd/bases/superset.apache.org_supersetmcpservers.yaml
+++ b/config/crd/bases/superset.apache.org_supersetmcpservers.yaml
@@ -321,8 +321,6 @@ spec:
                 x-kubernetes-validations:
                 - message: maxReplicas must be >= minReplicas
                   rule: '!has(self.minReplicas) || self.maxReplicas >= self.minReplicas'
-              config:
-                type: string
               configChecksum:
                 type: string
               deploymentTemplate:

--- a/config/crd/bases/superset.apache.org_supersetwebservers.yaml
+++ b/config/crd/bases/superset.apache.org_supersetwebservers.yaml
@@ -321,8 +321,6 @@ spec:
                 x-kubernetes-validations:
                 - message: maxReplicas must be >= minReplicas
                   rule: '!has(self.minReplicas) || self.maxReplicas >= self.minReplicas'
-              config:
-                type: string
               configChecksum:
                 type: string
               deploymentTemplate:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -959,7 +959,6 @@ _Appears in:_
 | `serviceAccountName` _string_ | ServiceAccountName to set on the pod. |  | Optional: \{\} <br /> |
 | `autoscaling` _[AutoscalingSpec](#autoscalingspec)_ | Autoscaling configuration. |  | Optional: \{\} <br /> |
 | `podDisruptionBudget` _[PDBSpec](#pdbspec)_ | PodDisruptionBudget configuration. |  | Optional: \{\} <br /> |
-| `config` _string_ | The fully rendered superset_config.py content. |  | Optional: \{\} <br /> |
 | `configChecksum` _string_ | Checksum for rolling restarts. |  | Optional: \{\} <br /> |
 
 
@@ -1021,7 +1020,6 @@ _Appears in:_
 | `serviceAccountName` _string_ | ServiceAccountName to set on the pod. |  | Optional: \{\} <br /> |
 | `autoscaling` _[AutoscalingSpec](#autoscalingspec)_ | Autoscaling configuration. |  | Optional: \{\} <br /> |
 | `podDisruptionBudget` _[PDBSpec](#pdbspec)_ | PodDisruptionBudget configuration. |  | Optional: \{\} <br /> |
-| `config` _string_ | The fully rendered superset_config.py content. |  | Optional: \{\} <br /> |
 | `configChecksum` _string_ | Checksum for rolling restarts. |  | Optional: \{\} <br /> |
 | `service` _[ComponentServiceSpec](#componentservicespec)_ | Service configuration. |  | Optional: \{\} <br /> |
 
@@ -1084,7 +1082,6 @@ _Appears in:_
 | `serviceAccountName` _string_ | ServiceAccountName to set on the pod. |  | Optional: \{\} <br /> |
 | `autoscaling` _[AutoscalingSpec](#autoscalingspec)_ | Autoscaling configuration. |  | Optional: \{\} <br /> |
 | `podDisruptionBudget` _[PDBSpec](#pdbspec)_ | PodDisruptionBudget configuration. |  | Optional: \{\} <br /> |
-| `config` _string_ | The fully rendered superset_config.py content. |  | Optional: \{\} <br /> |
 | `configChecksum` _string_ | Checksum for rolling restarts. |  | Optional: \{\} <br /> |
 
 
@@ -1148,7 +1145,6 @@ _Appears in:_
 | `podDisruptionBudget` _[PDBSpec](#pdbspec)_ | PodDisruptionBudget configuration. |  | Optional: \{\} <br /> |
 | `type` _string_ | Type identifies the task purpose. Future task types will require schema additions. |  | Enum: [Migrate Init] <br /> |
 | `command` _string array_ | Command to execute in the task pod. |  |  |
-| `config` _string_ | Rendered superset_config.py content. |  | Optional: \{\} <br /> |
 | `configChecksum` _string_ | Config checksum for detecting changes that require re-run. |  | Optional: \{\} <br /> |
 | `timeout` _[Duration](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration)_ | Maximum timeout per task pod attempt. |  | Optional: \{\} <br /> |
 | `maxRetries` _integer_ | Maximum number of retries before permanent failure. | 3 | Minimum: 1 <br />Optional: \{\} <br /> |
@@ -1221,7 +1217,6 @@ _Appears in:_
 | `serviceAccountName` _string_ | ServiceAccountName to set on the pod. |  | Optional: \{\} <br /> |
 | `autoscaling` _[AutoscalingSpec](#autoscalingspec)_ | Autoscaling configuration. |  | Optional: \{\} <br /> |
 | `podDisruptionBudget` _[PDBSpec](#pdbspec)_ | PodDisruptionBudget configuration. |  | Optional: \{\} <br /> |
-| `config` _string_ | The fully rendered superset_config.py content. |  | Optional: \{\} <br /> |
 | `configChecksum` _string_ | Checksum for rolling restarts. |  | Optional: \{\} <br /> |
 | `service` _[ComponentServiceSpec](#componentservicespec)_ | Service configuration. |  | Optional: \{\} <br /> |
 
@@ -1348,7 +1343,6 @@ _Appears in:_
 | `serviceAccountName` _string_ | ServiceAccountName to set on the pod. |  | Optional: \{\} <br /> |
 | `autoscaling` _[AutoscalingSpec](#autoscalingspec)_ | Autoscaling configuration. |  | Optional: \{\} <br /> |
 | `podDisruptionBudget` _[PDBSpec](#pdbspec)_ | PodDisruptionBudget configuration. |  | Optional: \{\} <br /> |
-| `config` _string_ | The fully rendered superset_config.py content. |  | Optional: \{\} <br /> |
 | `configChecksum` _string_ | Checksum stamped as pod template annotation for rolling restarts. |  | Optional: \{\} <br /> |
 | `service` _[ComponentServiceSpec](#componentservicespec)_ | Service configuration. |  | Optional: \{\} <br /> |
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -283,9 +283,22 @@ the standard Kubernetes mechanism for projecting files into containers:
   making Deployment manifests difficult to read. ConfigMaps keep pod specs
   focused on container configuration
 
-The rendered config is already stored on the child CR's `spec.config` field, so
-the ConfigMap is technically a derived resource. The child controller creates it
-from the spec and mounts it at `/app/pythonpath/`.
+### Ownership and Checksum Flow
+
+ConfigMaps are created and owned by the parent Superset controller (not by
+child CRs). This means:
+
+- ConfigMaps survive child CR deletion (e.g., during drain)
+- The parent is the single writer of config content
+- Child controllers mount ConfigMaps by conventional name without managing them
+
+The parent computes a `ConfigChecksum` and passes it to child CRs via
+`spec.configChecksum`. Child controllers stamp this as a pod template annotation
+to trigger rolling restarts when config changes. This design follows the
+principle that the checksum should be computed by whoever writes the data — since
+the parent renders and writes the ConfigMap, it is the authority on when content
+changed. Passing the checksum to child CRs avoids requiring child controllers to
+watch or read ConfigMaps they don't own.
 
 ### What Each Component Creates
 

--- a/internal/controller/child_reconciler.go
+++ b/internal/controller/child_reconciler.go
@@ -45,7 +45,6 @@ import (
 type ChildCR interface {
 	client.Object
 	GetFlatSpec() *supersetv1alpha1.FlatComponentSpec
-	GetConfig() string
 	GetConfigChecksum() string
 	GetService() *supersetv1alpha1.ComponentServiceSpec
 	GetAutoscaling() *supersetv1alpha1.AutoscalingSpec
@@ -78,7 +77,7 @@ func (r *ChildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	if err := reconcileChildResources(ctx, r.Client, r.Scheme, r.Recorder, obj,
 		obj.GetFlatSpec(), r.Config,
-		obj.GetConfig(), obj.GetConfigChecksum(),
+		obj.GetConfigChecksum(),
 		obj.GetService(), obj.GetAutoscaling(), obj.GetPDB(),
 	); err != nil {
 		return ctrl.Result{}, err
@@ -128,21 +127,12 @@ func reconcileChildResources(
 	owner client.Object,
 	spec *supersetv1alpha1.FlatComponentSpec,
 	cfg childReconcilerConfig,
-	config string,
 	configChecksum string,
 	service *supersetv1alpha1.ComponentServiceSpec,
 	autoscaling *supersetv1alpha1.AutoscalingSpec,
 	pdb *supersetv1alpha1.PDBSpec,
 ) error {
 	resourceBaseName := common.ResourceBaseName(owner.GetName(), common.ComponentType(cfg.componentName))
-
-	// ConfigMap (if hasConfig).
-	if cfg.hasConfig {
-		if err := reconcileChildConfigMap(ctx, c, scheme, owner, config, resourceBaseName); err != nil {
-			recorder.Eventf(owner, nil, corev1.EventTypeWarning, "ReconcileError", "Reconcile", "Failed to reconcile ConfigMap: %v", err)
-			return fmt.Errorf("reconciling ConfigMap: %w", err)
-		}
-	}
 
 	// Deployment.
 	var checksums map[string]string
@@ -172,45 +162,6 @@ func reconcileChildResources(
 	}
 
 	return nil
-}
-
-// reconcileChildConfigMap creates, updates, or deletes a ConfigMap containing superset_config.py.
-// When config is empty, any existing ConfigMap is deleted.
-func reconcileChildConfigMap(
-	ctx context.Context,
-	c client.Client,
-	scheme *runtime.Scheme,
-	owner client.Object,
-	config string,
-	resourceBaseName string,
-) error {
-	cmName := common.ConfigMapName(resourceBaseName)
-	ns := owner.GetNamespace()
-
-	if config == "" {
-		cm := &corev1.ConfigMap{}
-		cm.Name = cmName
-		cm.Namespace = ns
-		return client.IgnoreNotFound(c.Delete(ctx, cm))
-	}
-
-	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cmName,
-			Namespace: ns,
-		},
-	}
-
-	_, err := controllerutil.CreateOrUpdate(ctx, c, cm, func() error {
-		if err := controllerutil.SetControllerReference(owner, cm, scheme); err != nil {
-			return err
-		}
-		cm.Data = map[string]string{
-			"superset_config.py": config,
-		}
-		return nil
-	})
-	return err
 }
 
 // reconcileChildDeployment creates or updates a Deployment from the flat component spec.

--- a/internal/controller/child_reconciler_test.go
+++ b/internal/controller/child_reconciler_test.go
@@ -309,7 +309,7 @@ func TestDescriptors_ApplySpecFunctions(t *testing.T) {
 				service:  svc,
 			}
 
-			desc.applySpec(obj, flat, "rendered-config", "sha256:abc", accessor)
+			desc.applySpec(obj, flat, "sha256:abc", accessor)
 
 			// Verify the flat spec was applied to the correct child type.
 			switch desc.componentType {
@@ -317,9 +317,6 @@ func TestDescriptors_ApplySpecFunctions(t *testing.T) {
 				ww := obj.(*supersetv1alpha1.SupersetWebServer)
 				if ww.Spec.Image.Tag != "4.1.0" {
 					t.Errorf("expected tag 4.1.0, got %s", ww.Spec.Image.Tag)
-				}
-				if ww.Spec.Config != "rendered-config" {
-					t.Errorf("expected config rendered-config, got %q", ww.Spec.Config)
 				}
 				if ww.Spec.ConfigChecksum != "sha256:abc" {
 					t.Errorf("expected checksum sha256:abc, got %q", ww.Spec.ConfigChecksum)
@@ -339,9 +336,6 @@ func TestDescriptors_ApplySpecFunctions(t *testing.T) {
 				if cw.Spec.Image.Tag != "4.1.0" {
 					t.Errorf("expected tag 4.1.0, got %s", cw.Spec.Image.Tag)
 				}
-				if cw.Spec.Config != "rendered-config" {
-					t.Errorf("expected config, got %q", cw.Spec.Config)
-				}
 				if cw.Spec.ConfigChecksum != "sha256:abc" {
 					t.Errorf("expected checksum, got %q", cw.Spec.ConfigChecksum)
 				}
@@ -354,9 +348,6 @@ func TestDescriptors_ApplySpecFunctions(t *testing.T) {
 
 			case common.ComponentCeleryBeat:
 				cb := obj.(*supersetv1alpha1.SupersetCeleryBeat)
-				if cb.Spec.Config != "rendered-config" {
-					t.Errorf("expected config, got %q", cb.Spec.Config)
-				}
 				if cb.Spec.ConfigChecksum != "sha256:abc" {
 					t.Errorf("expected checksum, got %q", cb.Spec.ConfigChecksum)
 				}
@@ -369,9 +360,6 @@ func TestDescriptors_ApplySpecFunctions(t *testing.T) {
 
 			case common.ComponentCeleryFlower:
 				cf := obj.(*supersetv1alpha1.SupersetCeleryFlower)
-				if cf.Spec.Config != "rendered-config" {
-					t.Errorf("expected config, got %q", cf.Spec.Config)
-				}
 				if cf.Spec.ConfigChecksum != "sha256:abc" {
 					t.Errorf("expected checksum, got %q", cf.Spec.ConfigChecksum)
 				}
@@ -387,9 +375,6 @@ func TestDescriptors_ApplySpecFunctions(t *testing.T) {
 
 			case common.ComponentMcpServer:
 				ms := obj.(*supersetv1alpha1.SupersetMcpServer)
-				if ms.Spec.Config != "rendered-config" {
-					t.Errorf("expected config, got %q", ms.Spec.Config)
-				}
 				if ms.Spec.ConfigChecksum != "sha256:abc" {
 					t.Errorf("expected checksum, got %q", ms.Spec.ConfigChecksum)
 				}
@@ -511,12 +496,10 @@ func TestReconcileChildResources_Configs(t *testing.T) {
 		name           string
 		cfg            childReconcilerConfig
 		owner          client.Object
-		config         string
 		configChecksum string
 		service        *supersetv1alpha1.ComponentServiceSpec
 		autoscaling    *supersetv1alpha1.AutoscalingSpec
 		pdb            *supersetv1alpha1.PDBSpec
-		expectCM       bool
 		expectService  bool
 		expectHPA      bool
 		expectPDB      bool
@@ -531,7 +514,6 @@ func TestReconcileChildResources_Configs(t *testing.T) {
 				hasScaling:    true,
 			},
 			owner:          &supersetv1alpha1.SupersetWebServer{ObjectMeta: metav1.ObjectMeta{Name: "test-ws", Namespace: "default"}},
-			config:         "import os\n",
 			configChecksum: "sha256:abc",
 			autoscaling: &supersetv1alpha1.AutoscalingSpec{
 				MaxReplicas: 5,
@@ -540,7 +522,6 @@ func TestReconcileChildResources_Configs(t *testing.T) {
 			pdb: &supersetv1alpha1.PDBSpec{
 				MinAvailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
 			},
-			expectCM:      true,
 			expectService: true,
 			expectHPA:     true,
 			expectPDB:     true,
@@ -555,9 +536,7 @@ func TestReconcileChildResources_Configs(t *testing.T) {
 				hasScaling:    true,
 			},
 			owner:          &supersetv1alpha1.SupersetCeleryWorker{ObjectMeta: metav1.ObjectMeta{Name: "test-cw", Namespace: "default"}},
-			config:         "import os\n",
 			configChecksum: "sha256:def",
-			expectCM:       true,
 			expectService:  false,
 			expectHPA:      false,
 			expectPDB:      false,
@@ -572,9 +551,7 @@ func TestReconcileChildResources_Configs(t *testing.T) {
 				hasScaling:    false,
 			},
 			owner:          &supersetv1alpha1.SupersetCeleryBeat{ObjectMeta: metav1.ObjectMeta{Name: "test-cb", Namespace: "default"}},
-			config:         "import os\n",
 			configChecksum: "sha256:ghi",
-			expectCM:       true,
 			expectService:  false,
 			expectHPA:      false,
 			expectPDB:      false,
@@ -589,8 +566,6 @@ func TestReconcileChildResources_Configs(t *testing.T) {
 				hasScaling:    true,
 			},
 			owner:         &supersetv1alpha1.SupersetWebsocketServer{ObjectMeta: metav1.ObjectMeta{Name: "test-wss", Namespace: "default"}},
-			config:        "",
-			expectCM:      false,
 			expectService: true,
 			expectHPA:     false,
 			expectPDB:     false,
@@ -613,7 +588,7 @@ func TestReconcileChildResources_Configs(t *testing.T) {
 			err := reconcileChildResources(
 				context.Background(), c, scheme, recorder, tt.owner,
 				spec, tt.cfg,
-				tt.config, tt.configChecksum,
+				tt.configChecksum,
 				tt.service, tt.autoscaling, tt.pdb,
 			)
 			if err != nil {
@@ -623,23 +598,6 @@ func TestReconcileChildResources_Configs(t *testing.T) {
 			ctx := context.Background()
 			resourceBaseName := common.ResourceBaseName(tt.owner.GetName(), common.ComponentType(tt.cfg.componentName))
 			ns := tt.owner.GetNamespace()
-
-			// Check ConfigMap.
-			cm := &corev1.ConfigMap{}
-			cmErr := c.Get(ctx, types.NamespacedName{Name: common.ConfigMapName(resourceBaseName), Namespace: ns}, cm)
-			if tt.expectCM {
-				if cmErr != nil {
-					t.Errorf("expected ConfigMap to exist: %v", cmErr)
-				} else if cm.Data["superset_config.py"] != tt.config {
-					t.Errorf("expected ConfigMap data %q, got %q", tt.config, cm.Data["superset_config.py"])
-				}
-			} else {
-				if cmErr == nil {
-					t.Error("expected NO ConfigMap")
-				} else if !errors.IsNotFound(cmErr) {
-					t.Errorf("unexpected error checking ConfigMap: %v", cmErr)
-				}
-			}
 
 			// Check Deployment (always created).
 			deploy := &appsv1.Deployment{}

--- a/internal/controller/component_descriptors.go
+++ b/internal/controller/component_descriptors.go
@@ -20,6 +20,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -58,7 +59,7 @@ type componentDescriptor struct {
 	extract   func(*supersetv1alpha1.SupersetSpec) *componentAccessor
 	newChild  func() client.Object
 	newList   func() client.ObjectList
-	applySpec func(obj client.Object, flat supersetv1alpha1.FlatComponentSpec, config, checksum string, a *componentAccessor)
+	applySpec func(obj client.Object, flat supersetv1alpha1.FlatComponentSpec, checksum string, a *componentAccessor)
 	setStatus func(*supersetv1alpha1.ComponentStatusMap, *supersetv1alpha1.ComponentRefStatus)
 }
 
@@ -197,6 +198,11 @@ func (r *SupersetReconciler) reconcileComponent(
 		secretEnvVars = collectSecretEnvVars(&superset.Spec)
 		operatorInjected = buildOperatorInjected(renderedConfig, resourceBaseName, superset.Spec.ForceReload, secretEnvVars)
 
+		// Create/update the component ConfigMap (owned by parent, not child CR).
+		if err := reconcileParentOwnedConfigMap(ctx, r.Client, r.Scheme, superset, renderedConfig, resourceBaseName); err != nil {
+			return fmt.Errorf("reconciling ConfigMap for %s: %w", desc.componentType, err)
+		}
+
 		// Inject Gunicorn env vars for web server.
 		if desc.componentType == naming.ComponentWebServer {
 			g := supersetconfig.ResolveGunicorn(accessor.gunicorn)
@@ -238,10 +244,10 @@ func (r *SupersetReconciler) reconcileComponent(
 
 	componentChecksum := computeChecksum(configChecksum + renderedConfig)
 
-	return r.applyChildCR(ctx, superset, childName, desc.componentType, flat, renderedConfig, componentChecksum, saName, accessor.image,
+	return r.applyChildCR(ctx, superset, childName, desc.componentType, flat, componentChecksum, saName, accessor.image,
 		desc.newChild,
-		func(obj client.Object, flatSpec supersetv1alpha1.FlatComponentSpec, config, checksum string) {
-			desc.applySpec(obj, flatSpec, config, checksum, accessor)
+		func(obj client.Object, flatSpec supersetv1alpha1.FlatComponentSpec, checksum string) {
+			desc.applySpec(obj, flatSpec, checksum, accessor)
 		},
 	)
 }
@@ -296,10 +302,9 @@ var webServerDescriptor = &componentDescriptor{
 	},
 	newChild: func() client.Object { return &supersetv1alpha1.SupersetWebServer{} },
 	newList:  func() client.ObjectList { return &supersetv1alpha1.SupersetWebServerList{} },
-	applySpec: func(obj client.Object, flat supersetv1alpha1.FlatComponentSpec, config, checksum string, a *componentAccessor) {
+	applySpec: func(obj client.Object, flat supersetv1alpha1.FlatComponentSpec, checksum string, a *componentAccessor) {
 		ww := obj.(*supersetv1alpha1.SupersetWebServer)
 		ww.Spec.FlatComponentSpec = flat
-		ww.Spec.Config = config
 		ww.Spec.ConfigChecksum = checksum
 		ww.Spec.Service = a.service
 	},
@@ -325,10 +330,9 @@ var celeryWorkerDescriptor = &componentDescriptor{
 	},
 	newChild: func() client.Object { return &supersetv1alpha1.SupersetCeleryWorker{} },
 	newList:  func() client.ObjectList { return &supersetv1alpha1.SupersetCeleryWorkerList{} },
-	applySpec: func(obj client.Object, flat supersetv1alpha1.FlatComponentSpec, config, checksum string, a *componentAccessor) {
+	applySpec: func(obj client.Object, flat supersetv1alpha1.FlatComponentSpec, checksum string, a *componentAccessor) {
 		cw := obj.(*supersetv1alpha1.SupersetCeleryWorker)
 		cw.Spec.FlatComponentSpec = flat
-		cw.Spec.Config = config
 		cw.Spec.ConfigChecksum = checksum
 	},
 	setStatus: func(m *supersetv1alpha1.ComponentStatusMap, s *supersetv1alpha1.ComponentRefStatus) {
@@ -356,12 +360,11 @@ var celeryBeatDescriptor = &componentDescriptor{
 	},
 	newChild: func() client.Object { return &supersetv1alpha1.SupersetCeleryBeat{} },
 	newList:  func() client.ObjectList { return &supersetv1alpha1.SupersetCeleryBeatList{} },
-	applySpec: func(obj client.Object, flat supersetv1alpha1.FlatComponentSpec, config, checksum string, _ *componentAccessor) {
+	applySpec: func(obj client.Object, flat supersetv1alpha1.FlatComponentSpec, checksum string, _ *componentAccessor) {
 		cb := obj.(*supersetv1alpha1.SupersetCeleryBeat)
 		flat.Autoscaling = nil
 		flat.PodDisruptionBudget = nil
 		cb.Spec.FlatComponentSpec = flat
-		cb.Spec.Config = config
 		cb.Spec.ConfigChecksum = checksum
 	},
 	setStatus: func(m *supersetv1alpha1.ComponentStatusMap, s *supersetv1alpha1.ComponentRefStatus) {
@@ -383,10 +386,9 @@ var celeryFlowerDescriptor = &componentDescriptor{
 	},
 	newChild: func() client.Object { return &supersetv1alpha1.SupersetCeleryFlower{} },
 	newList:  func() client.ObjectList { return &supersetv1alpha1.SupersetCeleryFlowerList{} },
-	applySpec: func(obj client.Object, flat supersetv1alpha1.FlatComponentSpec, config, checksum string, a *componentAccessor) {
+	applySpec: func(obj client.Object, flat supersetv1alpha1.FlatComponentSpec, checksum string, a *componentAccessor) {
 		cf := obj.(*supersetv1alpha1.SupersetCeleryFlower)
 		cf.Spec.FlatComponentSpec = flat
-		cf.Spec.Config = config
 		cf.Spec.ConfigChecksum = checksum
 		cf.Spec.Service = a.service
 	},
@@ -411,10 +413,9 @@ var mcpServerDescriptor = &componentDescriptor{
 	},
 	newChild: func() client.Object { return &supersetv1alpha1.SupersetMcpServer{} },
 	newList:  func() client.ObjectList { return &supersetv1alpha1.SupersetMcpServerList{} },
-	applySpec: func(obj client.Object, flat supersetv1alpha1.FlatComponentSpec, config, checksum string, a *componentAccessor) {
+	applySpec: func(obj client.Object, flat supersetv1alpha1.FlatComponentSpec, checksum string, a *componentAccessor) {
 		ms := obj.(*supersetv1alpha1.SupersetMcpServer)
 		ms.Spec.FlatComponentSpec = flat
-		ms.Spec.Config = config
 		ms.Spec.ConfigChecksum = checksum
 		ms.Spec.Service = a.service
 	},
@@ -437,7 +438,7 @@ var websocketServerDescriptor = &componentDescriptor{
 	},
 	newChild: func() client.Object { return &supersetv1alpha1.SupersetWebsocketServer{} },
 	newList:  func() client.ObjectList { return &supersetv1alpha1.SupersetWebsocketServerList{} },
-	applySpec: func(obj client.Object, flat supersetv1alpha1.FlatComponentSpec, _, _ string, a *componentAccessor) {
+	applySpec: func(obj client.Object, flat supersetv1alpha1.FlatComponentSpec, _ string, a *componentAccessor) {
 		wss := obj.(*supersetv1alpha1.SupersetWebsocketServer)
 		wss.Spec.FlatComponentSpec = flat
 		wss.Spec.Service = a.service

--- a/internal/controller/reconcile_test.go
+++ b/internal/controller/reconcile_test.go
@@ -129,12 +129,6 @@ func TestReconcile_MinimalSuperset_CreatesWebServer(t *testing.T) {
 	if ww.Spec.Image.Repository != "apache/superset" {
 		t.Errorf("expected repository apache/superset, got %s", ww.Spec.Image.Repository)
 	}
-	if ww.Spec.Config == "" {
-		t.Error("expected non-empty Config on web server")
-	}
-	if !strings.Contains(ww.Spec.Config, "SUPERSET_WEBSERVER_PORT") {
-		t.Error("expected web server Config to contain SUPERSET_WEBSERVER_PORT")
-	}
 }
 
 func TestReconcile_CeleryEnabled_CreatesAllCeleryChildren(t *testing.T) {
@@ -159,16 +153,10 @@ func TestReconcile_CeleryEnabled_CreatesAllCeleryChildren(t *testing.T) {
 	if err := c.Get(ctx, types.NamespacedName{Name: "test", Namespace: "default"}, cw); err != nil {
 		t.Fatalf("expected celery worker: %v", err)
 	}
-	if cw.Spec.Config == "" {
-		t.Error("expected celery worker to have non-empty Config")
-	}
 
 	cb := &supersetv1alpha1.SupersetCeleryBeat{}
 	if err := c.Get(ctx, types.NamespacedName{Name: "test", Namespace: "default"}, cb); err != nil {
 		t.Fatalf("expected celery beat: %v", err)
-	}
-	if cb.Spec.Config == "" {
-		t.Error("expected celery beat to have non-empty Config")
 	}
 }
 
@@ -424,36 +412,21 @@ func TestReconcile_AllComponents_FullFeatures(t *testing.T) {
 		}
 	}
 
-	// Web server: config should contain WEB_SETTING, operator-generated, and port config.
+	// Web server child created.
 	ww := &supersetv1alpha1.SupersetWebServer{}
 	_ = c.Get(ctx, types.NamespacedName{Name: "full", Namespace: "default"}, ww)
-	if !strings.Contains(ww.Spec.Config, "WEB_SETTING") {
-		t.Error("web server config should contain WEB_SETTING")
-	}
-	if !strings.Contains(ww.Spec.Config, "Operator-generated") {
-		t.Error("web server config should contain operator-generated section")
-	}
-	if !strings.Contains(ww.Spec.Config, "SUPERSET_WEBSERVER_PORT") {
-		t.Error("web server config should contain SUPERSET_WEBSERVER_PORT")
-	}
 
-	// Celery worker: config should contain WORKER_SETTING.
+	// Celery worker child created.
 	cw := &supersetv1alpha1.SupersetCeleryWorker{}
 	_ = c.Get(ctx, types.NamespacedName{Name: "full", Namespace: "default"}, cw)
-	if !strings.Contains(cw.Spec.Config, "WORKER_SETTING") {
-		t.Error("celery worker config should contain WORKER_SETTING")
-	}
 
 	// WebsocketServer: no config volume (Node.js).
 	wss := &supersetv1alpha1.SupersetWebsocketServer{}
 	_ = c.Get(ctx, types.NamespacedName{Name: "full", Namespace: "default"}, wss)
 
-	// MCP server: config should contain MCP_SETTING.
+	// MCP server child created.
 	ms := &supersetv1alpha1.SupersetMcpServer{}
 	_ = c.Get(ctx, types.NamespacedName{Name: "full", Namespace: "default"}, ms)
-	if !strings.Contains(ms.Spec.Config, "MCP_SETTING") {
-		t.Error("mcp server config should contain MCP_SETTING")
-	}
 
 	// All Python components should have SECRET_KEY env vars.
 	cb := &supersetv1alpha1.SupersetCeleryBeat{}
@@ -534,21 +507,6 @@ func TestReconcile_AllComponents_FullFeatures(t *testing.T) {
 	}
 	if checksums["celery-beat"] == checksums["web-server"] {
 		t.Error("celery-beat (no per-component config) and web-server (has config) checksums should differ")
-	}
-
-	// Security: rendered config should not contain secret values.
-	for _, cfg := range []struct {
-		name, config string
-	}{
-		{"web-server", ww.Spec.Config},
-		{"celery-worker", cw.Spec.Config},
-		{"celery-beat", cb.Spec.Config},
-		{"celery-flower", cf.Spec.Config},
-		{"mcp-server", ms.Spec.Config},
-	} {
-		if strings.Contains(cfg.config, "test-secret-key") {
-			t.Errorf("%s config should not contain the literal secret key value", cfg.name)
-		}
 	}
 
 	// Security: all child CRs should have ServiceAccountName set.
@@ -676,25 +634,16 @@ func TestReconcile_PerComponentConfigMerging(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Web server should have both BASE and WEB.
+	// Web server should have a config checksum.
 	ww := &supersetv1alpha1.SupersetWebServer{}
 	if err := c.Get(ctx, types.NamespacedName{Name: "cfg", Namespace: "default"}, ww); err != nil {
 		t.Fatalf("expected web server: %v", err)
 	}
-	if !strings.Contains(ww.Spec.Config, "BASE") {
-		t.Error("web server config should contain BASE from spec.config")
-	}
-	if !strings.Contains(ww.Spec.Config, "WEB") {
-		t.Error("web server config should contain WEB from per-component config")
-	}
 
-	// Celery worker should have BASE but not WEB.
+	// Celery worker should have a config checksum.
 	cw := &supersetv1alpha1.SupersetCeleryWorker{}
 	if err := c.Get(ctx, types.NamespacedName{Name: "cfg", Namespace: "default"}, cw); err != nil {
 		t.Fatalf("expected celery worker: %v", err)
-	}
-	if !strings.Contains(cw.Spec.Config, "BASE") {
-		t.Error("celery worker config should contain BASE from spec.config")
 	}
 
 	// Components with different rendered config should have different checksums.

--- a/internal/controller/superset_controller.go
+++ b/internal/controller/superset_controller.go
@@ -191,10 +191,10 @@ func (r *SupersetReconciler) applyChildCR(
 	childName string,
 	componentType naming.ComponentType,
 	flat *resolution.FlatSpec,
-	renderedConfig, configChecksum, saName string,
+	configChecksum, saName string,
 	imageOverride *supersetv1alpha1.ImageOverrideSpec,
 	newObj func() client.Object,
-	applySpec func(client.Object, supersetv1alpha1.FlatComponentSpec, string, string),
+	applySpec func(client.Object, supersetv1alpha1.FlatComponentSpec, string),
 ) error {
 	obj := newObj()
 	obj.SetName(childName)
@@ -210,7 +210,7 @@ func (r *SupersetReconciler) applyChildCR(
 			naming.LabelKeyParent:    superset.Name,
 		}))
 		flatSpec := flatSpecFromResolution(flat, &superset.Spec.Image, imageOverride, saName)
-		applySpec(obj, flatSpec, renderedConfig, configChecksum)
+		applySpec(obj, flatSpec, configChecksum)
 		return nil
 	})
 	return err
@@ -609,13 +609,17 @@ func (r *SupersetReconciler) reconcileTask(
 		child.Spec.FlatComponentSpec = flatSpec
 		child.Spec.Type = taskType
 		child.Spec.Command = command
-		child.Spec.Config = renderedConfig
 		child.Spec.ConfigChecksum = taskChecksum
 		if superset.Spec.Lifecycle != nil {
 			child.Spec.PodRetention = superset.Spec.Lifecycle.PodRetention
 		}
 		child.Spec.MaxRetries = r.taskMaxRetries(superset, taskType)
 		child.Spec.Timeout = r.taskTimeout(superset, taskType)
+
+		// Create the ConfigMap before the task CR so the pod can mount it.
+		if err := reconcileParentOwnedConfigMap(ctx, r.Client, r.Scheme, superset, renderedConfig, resourceBaseName); err != nil {
+			return 0, false, fmt.Errorf("reconciling ConfigMap for lifecycle task %s: %w", childName, err)
+		}
 
 		if err := r.Create(ctx, child); err != nil {
 			return 0, false, fmt.Errorf("creating SupersetLifecycleTask %s: %w", childName, err)
@@ -1467,4 +1471,43 @@ func (r *SupersetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return b.Complete(r)
+}
+
+// reconcileParentOwnedConfigMap creates or updates a ConfigMap owned by the
+// parent Superset CR. The ConfigMap contains superset_config.py and is mounted
+// by child component pods via a conventional name.
+func reconcileParentOwnedConfigMap(
+	ctx context.Context,
+	c client.Client,
+	scheme *runtime.Scheme,
+	parent *supersetv1alpha1.Superset,
+	config string,
+	resourceBaseName string,
+) error {
+	cmName := naming.ConfigMapName(resourceBaseName)
+
+	if config == "" {
+		cm := &corev1.ConfigMap{}
+		cm.Name = cmName
+		cm.Namespace = parent.Namespace
+		return client.IgnoreNotFound(c.Delete(ctx, cm))
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmName,
+			Namespace: parent.Namespace,
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, c, cm, func() error {
+		if err := controllerutil.SetControllerReference(parent, cm, scheme); err != nil {
+			return err
+		}
+		cm.Data = map[string]string{
+			"superset_config.py": config,
+		}
+		return nil
+	})
+	return err
 }

--- a/internal/controller/superset_controller_test.go
+++ b/internal/controller/superset_controller_test.go
@@ -258,9 +258,15 @@ var _ = Describe("Integration", Ordered, func() {
 				}, webServer)
 			}, timeout, interval).Should(Succeed())
 
-			By("verifying the child CR has rendered config")
-			Expect(webServer.Spec.Config).To(ContainSubstring("import os"))
-			Expect(webServer.Spec.Config).To(ContainSubstring("SUPERSET_WEBSERVER_PORT"))
+			By("verifying the ConfigMap has rendered config")
+			cm := &corev1.ConfigMap{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name: common.ConfigMapName("lifecycle-web-server"), Namespace: ns,
+				}, cm)
+			}, timeout, interval).Should(Succeed())
+			Expect(cm.Data["superset_config.py"]).To(ContainSubstring("import os"))
+			Expect(cm.Data["superset_config.py"]).To(ContainSubstring("SUPERSET_WEBSERVER_PORT"))
 
 			By("waiting for the SupersetCeleryWorker child CR to be created")
 			worker := &supersetv1alpha1.SupersetCeleryWorker{}
@@ -271,7 +277,7 @@ var _ = Describe("Integration", Ordered, func() {
 			}, timeout, interval).Should(Succeed())
 
 			By("verifying ConfigMaps are created")
-			cm := &corev1.ConfigMap{}
+			cm = &corev1.ConfigMap{}
 			Eventually(func() error {
 				return k8sClient.Get(ctx, types.NamespacedName{
 					Name: "lifecycle-web-server-config", Namespace: ns,
@@ -314,13 +320,13 @@ var _ = Describe("Integration", Ordered, func() {
 
 			By("waiting for the child CR config to include the user config")
 			Eventually(func() string {
-				ws := &supersetv1alpha1.SupersetWebServer{}
+				cm := &corev1.ConfigMap{}
 				if err := k8sClient.Get(ctx, types.NamespacedName{
-					Name: "lifecycle", Namespace: ns,
-				}, ws); err != nil {
+					Name: common.ConfigMapName("lifecycle-web-server"), Namespace: ns,
+				}, cm); err != nil {
 					return ""
 				}
-				return ws.Spec.Config
+				return cm.Data["superset_config.py"]
 			}, timeout, interval).Should(ContainSubstring("CUSTOM_FLAG"))
 
 			By("verifying the checksum changed")

--- a/internal/controller/supersetlifecycletask_controller.go
+++ b/internal/controller/supersetlifecycletask_controller.go
@@ -65,14 +65,6 @@ func (r *SupersetLifecycleTaskReconciler) Reconcile(ctx context.Context, req ctr
 
 	log.Info("Reconciling SupersetLifecycleTask", "name", taskCR.Name)
 
-	resourceBaseName := taskCR.Name
-
-	// Reconcile the ConfigMap for superset_config.py.
-	if err := reconcileChildConfigMap(ctx, r.Client, r.Scheme, taskCR, taskCR.Spec.Config, resourceBaseName); err != nil {
-		r.Recorder.Eventf(taskCR, nil, corev1.EventTypeWarning, "ReconcileError", "Reconcile", "Failed to reconcile ConfigMap: %v", err)
-		return ctrl.Result{}, fmt.Errorf("reconciling ConfigMap: %w", err)
-	}
-
 	// Run the init pod lifecycle.
 	result, err := r.reconcileInitPod(ctx, taskCR)
 	if err != nil {

--- a/internal/controller/supersetlifecycletask_controller_test.go
+++ b/internal/controller/supersetlifecycletask_controller_test.go
@@ -281,13 +281,12 @@ func minimalInitCR() *supersetv1alpha1.SupersetLifecycleTask {
 					},
 				},
 			},
-			Config:         "# test config",
 			ConfigChecksum: "abc123",
 		},
 	}
 }
 
-func TestInitReconcile_CreatesConfigMapAndPod(t *testing.T) {
+func TestInitReconcile_CreatesPod(t *testing.T) {
 	scheme := testScheme(t)
 	initCR := minimalInitCR()
 
@@ -313,16 +312,6 @@ func TestInitReconcile_CreatesConfigMapAndPod(t *testing.T) {
 	// Should requeue to poll init pod status.
 	if result.RequeueAfter == 0 {
 		t.Error("expected RequeueAfter > 0")
-	}
-
-	// ConfigMap should exist.
-	cm := &corev1.ConfigMap{}
-	cmName := common.ConfigMapName("test-init")
-	if err := c.Get(context.Background(), types.NamespacedName{Name: cmName, Namespace: "default"}, cm); err != nil {
-		t.Fatalf("expected ConfigMap: %v", err)
-	}
-	if cm.Data["superset_config.py"] != "# test config" {
-		t.Errorf("expected config data, got %q", cm.Data["superset_config.py"])
 	}
 
 	// Pod should have been created.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -309,14 +308,14 @@ spec:
 				g.Expect(err).NotTo(HaveOccurred())
 			}, 30*time.Second, time.Second).Should(Succeed())
 
-			By("verifying the child CR config contains operator-generated content")
+			By("verifying the ConfigMap contains operator-generated content")
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "supersetwebserver",
-					crName, "-n", namespace,
-					"-o", "jsonpath={.spec.config}")
+				cmd := exec.Command("kubectl", "get", "configmap",
+					crName+"-web-server-config", "-n", namespace,
+					"-o", "jsonpath={.data.superset_config\\.py}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).NotTo(BeEmpty(), "spec.config should not be empty")
+				g.Expect(output).NotTo(BeEmpty(), "ConfigMap superset_config.py should not be empty")
 				g.Expect(output).To(ContainSubstring("import os"))
 				g.Expect(output).To(ContainSubstring("SUPERSET_WEBSERVER_PORT"))
 			}, 30*time.Second, time.Second).Should(Succeed())
@@ -431,22 +430,19 @@ spec:
 				g.Expect(output).To(Equal("2"))
 			}, 30*time.Second, time.Second).Should(Succeed())
 
-			By("verifying WebsocketServer child has empty config (no Python config for Node.js)")
+			By("verifying WebsocketServer has no ConfigMap (no Python config for Node.js)")
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "supersetwebsocketserver",
-					crName, "-n", namespace,
-					"-o", "jsonpath={.spec.config}")
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(strings.TrimSpace(output)).To(BeEmpty(),
-					"WebsocketServer should have no Python config")
+				cmd := exec.Command("kubectl", "get", "configmap",
+					crName+"-websocket-server-config", "-n", namespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).To(HaveOccurred(), "WebsocketServer should have no ConfigMap")
 			}, 30*time.Second, time.Second).Should(Succeed())
 
-			By("verifying CeleryWorker config contains both base and component config")
+			By("verifying CeleryWorker ConfigMap contains both base and component config")
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "supersetceleryworker",
-					crName, "-n", namespace,
-					"-o", "jsonpath={.spec.config}")
+				cmd := exec.Command("kubectl", "get", "configmap",
+					crName+"-celery-worker-config", "-n", namespace,
+					"-o", "jsonpath={.data.superset_config\\.py}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(output).To(ContainSubstring("FEATURE_FLAGS"),


### PR DESCRIPTION
## Summary

Remove the redundant `Config` field from all child CRD specs and move ConfigMap ownership to the parent Superset controller. Previously, rendered Python config was stored on the child CR spec AND in a ConfigMap created by the child
controller, making `kubectl describe` noisy and duplicating data.

Now:
- Parent renders config and creates ConfigMaps directly (owned by parent CR)
- Child CRDs no longer carry config content — only `ConfigChecksum` for rolling restarts
- Child controllers mount ConfigMaps by conventional name without managing them
- ConfigMaps survive child CR deletion (important during drain)

### Design rationale

The checksum is computed by whoever writes the data. Since the parent renders and writes the ConfigMap, it passes the checksum to child CRs via `spec.configChecksum`. Child controllers stamp it as a pod annotation to trigger rolling restarts. This avoids child controllers needing to watch ConfigMaps they don't own.