### PR TITLE
fix(lifecycle): prevent drain loop and fix clone pod execution

### DIFF
--- a/api/v1alpha1/superset_types.go
+++ b/api/v1alpha1/superset_types.go
@@ -398,10 +398,12 @@ type AdminUserSpec struct {
 // PodRetentionSpec defines retention behavior for init pods.
 type PodRetentionSpec struct {
 	// Retention policy: Delete removes pods after completion, Retain keeps all,
-	// RetainOnFailure keeps only failed pods for debugging.
+	// RetainOnFailure keeps only failed pods for debugging. Retained pods are
+	// automatically cleaned up by garbage collection when the task CR is
+	// deleted on the next lifecycle run.
 	// +optional
 	// +kubebuilder:validation:Enum=Delete;Retain;RetainOnFailure
-	// +kubebuilder:default=Delete
+	// +kubebuilder:default=Retain
 	Policy *string `json:"policy,omitempty"`
 }
 
@@ -473,6 +475,12 @@ type CloneTaskSpec struct {
 	// needed by migrations but not for testing (e.g., "logs", "query").
 	// +optional
 	ExcludeTableData []string `json:"excludeTableData,omitempty"`
+
+	// SQL statements to execute against the target database after cloning.
+	// Useful for sanitizing cloned data (e.g., disabling alerts, deleting
+	// OAuth tokens, masking PII).
+	// +optional
+	PostCloneSQL []string `json:"postCloneSQL,omitempty"`
 
 	// Image for the clone pod. Defaults to postgres:17-alpine (PostgreSQL)
 	// or mysql:8-alpine (MySQL) based on source.type.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -373,6 +373,11 @@ func (in *CloneTaskSpec) DeepCopyInto(out *CloneTaskSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.PostCloneSQL != nil {
+		in, out := &in.PostCloneSQL, &out.PostCloneSQL
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Image != nil {
 		in, out := &in.Image, &out.Image
 		*out = new(ImageSpec)

--- a/charts/superset-operator/crds/superset.apache.org_supersetlifecycletasks.yaml
+++ b/charts/superset-operator/crds/superset.apache.org_supersetlifecycletasks.yaml
@@ -408,7 +408,7 @@ spec:
               podRetention:
                 properties:
                   policy:
-                    default: Delete
+                    default: Retain
                     enum:
                     - Delete
                     - Retain

--- a/charts/superset-operator/crds/superset.apache.org_supersets.yaml
+++ b/charts/superset-operator/crds/superset.apache.org_supersets.yaml
@@ -12018,7 +12018,7 @@ spec:
                       podRetention:
                         properties:
                           policy:
-                            default: Delete
+                            default: Retain
                             enum:
                             - Delete
                             - Retain
@@ -15593,6 +15593,10 @@ spec:
                               type: object
                             type: array
                         type: object
+                      postCloneSQL:
+                        items:
+                          type: string
+                        type: array
                       requiresDrain:
                         type: boolean
                       source:
@@ -19354,7 +19358,7 @@ spec:
                   podRetention:
                     properties:
                       policy:
-                        default: Delete
+                        default: Retain
                         enum:
                         - Delete
                         - Retain

--- a/config/crd/bases/superset.apache.org_supersetlifecycletasks.yaml
+++ b/config/crd/bases/superset.apache.org_supersetlifecycletasks.yaml
@@ -408,7 +408,7 @@ spec:
               podRetention:
                 properties:
                   policy:
-                    default: Delete
+                    default: Retain
                     enum:
                     - Delete
                     - Retain

--- a/config/crd/bases/superset.apache.org_supersets.yaml
+++ b/config/crd/bases/superset.apache.org_supersets.yaml
@@ -12018,7 +12018,7 @@ spec:
                       podRetention:
                         properties:
                           policy:
-                            default: Delete
+                            default: Retain
                             enum:
                             - Delete
                             - Retain
@@ -15593,6 +15593,10 @@ spec:
                               type: object
                             type: array
                         type: object
+                      postCloneSQL:
+                        items:
+                          type: string
+                        type: array
                       requiresDrain:
                         type: boolean
                       source:
@@ -19354,7 +19358,7 @@ spec:
                   podRetention:
                     properties:
                       policy:
-                        default: Delete
+                        default: Retain
                         enum:
                         - Delete
                         - Retain

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -265,6 +265,7 @@ _Appears in:_
 | `source` _[CloneSourceSpec](#clonesourcespec)_ | Source database to clone from (typically production, read-only user). |  |  |
 | `excludeTables` _string array_ | Tables to exclude entirely from the dump (schema and data). |  | Optional: \{\} <br /> |
 | `excludeTableData` _string array_ | Tables where schema is dumped but data is not. Useful for large tables<br />needed by migrations but not for testing (e.g., "logs", "query"). |  | Optional: \{\} <br /> |
+| `postCloneSQL` _string array_ | SQL statements to execute against the target database after cloning.<br />Useful for sanitizing cloned data (e.g., disabling alerts, deleting<br />OAuth tokens, masking PII). |  | Optional: \{\} <br /> |
 | `image` _[ImageSpec](#imagespec)_ | Image for the clone pod. Defaults to postgres:17-alpine (PostgreSQL)<br />or mysql:8-alpine (MySQL) based on source.type. |  | Optional: \{\} <br /> |
 | `podTemplate` _[PodTemplate](#podtemplate)_ | Pod and container template for the clone task pod. |  | Optional: \{\} <br /> |
 | `podRetention` _[PodRetentionSpec](#podretentionspec)_ | Pod retention policy for completed clone pods. |  | Optional: \{\} <br /> |
@@ -879,7 +880,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `policy` _string_ | Retention policy: Delete removes pods after completion, Retain keeps all,<br />RetainOnFailure keeps only failed pods for debugging. | Delete | Enum: [Delete Retain RetainOnFailure] <br />Optional: \{\} <br /> |
+| `policy` _string_ | Retention policy: Delete removes pods after completion, Retain keeps all,<br />RetainOnFailure keeps only failed pods for debugging. Retained pods are<br />automatically cleaned up by garbage collection when the task CR is<br />deleted on the next lifecycle run. | Retain | Enum: [Delete Retain RetainOnFailure] <br />Optional: \{\} <br /> |
 
 
 #### PodTemplate

--- a/internal/controller/clone_test.go
+++ b/internal/controller/clone_test.go
@@ -27,6 +27,7 @@ import (
 
 	supersetv1alpha1 "github.com/apache/superset-kubernetes-operator/api/v1alpha1"
 	"github.com/apache/superset-kubernetes-operator/internal/common"
+	"github.com/apache/superset-kubernetes-operator/internal/resolution"
 )
 
 func TestBuildPostgresCloneScript(t *testing.T) {
@@ -145,6 +146,48 @@ func TestBuildMySQLCloneScript_ExcludeTables(t *testing.T) {
 	}
 }
 
+func TestBuildCloneScript_PostCloneSQL(t *testing.T) {
+	t.Run("postgres", func(t *testing.T) {
+		clone := &supersetv1alpha1.CloneTaskSpec{
+			Source: supersetv1alpha1.CloneSourceSpec{
+				Host: "pg-prod.svc", Database: "superset_prod", Username: "reader",
+			},
+			PostCloneSQL: []string{
+				"UPDATE report_schedule SET active = false",
+				"DELETE FROM oauth2_token",
+			},
+		}
+
+		script := buildPostgresCloneScript(clone)
+
+		if !strings.Contains(script, `psql`) {
+			t.Fatal("expected psql in script")
+		}
+		if !strings.Contains(script, `-c "UPDATE report_schedule SET active = false"`) {
+			t.Errorf("expected first postCloneSQL statement, got: %s", script)
+		}
+		if !strings.Contains(script, `-c "DELETE FROM oauth2_token"`) {
+			t.Errorf("expected second postCloneSQL statement, got: %s", script)
+		}
+	})
+
+	t.Run("mysql", func(t *testing.T) {
+		mysqlType := "MySQL"
+		clone := &supersetv1alpha1.CloneTaskSpec{
+			Source: supersetv1alpha1.CloneSourceSpec{
+				Type: &mysqlType, Host: "mysql-prod.svc", Database: "superset_prod", Username: "reader",
+			},
+			PostCloneSQL: []string{"UPDATE report_schedule SET active = 0"},
+		}
+
+		script := buildMySQLCloneScript(clone)
+
+		if !strings.Contains(script, `-e "UPDATE report_schedule SET active = 0"`) {
+			t.Errorf("expected postCloneSQL statement in mysql script, got: %s", script)
+		}
+	})
+}
+
 func TestBuildCloneCommand_CustomCommand(t *testing.T) {
 	r := &SupersetReconciler{}
 	superset := &supersetv1alpha1.Superset{}
@@ -215,6 +258,41 @@ func TestBuildCloneCommand_MySQL(t *testing.T) {
 	}
 	if !strings.Contains(cmd[2], "mysqldump") {
 		t.Errorf("expected mysqldump in command, got: %s", cmd[2])
+	}
+}
+
+func TestBuildCloneTaskFlatSpec_CommandOnContainer(t *testing.T) {
+	r := &SupersetReconciler{}
+	superset := &supersetv1alpha1.Superset{}
+	superset.Spec.Lifecycle = &supersetv1alpha1.LifecycleSpec{
+		Clone: &supersetv1alpha1.CloneTaskSpec{
+			Source: supersetv1alpha1.CloneSourceSpec{
+				Host:     "pg-prod.svc",
+				Database: "superset_prod",
+				Username: "reader",
+				Password: common.Ptr("secret"),
+			},
+		},
+	}
+	superset.Spec.Metastore = &supersetv1alpha1.MetastoreSpec{
+		Host:     common.Ptr("postgres"),
+		Database: common.Ptr("superset_staging"),
+		Username: common.Ptr("superset"),
+		Password: common.Ptr("pass"),
+	}
+
+	flatSpec := r.buildCloneTaskFlatSpec(superset, "default", &resolution.SharedInput{})
+	podSpec := buildInitPod(&flatSpec)
+
+	if len(podSpec.Containers) == 0 {
+		t.Fatal("expected at least one container")
+	}
+	cmd := podSpec.Containers[0].Command
+	if len(cmd) == 0 {
+		t.Fatal("expected command on clone pod container, got nil")
+	}
+	if cmd[0] != "/bin/sh" || !strings.Contains(cmd[2], "pg_dump") {
+		t.Errorf("expected pg_dump shell command, got: %v", cmd)
 	}
 }
 
@@ -1006,4 +1084,124 @@ func TestScheduleRequeue_DisabledClone(t *testing.T) {
 	if requeue != 0 {
 		t.Errorf("expected 0 requeue with disabled clone, got %v", requeue)
 	}
+}
+
+func TestAllTasksStillComplete_SkipsDrainWhenNothingChanged(t *testing.T) {
+	now := time.Date(2026, 5, 11, 14, 30, 0, 0, time.UTC)
+	r := &SupersetReconciler{Now: func() time.Time { return now }}
+
+	superset := &supersetv1alpha1.Superset{}
+	superset.UID = "test-uid"
+	superset.Spec.Image = supersetv1alpha1.ImageSpec{Tag: "4.1.4"}
+	superset.Spec.Lifecycle = &supersetv1alpha1.LifecycleSpec{
+		Migrate: &supersetv1alpha1.MigrateTaskSpec{},
+		Init:    &supersetv1alpha1.InitTaskSpec{},
+	}
+
+	configChecksum := "config-abc"
+
+	// Simulate a completed lifecycle: compute checksums and store them.
+	incomingChecksum := string(superset.UID)
+	migrateCmd := defaultMigrateCommand(superset)
+	migrateChecksum := r.computeStepChecksum(incomingChecksum, taskTypeMigrate, migrateCmd, r.migrateInputs(superset))
+	initCmd := defaultInitCommand(superset)
+	initChecksum := r.computeStepChecksum(migrateChecksum, taskTypeInit, initCmd, r.initInputs(superset, configChecksum))
+
+	superset.Status.Lifecycle = &supersetv1alpha1.LifecycleStatus{
+		LastCompletedChecksums: map[string]string{
+			taskTypeMigrate: migrateChecksum,
+			taskTypeInit:    initChecksum,
+		},
+	}
+
+	t.Run("returns true when nothing changed", func(t *testing.T) {
+		if !r.allTasksStillComplete(superset, false, true, true, configChecksum) {
+			t.Error("expected allTasksStillComplete=true when checksums match")
+		}
+	})
+
+	t.Run("returns false when config changes", func(t *testing.T) {
+		if r.allTasksStillComplete(superset, false, true, true, "config-changed") {
+			t.Error("expected allTasksStillComplete=false when config checksum changed")
+		}
+	})
+
+	t.Run("returns false when image changes", func(t *testing.T) {
+		modified := superset.DeepCopy()
+		modified.Spec.Image.Tag = "5.0.0"
+		if r.allTasksStillComplete(modified, false, true, true, configChecksum) {
+			t.Error("expected allTasksStillComplete=false when image changed")
+		}
+	})
+
+	t.Run("returns false with no stored checksums", func(t *testing.T) {
+		modified := superset.DeepCopy()
+		modified.Status.Lifecycle.LastCompletedChecksums = nil
+		if r.allTasksStillComplete(modified, false, true, true, configChecksum) {
+			t.Error("expected allTasksStillComplete=false with nil checksums")
+		}
+	})
+
+	t.Run("returns false when trigger changes", func(t *testing.T) {
+		modified := superset.DeepCopy()
+		modified.Spec.Lifecycle.Migrate = &supersetv1alpha1.MigrateTaskSpec{
+			BaseTaskSpec: supersetv1alpha1.BaseTaskSpec{Trigger: common.Ptr("force-v1")},
+		}
+		if r.allTasksStillComplete(modified, false, true, true, configChecksum) {
+			t.Error("expected allTasksStillComplete=false when trigger changed")
+		}
+	})
+}
+
+func TestAllTasksStillComplete_WithCloneSchedule(t *testing.T) {
+	now := time.Date(2026, 5, 11, 14, 30, 0, 0, time.UTC)
+	r := &SupersetReconciler{Now: func() time.Time { return now }}
+
+	cronExpr := "0 * * * *"
+	superset := &supersetv1alpha1.Superset{}
+	superset.UID = "test-uid"
+	superset.Spec.Image = supersetv1alpha1.ImageSpec{Tag: "4.1.4"}
+	superset.Spec.Lifecycle = &supersetv1alpha1.LifecycleSpec{
+		Clone: &supersetv1alpha1.CloneTaskSpec{
+			SchedulableBaseTaskSpec: supersetv1alpha1.SchedulableBaseTaskSpec{
+				CronSchedule: &cronExpr,
+			},
+			Source: supersetv1alpha1.CloneSourceSpec{Host: "prod-db", Database: "superset", Username: "reader"},
+		},
+		Migrate: &supersetv1alpha1.MigrateTaskSpec{},
+		Init:    &supersetv1alpha1.InitTaskSpec{},
+	}
+
+	configChecksum := "config-abc"
+
+	// Compute and store checksums as if lifecycle already completed at :30.
+	incomingChecksum := string(superset.UID)
+	cloneCmd := r.buildCloneCommand(superset)
+	cloneChecksum := r.computeStepChecksum(incomingChecksum, taskTypeClone, cloneCmd, r.cloneInputs(superset))
+	migrateCmd := defaultMigrateCommand(superset)
+	migrateChecksum := r.computeStepChecksum(cloneChecksum, taskTypeMigrate, migrateCmd, r.migrateInputs(superset))
+	initCmd := defaultInitCommand(superset)
+	initChecksum := r.computeStepChecksum(migrateChecksum, taskTypeInit, initCmd, r.initInputs(superset, configChecksum))
+
+	superset.Status.Lifecycle = &supersetv1alpha1.LifecycleStatus{
+		LastCompletedChecksums: map[string]string{
+			taskTypeClone:   cloneChecksum,
+			taskTypeMigrate: migrateChecksum,
+			taskTypeInit:    initChecksum,
+		},
+	}
+
+	t.Run("stable within cron window", func(t *testing.T) {
+		if !r.allTasksStillComplete(superset, true, true, true, configChecksum) {
+			t.Error("expected allTasksStillComplete=true within same cron window")
+		}
+	})
+
+	t.Run("returns false when cron tick crosses boundary", func(t *testing.T) {
+		nextHour := time.Date(2026, 5, 11, 15, 1, 0, 0, time.UTC)
+		r2 := &SupersetReconciler{Now: func() time.Time { return nextHour }}
+		if r2.allTasksStillComplete(superset, true, true, true, configChecksum) {
+			t.Error("expected allTasksStillComplete=false after cron boundary crossing")
+		}
+	})
 }

--- a/internal/controller/initpod.go
+++ b/internal/controller/initpod.go
@@ -32,7 +32,7 @@ import (
 const (
 	defaultInitTimeout           = 300 * time.Second
 	defaultMaxRetries      int32 = 3
-	defaultRetentionPolicy       = retentionDelete
+	defaultRetentionPolicy       = retentionRetain
 
 	retentionDelete       = "Delete"
 	retentionRetain       = "Retain"

--- a/internal/controller/maintenance.go
+++ b/internal/controller/maintenance.go
@@ -463,7 +463,7 @@ func renderNginxConf() string {
 
     location = / {
         root /usr/share/nginx/html;
-        index index.html;
+        try_files /index.html =404;
     }
 
     location / {

--- a/internal/controller/superset_controller.go
+++ b/internal/controller/superset_controller.go
@@ -154,6 +154,14 @@ func (r *SupersetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
+	// Persist lifecycle completion status (lastCompletedChecksums) before
+	// creating components. Component creation triggers watch events that cause
+	// concurrent reconciles — if we defer this to Phase 5, a conflict there
+	// loses the checksums and the next reconcile re-enters lifecycle.
+	if statusErr := r.Status().Update(ctx, superset); statusErr != nil {
+		return ctrl.Result{}, fmt.Errorf("updating status after lifecycle: %w", statusErr)
+	}
+
 	// Phase 3: Resolve and reconcile each component (table-driven).
 	for _, desc := range componentDescriptors {
 		if err := r.reconcileComponent(ctx, superset, desc, topLevel, configChecksum, saName); err != nil {
@@ -384,6 +392,16 @@ func (r *SupersetReconciler) reconcileLifecycle(
 		return 0, true, nil
 	}
 
+	// Fast path: if all enabled tasks already completed with matching checksums,
+	// skip drain and pipeline entirely. This prevents unnecessary component
+	// deletion on reconciles triggered by child CR creation.
+	if r.allTasksStillComplete(superset, cloneEnabled, migrateEnabled, initEnabled, configChecksum) {
+		superset.Status.Lifecycle.Phase = lifecyclePhaseComplete
+		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
+			metav1.ConditionTrue, "LifecycleComplete", "Lifecycle tasks completed successfully", superset.Generation)
+		return 0, true, nil
+	}
+
 	// Spin up the maintenance page before drain (if configured).
 	needsDrain := (cloneEnabled && r.taskRequiresDrain(superset, taskTypeClone)) ||
 		(migrateEnabled && r.taskRequiresDrain(superset, taskTypeMigrate)) ||
@@ -413,33 +431,41 @@ func (r *SupersetReconciler) reconcileLifecycle(
 		return requeueAfter, false, nil
 	}
 
-	// All tasks complete. Tear down maintenance page before re-creating components.
+	// All tasks complete.
+	return 0, true, r.finalizeLifecycle(ctx, superset, currentImage)
+}
+
+// finalizeLifecycle tears down maintenance page, updates status, and clears
+// approval annotations after all lifecycle tasks complete.
+func (r *SupersetReconciler) finalizeLifecycle(
+	ctx context.Context,
+	superset *supersetv1alpha1.Superset,
+	currentImage string,
+) error {
 	if isMaintenancePageEnabled(superset) {
 		if err := r.reconcileMaintenancePageDown(ctx, superset); err != nil {
-			return 0, false, fmt.Errorf("tearing down maintenance page: %w", err)
+			return fmt.Errorf("tearing down maintenance page: %w", err)
 		}
 	}
 
-	// Update lastLifecycleImage and clear upgrade context.
 	superset.Status.LastLifecycleImage = currentImage
 	superset.Status.Lifecycle.Phase = lifecyclePhaseComplete
 	superset.Status.Lifecycle.Upgrade = nil
 
-	// Clear approval annotation if it was set.
 	if annotations := superset.GetAnnotations(); annotations != nil {
 		if _, ok := annotations[annotationApproveUpgrade]; ok {
 			patch := client.MergeFrom(superset.DeepCopy())
 			delete(annotations, annotationApproveUpgrade)
 			superset.SetAnnotations(annotations)
 			if err := r.Patch(ctx, superset, patch); err != nil {
-				return 0, false, fmt.Errorf("clearing approval annotation: %w", err)
+				return fmt.Errorf("clearing approval annotation: %w", err)
 			}
 		}
 	}
 
 	setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
 		metav1.ConditionTrue, "LifecycleComplete", "Lifecycle tasks completed successfully", superset.Generation)
-	return 0, true, nil
+	return nil
 }
 
 // runLifecyclePipeline executes the sequential task pipeline (clone → migrate → init).
@@ -766,7 +792,8 @@ func (r *SupersetReconciler) buildCloneTaskFlatSpec(
 	childName := superset.Name + suffixClone
 
 	cloneEnvVars := collectCloneEnvVars(superset)
-	comp := convertCloneComponent(clone)
+	cloneCmd := r.buildCloneCommand(superset)
+	comp := convertCloneComponent(clone, cloneCmd)
 	operatorInjected := &resolution.OperatorInjected{Env: cloneEnvVars}
 
 	flat := resolution.ResolveChildSpec(
@@ -973,12 +1000,14 @@ func (r *SupersetReconciler) cloneInputs(superset *supersetv1alpha1.Superset) an
 		Source           supersetv1alpha1.CloneSourceSpec
 		ExcludeTables    []string
 		ExcludeTableData []string
+		PostCloneSQL     []string
 	}{
 		Trigger:          derefOrDefault(clone.Trigger, ""),
 		ScheduleTick:     r.scheduleTick(clone.CronSchedule),
 		Source:           clone.Source,
 		ExcludeTables:    clone.ExcludeTables,
 		ExcludeTableData: clone.ExcludeTableData,
+		PostCloneSQL:     clone.PostCloneSQL,
 	}
 }
 
@@ -1011,6 +1040,49 @@ func (r *SupersetReconciler) initInputs(superset *supersetv1alpha1.Superset, con
 		ConfigChecksum: configChecksum,
 		Trigger:        trigger,
 	}
+}
+
+// allTasksStillComplete checks whether all enabled tasks have already completed
+// with checksums matching the current inputs. Used as a fast path to avoid
+// unnecessary draining on reconciles where nothing has changed.
+func (r *SupersetReconciler) allTasksStillComplete(
+	superset *supersetv1alpha1.Superset,
+	cloneEnabled, migrateEnabled, initEnabled bool,
+	configChecksum string,
+) bool {
+	if superset.Status.Lifecycle == nil || superset.Status.Lifecycle.LastCompletedChecksums == nil {
+		return false
+	}
+	checksums := superset.Status.Lifecycle.LastCompletedChecksums
+	incomingChecksum := string(superset.UID)
+
+	if cloneEnabled {
+		cloneCmd := r.buildCloneCommand(superset)
+		taskChecksum := r.computeStepChecksum(incomingChecksum, taskTypeClone, cloneCmd, r.cloneInputs(superset))
+		if checksums[taskTypeClone] != taskChecksum {
+			return false
+		}
+		incomingChecksum = checksums[taskTypeClone]
+	}
+
+	if migrateEnabled {
+		migrateCmd := defaultMigrateCommand(superset)
+		taskChecksum := r.computeStepChecksum(incomingChecksum, taskTypeMigrate, migrateCmd, r.migrateInputs(superset))
+		if checksums[taskTypeMigrate] != taskChecksum {
+			return false
+		}
+		incomingChecksum = checksums[taskTypeMigrate]
+	}
+
+	if initEnabled {
+		initCmd := defaultInitCommand(superset)
+		taskChecksum := r.computeStepChecksum(incomingChecksum, taskTypeInit, initCmd, r.initInputs(superset, configChecksum))
+		if checksums[taskTypeInit] != taskChecksum {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (r *SupersetReconciler) now() time.Time {
@@ -1193,6 +1265,11 @@ PGPASSWORD="$SUPERSET_OPERATOR__CLONE_SRC_PASS" pg_dump -h "$SUPERSET_OPERATOR__
 	}
 
 	b.WriteString(` "$SUPERSET_OPERATOR__CLONE_SRC_DB" | PGPASSWORD="$SUPERSET_OPERATOR__DB_PASS" psql -h "$SUPERSET_OPERATOR__DB_HOST" -p "$SUPERSET_OPERATOR__DB_PORT" -U "$SUPERSET_OPERATOR__DB_USER" "$SUPERSET_OPERATOR__DB_NAME"`)
+
+	for _, sql := range clone.PostCloneSQL {
+		fmt.Fprintf(&b, "\nPGPASSWORD=\"$SUPERSET_OPERATOR__DB_PASS\" psql -h \"$SUPERSET_OPERATOR__DB_HOST\" -p \"$SUPERSET_OPERATOR__DB_PORT\" -U \"$SUPERSET_OPERATOR__DB_USER\" \"$SUPERSET_OPERATOR__DB_NAME\" -c %q", sql)
+	}
+
 	return b.String()
 }
 
@@ -1207,6 +1284,11 @@ mysqldump -h "$SUPERSET_OPERATOR__CLONE_SRC_HOST" -P "$SUPERSET_OPERATOR__CLONE_
 	}
 
 	b.WriteString(` "$SUPERSET_OPERATOR__CLONE_SRC_DB" | mysql -h "$SUPERSET_OPERATOR__DB_HOST" -P "$SUPERSET_OPERATOR__DB_PORT" -u "$SUPERSET_OPERATOR__DB_USER" -p"$SUPERSET_OPERATOR__DB_PASS" "$SUPERSET_OPERATOR__DB_NAME"`)
+
+	for _, sql := range clone.PostCloneSQL {
+		fmt.Fprintf(&b, "\nmysql -h \"$SUPERSET_OPERATOR__DB_HOST\" -P \"$SUPERSET_OPERATOR__DB_PORT\" -u \"$SUPERSET_OPERATOR__DB_USER\" -p\"$SUPERSET_OPERATOR__DB_PASS\" \"$SUPERSET_OPERATOR__DB_NAME\" -e %q", sql)
+	}
+
 	return b.String()
 }
 
@@ -1289,13 +1371,32 @@ func splitImageRef(ref string) (string, string) {
 }
 
 // convertCloneComponent builds a minimal ComponentInput for the clone task pod.
-func convertCloneComponent(clone *supersetv1alpha1.CloneTaskSpec) *resolution.ComponentInput {
-	if clone.PodTemplate == nil {
-		return &resolution.ComponentInput{}
+func convertCloneComponent(clone *supersetv1alpha1.CloneTaskSpec, command []string) *resolution.ComponentInput {
+	var pt *supersetv1alpha1.PodTemplate
+	if clone.PodTemplate != nil {
+		pt = clone.PodTemplate
 	}
+
+	var ct *supersetv1alpha1.ContainerTemplate
+	if pt != nil && pt.Container != nil {
+		copied := *pt.Container
+		ct = &copied
+	} else {
+		ct = &supersetv1alpha1.ContainerTemplate{}
+	}
+	ct.Command = command
+
+	if pt != nil {
+		copied := *pt
+		copied.Container = ct
+		pt = &copied
+	} else {
+		pt = &supersetv1alpha1.PodTemplate{Container: ct}
+	}
+
 	return &resolution.ComponentInput{
 		SharedInput: resolution.SharedInput{
-			PodTemplate: clone.PodTemplate,
+			PodTemplate: pt,
 		},
 	}
 }

--- a/internal/controller/supersetlifecycletask_controller_test.go
+++ b/internal/controller/supersetlifecycletask_controller_test.go
@@ -228,7 +228,7 @@ func TestGetInitRetentionPolicy(t *testing.T) {
 		{
 			"default",
 			&supersetv1alpha1.SupersetLifecycleTask{},
-			"Delete",
+			"Retain",
 		},
 		{
 			"retain",
@@ -503,12 +503,12 @@ func TestInitReconcile_PodSucceeded_RetentionDeferredUntilNextReconcile(t *testi
 		t.Fatalf("reconcile 2: %v", err)
 	}
 
-	// Pod should now be deleted (default retention = Delete).
+	// Pod should still exist (default retention = Retain).
 	if err := c.List(context.Background(), podList); err != nil {
 		t.Fatalf("list pods: %v", err)
 	}
-	if len(podList.Items) != 0 {
-		t.Errorf("expected pod to be deleted after retention reconcile, got %d pods", len(podList.Items))
+	if len(podList.Items) != 1 {
+		t.Errorf("expected pod to be retained after retention reconcile, got %d pods", len(podList.Items))
 	}
 }
 
@@ -1034,8 +1034,10 @@ func TestApplyRetentionPolicy(t *testing.T) {
 		phase      corev1.PodPhase
 		wantDelete bool
 	}{
-		{"Delete/Succeeded", nil, corev1.PodSucceeded, true},
-		{"Delete/Failed", nil, corev1.PodFailed, true},
+		{"Default/Succeeded", nil, corev1.PodSucceeded, false},
+		{"Default/Failed", nil, corev1.PodFailed, false},
+		{"Delete/Succeeded", strPtr("Delete"), corev1.PodSucceeded, true},
+		{"Delete/Failed", strPtr("Delete"), corev1.PodFailed, true},
 		{"Retain/Succeeded", strPtr("Retain"), corev1.PodSucceeded, false},
 		{"Retain/Failed", strPtr("Retain"), corev1.PodFailed, false},
 		{"RetainOnFailure/Succeeded", strPtr("RetainOnFailure"), corev1.PodSucceeded, true},


### PR DESCRIPTION
## Summary

Fixes several issues discovered while testing the clone feature with cron scheduling:

- **Drain loop after lifecycle completion**: The reconciler would drain components on every reconcile even after tasks completed, because `drainIfNeeded` ran before checking task completion. Added a fast-path checksum comparison (`allTasksStillComplete`) that skips drain when all enabled tasks already completed with matching checksums. Also persist lifecycle status immediately after completion (before creating components) to prevent conflicts from losing `lastCompletedChecksums`.
- **Clone pod not executing command**: `convertCloneComponent` did not inject the clone shell script into the container's `Command` field, causing the `postgres:17-alpine` image to run its default entrypoint (PostgreSQL server startup) instead of `pg_dump | psql`.
- **Maintenance page redirect loop**: The nginx config used `index index.html` which caused an internal redirect to `/index.html`, matching the catch-all `location /` that 302'd back to `/`. Replaced with `try_files`.

- **`postCloneSQL` field**: New field on `CloneTaskSpec` for executing SQL statements against the target database after cloning (e.g., disabling alerts, deleting OAuth tokens). Included in checksum inputs so changes trigger re-execution.

- **Pod retention default changed to `Retain`**: Lifecycle task pods are now kept after completion by default for log inspection. They are automatically cleaned up by GC when the task CR is deleted on the next lifecycle run.