### PR TITLE
fix(lifecycle): tighten retry/schedule semantics and add metrics TLS

### DIFF
--- a/api/v1alpha1/superset_types.go
+++ b/api/v1alpha1/superset_types.go
@@ -425,12 +425,13 @@ type AdminUserSpec struct {
 // PodRetentionSpec defines retention behavior for init pods.
 type PodRetentionSpec struct {
 	// Retention policy: Delete removes pods after completion, Retain keeps all,
-	// RetainOnFailure keeps only failed pods for debugging. Retained pods are
-	// automatically cleaned up by garbage collection when the task CR is
-	// deleted on the next lifecycle run.
+	// RetainOnFailure (the default) keeps only failed pods for debugging and
+	// deletes successful ones to reduce noise. Retained pods are automatically
+	// cleaned up by garbage collection when the task CR is deleted on the
+	// next lifecycle run.
 	// +optional
 	// +kubebuilder:validation:Enum=Delete;Retain;RetainOnFailure
-	// +kubebuilder:default=Retain
+	// +kubebuilder:default=RetainOnFailure
 	Policy *string `json:"policy,omitempty"`
 }
 

--- a/api/v1alpha1/supersetlifecycletask_types.go
+++ b/api/v1alpha1/supersetlifecycletask_types.go
@@ -68,6 +68,12 @@ type SupersetLifecycleTaskStatus struct {
 	Duration string `json:"duration,omitempty"`
 	// +optional
 	Attempts int32 `json:"attempts,omitempty"`
+	// NextAttemptAt is the earliest time at which the controller may create
+	// the next Pod after a failure or timeout. Persisting this prevents the
+	// Pod-delete owner watch from enqueuing a reconcile that bypasses the
+	// exponential backoff.
+	// +optional
+	NextAttemptAt *metav1.Time `json:"nextAttemptAt,omitempty"`
 	// +optional
 	Image string `json:"image,omitempty"`
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -2076,6 +2076,10 @@ func (in *SupersetLifecycleTaskStatus) DeepCopyInto(out *SupersetLifecycleTaskSt
 		in, out := &in.CompletedAt, &out.CompletedAt
 		*out = (*in).DeepCopy()
 	}
+	if in.NextAttemptAt != nil {
+		in, out := &in.NextAttemptAt, &out.NextAttemptAt
+		*out = (*in).DeepCopy()
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]metav1.Condition, len(*in))

--- a/charts/superset-operator/crds/superset.apache.org_supersetlifecycletasks.yaml
+++ b/charts/superset-operator/crds/superset.apache.org_supersetlifecycletasks.yaml
@@ -408,7 +408,7 @@ spec:
               podRetention:
                 properties:
                   policy:
-                    default: Retain
+                    default: RetainOnFailure
                     enum:
                     - Delete
                     - Retain

--- a/charts/superset-operator/crds/superset.apache.org_supersetlifecycletasks.yaml
+++ b/charts/superset-operator/crds/superset.apache.org_supersetlifecycletasks.yaml
@@ -4055,6 +4055,9 @@ spec:
                 type: string
               message:
                 type: string
+              nextAttemptAt:
+                format: date-time
+                type: string
               observedGeneration:
                 format: int64
                 type: integer

--- a/charts/superset-operator/crds/superset.apache.org_supersets.yaml
+++ b/charts/superset-operator/crds/superset.apache.org_supersets.yaml
@@ -12018,7 +12018,7 @@ spec:
                       podRetention:
                         properties:
                           policy:
-                            default: Retain
+                            default: RetainOnFailure
                             enum:
                             - Delete
                             - Retain
@@ -19358,7 +19358,7 @@ spec:
                   podRetention:
                     properties:
                       policy:
-                        default: Retain
+                        default: RetainOnFailure
                         enum:
                         - Delete
                         - Retain

--- a/charts/superset-operator/templates/deployment.yaml
+++ b/charts/superset-operator/templates/deployment.yaml
@@ -55,6 +55,11 @@ spec:
             - --health-probe-bind-address=:8081
             {{- if .Values.metrics.enabled }}
             - --metrics-bind-address=:{{ .Values.metrics.service.port }}
+            {{- if .Values.metrics.certSecretName }}
+            - --metrics-cert-path=/tmp/k8s-metrics-server/metrics-certs
+            - --metrics-cert-name=tls.crt
+            - --metrics-cert-key=tls.key
+            {{- end }}
             {{- else }}
             - --metrics-bind-address=0
             {{- end }}
@@ -74,6 +79,26 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if and .Values.metrics.enabled .Values.metrics.certSecretName }}
+          volumeMounts:
+            - name: metrics-certs
+              mountPath: /tmp/k8s-metrics-server/metrics-certs
+              readOnly: true
+          {{- end }}
+      {{- if and .Values.metrics.enabled .Values.metrics.certSecretName }}
+      volumes:
+        - name: metrics-certs
+          secret:
+            secretName: {{ .Values.metrics.certSecretName }}
+            optional: false
+            items:
+              - key: ca.crt
+                path: ca.crt
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/superset-operator/templates/metrics-servicemonitor.yaml
+++ b/charts/superset-operator/templates/metrics-servicemonitor.yaml
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "superset-operator.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "superset-operator.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "superset-operator.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: https
+      path: /metrics
+      scheme: https
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      bearerTokenFile: {{ .Values.metrics.serviceMonitor.bearerTokenFile }}
+      {{- with .Values.metrics.serviceMonitor.tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/superset-operator/values.yaml
+++ b/charts/superset-operator/values.yaml
@@ -25,6 +25,44 @@ metrics:
   enabled: true
   service:
     port: 8443
+  # When non-empty, mount this Secret into the manager pod at
+  # /tmp/k8s-metrics-server/metrics-certs and start the manager with
+  # --metrics-cert-path so the metrics server presents a real certificate
+  # instead of the built-in self-signed one. The Secret must contain
+  # tls.crt, tls.key, and (for the scraper's CA bundle) ca.crt.
+  # Typically this is the Secret written by a cert-manager Certificate.
+  certSecretName: ""
+  # serviceMonitor creates a Prometheus Operator ServiceMonitor scraping the
+  # operator's controller-runtime metrics. Requires the prometheus-operator
+  # CRDs to be installed; otherwise Helm will fail to apply this resource.
+  serviceMonitor:
+    enabled: false
+    # How often Prometheus scrapes the operator metrics endpoint.
+    interval: 30s
+    # Empty string means "inherit Prometheus' default scrape timeout".
+    scrapeTimeout: ""
+    # Extra labels applied to the ServiceMonitor so Prometheus Operator
+    # selects it (e.g., {release: prometheus} for kube-prometheus-stack).
+    labels: {}
+    # Free-form ServiceMonitor tlsConfig. The default trusts any cert
+    # (matches the operator's built-in self-signed flow). To scrape over
+    # real TLS, provision a cert-manager-managed Secret, set metrics.certSecretName
+    # above, and override tlsConfig with something like:
+    #   tlsConfig:
+    #     insecureSkipVerify: false
+    #     serverName: <release-name>-superset-operator-metrics.<namespace>.svc
+    #     ca:
+    #       secret:
+    #         name: metrics-server-cert
+    #         key: ca.crt
+    # The metrics endpoint authenticates scrapers via bearer token, not
+    # client cert, so cert/keySecret are unnecessary unless you've
+    # configured client-cert auth yourself.
+    tlsConfig:
+      insecureSkipVerify: true
+    # Path to the token Prometheus uses to authenticate to the metrics
+    # endpoint. Default matches Prometheus Operator's in-cluster setup.
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
 
 healthProbes:
   livenessProbe:

--- a/config/certmanager/certificate-metrics.yaml
+++ b/config/certmanager/certificate-metrics.yaml
@@ -1,0 +1,56 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Self-signed Issuer for the metrics server certificate. Users who already
+# have an Issuer or ClusterIssuer they want to reuse can replace this with
+# their own by editing this manifest.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/name: superset-kubernetes-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: selfsigned-issuer
+  namespace: system
+spec:
+  selfSigned: {}
+---
+# Certificate issued by the Issuer above, stored in the metrics-server-cert
+# Secret and mounted into the manager pod by the [METRICS-WITH-CERTS] patch
+# in config/default/kustomization.yaml.
+#
+# The dnsNames entries contain the placeholders SERVICE_NAME and
+# SERVICE_NAMESPACE; Kustomize replacements (in the default overlay) swap
+# them for the actual metrics Service identity.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/name: superset-kubernetes-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: metrics-certs
+  namespace: system
+spec:
+  dnsNames:
+    - SERVICE_NAME.SERVICE_NAMESPACE.svc
+    - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: metrics-server-cert

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,0 +1,9 @@
+# cert-manager resources for the operator's metrics endpoint TLS. Included
+# from config/default/kustomization.yaml via the [CERTMANAGER] section.
+resources:
+  - certificate-metrics.yaml
+
+# Teach Kustomize about cert-manager name references so issuerRef.name is
+# rewritten when the Issuer is renamed by the parent overlay's namePrefix.
+configurations:
+  - kustomizeconfig.yaml

--- a/config/certmanager/kustomizeconfig.yaml
+++ b/config/certmanager/kustomizeconfig.yaml
@@ -1,0 +1,12 @@
+# Kustomize configuration hooks for cert-manager types. Kustomize doesn't
+# know about cert-manager out of the box, so we teach it that Certificate's
+# spec.issuerRef.name is a reference to an Issuer/ClusterIssuer — otherwise
+# the namePrefix transformer renames the Issuer but leaves issuerRef.name
+# pointing at the old name.
+nameReference:
+  - kind: Issuer
+    group: cert-manager.io
+    fieldSpecs:
+      - kind: Certificate
+        group: cert-manager.io
+        path: spec/issuerRef/name

--- a/config/crd/bases/superset.apache.org_supersetlifecycletasks.yaml
+++ b/config/crd/bases/superset.apache.org_supersetlifecycletasks.yaml
@@ -408,7 +408,7 @@ spec:
               podRetention:
                 properties:
                   policy:
-                    default: Retain
+                    default: RetainOnFailure
                     enum:
                     - Delete
                     - Retain

--- a/config/crd/bases/superset.apache.org_supersetlifecycletasks.yaml
+++ b/config/crd/bases/superset.apache.org_supersetlifecycletasks.yaml
@@ -4055,6 +4055,9 @@ spec:
                 type: string
               message:
                 type: string
+              nextAttemptAt:
+                format: date-time
+                type: string
               observedGeneration:
                 format: int64
                 type: integer

--- a/config/crd/bases/superset.apache.org_supersets.yaml
+++ b/config/crd/bases/superset.apache.org_supersets.yaml
@@ -12018,7 +12018,7 @@ spec:
                       podRetention:
                         properties:
                           policy:
-                            default: Retain
+                            default: RetainOnFailure
                             enum:
                             - Delete
                             - Retain
@@ -19358,7 +19358,7 @@ spec:
                   podRetention:
                     properties:
                       policy:
-                        default: Retain
+                        default: RetainOnFailure
                         enum:
                         - Delete
                         - Retain

--- a/config/default/cert_metrics_manager_patch.yaml
+++ b/config/default/cert_metrics_manager_patch.yaml
@@ -1,30 +1,43 @@
-# This patch adds the args, volumes, and ports to allow the manager to use the metrics-server certs.
+# This patch mounts the cert-manager-managed metrics-server-cert secret
+# into the manager Deployment and adds the --metrics-cert-path args so the
+# metrics server presents that certificate instead of the built-in
+# self-signed one.
+#
+# The base Deployment (config/manager/manager.yaml) has no volumeMounts or
+# volumes fields, so these patches add them directly rather than appending
+# to a non-existent array — that's why each patch uses the full field path
+# instead of the `/-` append token.
 
-# Add the volumeMount for the metrics-server certs
 - op: add
-  path: /spec/template/spec/containers/0/volumeMounts/-
+  path: /spec/template/spec/containers/0/volumeMounts
   value:
-    mountPath: /tmp/k8s-metrics-server/metrics-certs
-    name: metrics-certs
-    readOnly: true
+    - mountPath: /tmp/k8s-metrics-server/metrics-certs
+      name: metrics-certs
+      readOnly: true
 
-# Add the --metrics-cert-path argument for the metrics server
 - op: add
   path: /spec/template/spec/containers/0/args/-
   value: --metrics-cert-path=/tmp/k8s-metrics-server/metrics-certs
 
-# Add the metrics-server certs volume configuration
 - op: add
-  path: /spec/template/spec/volumes/-
+  path: /spec/template/spec/containers/0/args/-
+  value: --metrics-cert-name=tls.crt
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --metrics-cert-key=tls.key
+
+- op: add
+  path: /spec/template/spec/volumes
   value:
-    name: metrics-certs
-    secret:
-      secretName: metrics-server-cert
-      optional: false
-      items:
-        - key: ca.crt
-          path: ca.crt
-        - key: tls.crt
-          path: tls.crt
-        - key: tls.key
-          path: tls.key
+    - name: metrics-certs
+      secret:
+        secretName: metrics-server-cert
+        optional: false
+        items:
+          - key: ca.crt
+            path: ca.crt
+          - key: tls.crt
+            path: tls.crt
+          - key: tls.key
+            path: tls.key

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -22,6 +22,11 @@ resources:
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
+# [CERTMANAGER] Enable cert-manager-managed TLS for the metrics endpoint.
+# Uncomment alongside the [METRICS-WITH-CERTS] patch below (and optionally
+# [PROMETHEUS-WITH-CERTS] in config/prometheus) to switch from the
+# self-signed built-in cert to a cert-manager Certificate.
+#- ../certmanager
 
 patches:
 # [METRICS] The following patch will enable the metrics endpoint using HTTPS and the port :8443.
@@ -29,3 +34,75 @@ patches:
 - path: manager_metrics_patch.yaml
   target:
     kind: Deployment
+# [METRICS-WITH-CERTS] Mount the cert-manager-issued metrics-server-cert
+# secret into the manager pod and point the metrics server at it. Requires
+# the [CERTMANAGER] resource include above (and cert-manager installed on
+# the cluster).
+#- path: cert_metrics_manager_patch.yaml
+#  target:
+#    kind: Deployment
+
+# [PROMETHEUS-WITH-CERTS] Substitute the actual metrics Service name and
+# namespace into the Certificate's dnsNames and into the ServiceMonitor's
+# tlsConfig.serverName placeholder (added by
+# config/prometheus/monitor_tls_patch.yaml). Requires the [CERTMANAGER]
+# and [PROMETHEUS] resource includes above.
+#replacements:
+#  - source:
+#      kind: Service
+#      version: v1
+#      name: controller-manager-metrics-service
+#      fieldPath: metadata.name
+#    targets:
+#      - select:
+#          kind: Certificate
+#          group: cert-manager.io
+#          version: v1
+#          name: metrics-certs
+#        fieldPaths:
+#          - spec.dnsNames.0
+#          - spec.dnsNames.1
+#        options:
+#          delimiter: '.'
+#          index: 0
+#          create: true
+#      - select:
+#          kind: ServiceMonitor
+#          group: monitoring.coreos.com
+#          version: v1
+#          name: controller-manager-metrics-monitor
+#        fieldPaths:
+#          - spec.endpoints.0.tlsConfig.serverName
+#        options:
+#          delimiter: '.'
+#          index: 0
+#          create: true
+#  - source:
+#      kind: Service
+#      version: v1
+#      name: controller-manager-metrics-service
+#      fieldPath: metadata.namespace
+#    targets:
+#      - select:
+#          kind: Certificate
+#          group: cert-manager.io
+#          version: v1
+#          name: metrics-certs
+#        fieldPaths:
+#          - spec.dnsNames.0
+#          - spec.dnsNames.1
+#        options:
+#          delimiter: '.'
+#          index: 1
+#          create: true
+#      - select:
+#          kind: ServiceMonitor
+#          group: monitoring.coreos.com
+#          version: v1
+#          name: controller-manager-metrics-monitor
+#        fieldPaths:
+#          - spec.endpoints.0.tlsConfig.serverName
+#        options:
+#          delimiter: '.'
+#          index: 1
+#          create: true

--- a/config/prometheus/monitor_tls_patch.yaml
+++ b/config/prometheus/monitor_tls_patch.yaml
@@ -1,19 +1,20 @@
-# Patch for Prometheus ServiceMonitor to enable secure TLS configuration
-# using certificates managed by cert-manager
+# Patch for the Prometheus ServiceMonitor to verify the operator's
+# cert-manager-managed serving certificate (instead of trusting any cert
+# with insecureSkipVerify: true).
+#
+# Kustomize replacements in config/default/kustomization.yaml fill in
+# SERVICE_NAME and SERVICE_NAMESPACE based on the actual metrics Service.
+#
+# Note: only ca + serverName are needed for server-cert verification. The
+# operator's metrics endpoint authenticates scrapers with a bearer token
+# (TokenReview), not mTLS, so client cert + key are intentionally omitted —
+# that keeps the serving private key out of the Prometheus pods.
 - op: replace
   path: /spec/endpoints/0/tlsConfig
   value:
-    # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
     serverName: SERVICE_NAME.SERVICE_NAMESPACE.svc
     insecureSkipVerify: false
     ca:
       secret:
         name: metrics-server-cert
         key: ca.crt
-    cert:
-      secret:
-        name: metrics-server-cert
-        key: tls.crt
-    keySecret:
-      name: metrics-server-cert
-      key: tls.key

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -1342,6 +1342,7 @@ _Appears in:_
 | `completedAt` _[Time](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Time)_ |  |  | Optional: \{\} <br /> |
 | `duration` _string_ |  |  | Optional: \{\} <br /> |
 | `attempts` _integer_ |  |  | Optional: \{\} <br /> |
+| `nextAttemptAt` _[Time](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Time)_ | NextAttemptAt is the earliest time at which the controller may create<br />the next Pod after a failure or timeout. Persisting this prevents the<br />Pod-delete owner watch from enqueuing a reconcile that bypasses the<br />exponential backoff. |  | Optional: \{\} <br /> |
 | `image` _string_ |  |  | Optional: \{\} <br /> |
 | `message` _string_ |  |  | Optional: \{\} <br /> |
 | `configChecksum` _string_ | Config checksum that was active when the task last completed.<br />Used to detect changes and trigger re-execution. |  | Optional: \{\} <br /> |

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -876,7 +876,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `policy` _string_ | Retention policy: Delete removes pods after completion, Retain keeps all,<br />RetainOnFailure keeps only failed pods for debugging. Retained pods are<br />automatically cleaned up by garbage collection when the task CR is<br />deleted on the next lifecycle run. | Retain | Enum: [Delete Retain RetainOnFailure] <br />Optional: \{\} <br /> |
+| `policy` _string_ | Retention policy: Delete removes pods after completion, Retain keeps all,<br />RetainOnFailure (the default) keeps only failed pods for debugging and<br />deletes successful ones to reduce noise. Retained pods are automatically<br />cleaned up by garbage collection when the task CR is deleted on the<br />next lifecycle run. | RetainOnFailure | Enum: [Delete Retain RetainOnFailure] <br />Optional: \{\} <br /> |
 
 
 #### PodTemplate

--- a/docs/user-guide/lifecycle.md
+++ b/docs/user-guide/lifecycle.md
@@ -106,7 +106,7 @@ spec:
 ```
 
 When a schedule is configured, the operator automatically re-runs the full
-lifecycle pipeline (clone → migrate → init) each time a cron tick boundary is
+lifecycle pipeline (clone → migrate → rotate → init) each time a cron tick boundary is
 crossed. The `trigger` field remains functional for manual overrides on top of
 the schedule — both contribute independently.
 
@@ -537,9 +537,11 @@ spec:
   # celeryBeat intentionally omitted — prevents alert double-triggers
 ```
 
-The lifecycle pipeline runs: **clone → migrate → init → components**. Components
-are not deployed until all tasks complete, and clone always drains existing
-components before running (DROP DATABASE fails with active connections).
+The lifecycle pipeline runs: **clone → migrate → rotate → init → components**. Components
+are not deployed until all enabled tasks complete, and clone always drains existing
+components before running (DROP DATABASE fails with active connections). Only
+the tasks you configure run; `rotate`, for example, is skipped when no
+`lifecycle.rotate` spec is set.
 
 ### Clone Trigger and Scheduling
 

--- a/docs/user-guide/lifecycle.md
+++ b/docs/user-guide/lifecycle.md
@@ -336,7 +336,7 @@ Each task has configurable timeout and retry behavior:
 spec:
   lifecycle:
     podRetention:
-      policy: RetainOnFailure    # Delete (default) | Retain | RetainOnFailure
+      policy: Retain                # Delete | Retain | RetainOnFailure (default)
     migrate:
       timeout: 10m               # max time per attempt (default: 5m)
       maxRetries: 5              # attempts before permanent failure (default: 3)
@@ -353,11 +353,15 @@ as a failed attempt.
 
 | Policy | On Success | On Failure |
 |---|---|---|
-| `Delete` (default) | Pod deleted | Pod deleted |
+| `Delete` | Pod deleted | Pod deleted |
 | `Retain` | Pod kept | Pod kept |
-| `RetainOnFailure` | Pod deleted | Pod kept for debugging |
+| `RetainOnFailure` (default) | Pod deleted | Pod kept for debugging |
 
-Use `RetainOnFailure` to inspect logs of failed migrations:
+The default keeps only failed task pods so you can inspect logs without
+cluttering the namespace with completed-success pods. Override to `Retain`
+if you want the full history, or `Delete` to garbage-collect everything.
+
+To inspect logs of a retained failed pod:
 
 ```bash
 kubectl logs <pod-name> -c superset

--- a/docs/user-guide/networking-and-monitoring.md
+++ b/docs/user-guide/networking-and-monitoring.md
@@ -83,7 +83,7 @@ If Gateway API CRDs are not present, the controller skips HTTPRoute watch
 registration and catches `meta.IsNoMatchError` at reconciliation time. The
 operator runs with reduced functionality rather than failing.
 
-## Prometheus ServiceMonitor
+## Superset Instance Metrics
 
 Requires [prometheus-operator](https://prometheus-operator.dev/) CRDs. The operator gracefully skips if they are not installed.
 
@@ -100,6 +100,117 @@ The controller creates a Prometheus `ServiceMonitor` targeting the web-server
 component using unstructured objects (because the ServiceMonitor CRD is
 external: `monitoring.coreos.com/v1`). Default scrape interval is 30s
 (configurable). Targets pods with `app.kubernetes.io/component: web-server`.
+
+## Operator Metrics
+
+The operator itself exposes [controller-runtime](https://book.kubebuilder.io/reference/metrics.html)
+default metrics — reconcile counts and durations, work-queue depth, leader
+election state. These are served over HTTPS on port 8443, guarded by
+Kubernetes bearer-token authentication and authorization. No custom
+lifecycle metrics are emitted today; condition and event streams cover the
+per-instance lifecycle state.
+
+**RBAC.** Any scraper (typically Prometheus) needs the `metrics-reader`
+ClusterRole bound to its own ServiceAccount. Both install paths ship this
+role; bind it to your Prometheus ServiceAccount, for example:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-superset-operator-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: superset-operator-metrics-reader  # Kustomize. For Helm, check the installed role name.
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: monitoring
+```
+
+**TLS — out of the box.** The operator generates a self-signed certificate at
+startup, so scrapers connect over HTTPS with `insecureSkipVerify: true`. This
+is the default in both the Kustomize ServiceMonitor (`config/prometheus/monitor.yaml`)
+and the Helm chart. It's fine for a trusted cluster but not for
+zero-trust environments.
+
+### Enable via Helm
+
+The chart ships a ServiceMonitor template, off by default. The minimal
+opt-in looks like:
+
+```yaml
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    interval: 30s
+    labels:
+      release: prometheus           # selector your Prometheus picks up
+```
+
+That keeps the default self-signed + `insecureSkipVerify: true` behavior.
+
+For real TLS via cert-manager, provision a `metrics-server-cert` Secret
+(typically via a `cert-manager.io/v1` Certificate keyed to a self-signed
+Issuer) and point the chart at it:
+
+```yaml
+metrics:
+  enabled: true
+  certSecretName: metrics-server-cert   # mounts Secret into manager pod
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: prometheus
+    tlsConfig:                           # free-form ServiceMonitor tlsConfig
+      insecureSkipVerify: false
+      serverName: <release>-superset-operator-metrics.<namespace>.svc
+      ca:
+        secret:
+          name: metrics-server-cert
+          key: ca.crt
+```
+
+The operator authenticates scrapers via bearer token (TokenReview), not
+mTLS, so `ca` + `serverName` are sufficient for the scraper to verify the
+server. Add `cert`/`keySecret` only if you've separately configured the
+metrics server to require client certs.
+
+Setting `metrics.certSecretName` mounts the Secret into the manager pod
+and adds `--metrics-cert-path` args so the metrics server presents that
+certificate. The full set of knobs is documented in
+`charts/superset-operator/values.yaml`.
+
+The chart does not ship the cert-manager `Certificate` or `Issuer`
+resources themselves; you create them (for example via
+`cert-manager.io/v1` manifests alongside your values). See the Kustomize
+section below for a working example of those manifests.
+
+### Enable via Kustomize
+
+Uncomment `- ../prometheus` in `config/default/kustomization.yaml` and
+re-apply. This adds the shipped ServiceMonitor in
+`config/prometheus/monitor.yaml`, which scrapes the operator's self-signed
+metrics endpoint with `insecureSkipVerify: true`.
+
+For a cert-manager-managed certificate (real TLS, no `insecureSkipVerify`),
+install [cert-manager](https://cert-manager.io/) on the cluster, then
+uncomment three more sections in `config/default/kustomization.yaml`:
+
+- `[CERTMANAGER]` — pulls in `config/certmanager` (a `selfsigned-issuer`
+  Issuer plus a `metrics-certs` Certificate that issues the
+  `metrics-server-cert` Secret).
+- `[METRICS-WITH-CERTS]` — mounts that Secret into the manager pod and
+  adds the `--metrics-cert-path` args.
+- `[PROMETHEUS-WITH-CERTS]` — a `replacements` block that substitutes the
+  real Service name and namespace into the Certificate's dnsNames and the
+  ServiceMonitor's `tlsConfig.serverName`.
+
+Also uncomment the patch reference in `config/prometheus/kustomization.yaml`
+so the ServiceMonitor picks up the real-TLS `tlsConfig` from
+`monitor_tls_patch.yaml`.
 
 ## Network Policies
 

--- a/internal/controller/clone_test.go
+++ b/internal/controller/clone_test.go
@@ -1449,3 +1449,39 @@ func TestAllTasksStillComplete_WithRotate(t *testing.T) {
 		}
 	})
 }
+
+// TestIsTaskEnabled_InvalidCronScheduleGatesClone verifies that an invalid
+// cron expression causes clone to be treated as disabled — the user's
+// malformed schedule surfaces as a ScheduleValid=False condition (set by
+// validateSchedules) and does not trigger an opportunistic one-shot clone.
+func TestIsTaskEnabled_InvalidCronScheduleGatesClone(t *testing.T) {
+	r := &SupersetReconciler{}
+
+	badExpr := "not a cron expression"
+	superset := &supersetv1alpha1.Superset{}
+	superset.Spec.Lifecycle = &supersetv1alpha1.LifecycleSpec{
+		Clone: &supersetv1alpha1.CloneTaskSpec{
+			SchedulableBaseTaskSpec: supersetv1alpha1.SchedulableBaseTaskSpec{
+				CronSchedule: &badExpr,
+			},
+			Source: supersetv1alpha1.CloneSourceSpec{Host: "h", Database: "d", Username: "u"},
+		},
+	}
+
+	if r.isTaskEnabled(superset, taskTypeClone) {
+		t.Fatal("expected clone to be disabled when CronSchedule is invalid")
+	}
+
+	// A valid schedule re-enables clone.
+	validExpr := "0 * * * *"
+	superset.Spec.Lifecycle.Clone.CronSchedule = &validExpr
+	if !r.isTaskEnabled(superset, taskTypeClone) {
+		t.Fatal("expected clone to be enabled for a valid CronSchedule")
+	}
+
+	// No schedule at all — clone remains enabled (legacy on-demand path).
+	superset.Spec.Lifecycle.Clone.CronSchedule = nil
+	if !r.isTaskEnabled(superset, taskTypeClone) {
+		t.Fatal("expected clone to be enabled when no CronSchedule is set")
+	}
+}

--- a/internal/controller/drain.go
+++ b/internal/controller/drain.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -51,33 +50,33 @@ func (r *SupersetReconciler) deleteTaskCR(ctx context.Context, name, namespace s
 }
 
 // drainIfNeeded checks whether any enabled task requires drain and executes it.
-// Returns (requeueAfter, drained, error). drained=true means either drain is not
-// needed or drain completed successfully.
+// Complete=true means drain isn't needed or completed successfully; otherwise
+// RequeueAfter indicates how long to wait before re-checking.
 func (r *SupersetReconciler) drainIfNeeded(
 	ctx context.Context,
 	superset *supersetv1alpha1.Superset,
 	cloneEnabled, migrateEnabled, rotateEnabled, initEnabled bool,
-) (time.Duration, bool, error) {
+) (lifecycleResult, error) {
 	needsDrain := (cloneEnabled && r.taskRequiresDrain(superset, taskTypeClone)) ||
 		(migrateEnabled && r.taskRequiresDrain(superset, taskTypeMigrate)) ||
 		(rotateEnabled && r.taskRequiresDrain(superset, taskTypeRotate)) ||
 		(initEnabled && r.taskRequiresDrain(superset, taskTypeInit))
 	if !needsDrain {
-		return 0, true, nil
+		return lifecycleComplete(), nil
 	}
 
 	superset.Status.Lifecycle.Phase = lifecyclePhaseDraining
 	superset.Status.Phase = phaseDraining
 	drained, err := r.drainComponents(ctx, superset)
 	if err != nil {
-		return 0, false, fmt.Errorf("draining components: %w", err)
+		return lifecycleResult{}, fmt.Errorf("draining components: %w", err)
 	}
 	if !drained {
 		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
 			metav1.ConditionFalse, "Draining", "Scaling components to zero before lifecycle tasks", superset.Generation)
-		return taskRequeueInterval, false, nil
+		return lifecycleWait(), nil
 	}
-	return 0, true, nil
+	return lifecycleComplete(), nil
 }
 
 // drainComponents deletes all component child CRs, which cascades to their

--- a/internal/controller/initpod.go
+++ b/internal/controller/initpod.go
@@ -32,7 +32,7 @@ import (
 const (
 	defaultInitTimeout           = 300 * time.Second
 	defaultMaxRetries      int32 = 3
-	defaultRetentionPolicy       = retentionRetain
+	defaultRetentionPolicy       = retentionRetainOnFail
 
 	retentionDelete       = "Delete"
 	retentionRetain       = "Retain"

--- a/internal/controller/lifecycle.go
+++ b/internal/controller/lifecycle.go
@@ -75,15 +75,39 @@ const (
 	phaseAwaitingApproval = "AwaitingApproval"
 )
 
+// lifecycleResult carries the outcome of a lifecycle reconcile step.
+// Complete=true means the caller may proceed past lifecycle (to components).
+// TerminalFailure=true means a permanent failure was reached: the parent will
+// not requeue on its own, but callers should still consider scheduled re-runs
+// (cron schedules) before giving up.
+// RequeueAfter>0 means wait that long before reconciling again.
+// Complete/TerminalFailure/RequeueAfter are mutually exclusive outcomes
+// except that RequeueAfter may coexist with !Complete.
+type lifecycleResult struct {
+	RequeueAfter    time.Duration
+	Complete        bool
+	TerminalFailure bool
+}
+
+// lifecycleComplete is the "pipeline done, move on" result.
+func lifecycleComplete() lifecycleResult { return lifecycleResult{Complete: true} }
+
+// lifecycleWait returns a "not done, requeue after taskRequeueInterval" result.
+// All lifecycle steps that poll the task CR use the same interval.
+func lifecycleWait() lifecycleResult { return lifecycleResult{RequeueAfter: taskRequeueInterval} }
+
+// lifecycleTerminal is a "permanent failure, don't requeue on own" result.
+func lifecycleTerminal() lifecycleResult { return lifecycleResult{TerminalFailure: true} }
+
 // reconcileLifecycle orchestrates the lifecycle tasks (clone + migrate + init) and gates
-// component deployment. Returns (requeueAfter, lifecycleComplete, error).
+// component deployment.
 func (r *SupersetReconciler) reconcileLifecycle(
 	ctx context.Context,
 	superset *supersetv1alpha1.Superset,
 	configChecksum string,
 	topLevel *resolution.SharedInput,
 	saName string,
-) (time.Duration, bool, error) {
+) (lifecycleResult, error) {
 
 	// If lifecycle is disabled, prune orphans and mark complete.
 	if isLifecycleDisabled(superset) {
@@ -92,15 +116,15 @@ func (r *SupersetReconciler) reconcileLifecycle(
 			func() client.ObjectList { return &supersetv1alpha1.SupersetLifecycleTaskList{} },
 			"",
 		); err != nil {
-			return 0, false, fmt.Errorf("pruning orphaned task CRs: %w", err)
+			return lifecycleResult{}, fmt.Errorf("pruning orphaned task CRs: %w", err)
 		}
 		if err := r.cleanupMaintenanceResources(ctx, superset); err != nil {
-			return 0, false, fmt.Errorf("cleaning up maintenance resources: %w", err)
+			return lifecycleResult{}, fmt.Errorf("cleaning up maintenance resources: %w", err)
 		}
 		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
 			metav1.ConditionTrue, "LifecycleDisabled", "Lifecycle tasks are disabled", superset.Generation)
 		superset.Status.Lifecycle = nil
-		return 0, true, nil
+		return lifecycleComplete(), nil
 	}
 
 	// Ensure lifecycle status exists.
@@ -122,7 +146,7 @@ func (r *SupersetReconciler) reconcileLifecycle(
 
 	// Check upgrade gates (version comparison, downgrade blocking, supervised approval).
 	if gateResult, gated := r.checkUpgradeGates(ctx, superset, imageChanged, lastImage, currentImage); gated {
-		return gateResult, false, nil
+		return gateResult, nil
 	}
 
 	// Determine which tasks are enabled and prune orphans for disabled ones.
@@ -132,7 +156,7 @@ func (r *SupersetReconciler) reconcileLifecycle(
 	initEnabled := r.isTaskEnabled(superset, taskTypeInit)
 
 	if err := r.pruneDisabledTasks(ctx, superset, cloneEnabled, migrateEnabled, rotateEnabled, initEnabled); err != nil {
-		return 0, false, err
+		return lifecycleResult{}, err
 	}
 
 	// If no tasks are enabled, lifecycle is complete.
@@ -140,7 +164,7 @@ func (r *SupersetReconciler) reconcileLifecycle(
 		superset.Status.Lifecycle.Phase = lifecyclePhaseComplete
 		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
 			metav1.ConditionTrue, "LifecycleComplete", "Lifecycle tasks completed successfully", superset.Generation)
-		return 0, true, nil
+		return lifecycleComplete(), nil
 	}
 
 	// Fast path: if all enabled tasks already completed with matching checksums,
@@ -150,45 +174,68 @@ func (r *SupersetReconciler) reconcileLifecycle(
 		superset.Status.Lifecycle.Phase = lifecyclePhaseComplete
 		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
 			metav1.ConditionTrue, "LifecycleComplete", "Lifecycle tasks completed successfully", superset.Generation)
-		return 0, true, nil
+		return lifecycleComplete(), nil
 	}
 
 	// Spin up the maintenance page before drain (if configured).
+	if result, err := r.prepareMaintenancePage(ctx, superset, cloneEnabled, migrateEnabled, rotateEnabled, initEnabled); err != nil {
+		return lifecycleResult{}, err
+	} else if !result.Complete {
+		return result, nil
+	}
+
+	// Drain components if any enabled task requires it.
+	drainResult, err := r.drainIfNeeded(ctx, superset, cloneEnabled, migrateEnabled, rotateEnabled, initEnabled)
+	if err != nil {
+		return lifecycleResult{}, err
+	}
+	if !drainResult.Complete {
+		return drainResult, nil
+	}
+
+	// Orchestrate lifecycle pipeline: clone → migrate → rotate → init.
+	pipelineResult, err := r.runLifecyclePipeline(ctx, superset, cloneEnabled, migrateEnabled, rotateEnabled, initEnabled, imageChanged, configChecksum, topLevel, saName)
+	if err != nil {
+		return lifecycleResult{}, err
+	}
+	if !pipelineResult.Complete {
+		return pipelineResult, nil
+	}
+
+	// All tasks complete.
+	if err := r.finalizeLifecycle(ctx, superset, currentImage); err != nil {
+		return lifecycleResult{}, err
+	}
+	return lifecycleComplete(), nil
+}
+
+// prepareMaintenancePage brings up the maintenance Deployment and switches
+// the web-server Service selector before the drain step, if configured.
+// Returns Complete=true if maintenance isn't needed or the page is serving.
+func (r *SupersetReconciler) prepareMaintenancePage(
+	ctx context.Context,
+	superset *supersetv1alpha1.Superset,
+	cloneEnabled, migrateEnabled, rotateEnabled, initEnabled bool,
+) (lifecycleResult, error) {
 	needsDrain := (cloneEnabled && r.taskRequiresDrain(superset, taskTypeClone)) ||
 		(migrateEnabled && r.taskRequiresDrain(superset, taskTypeMigrate)) ||
 		(rotateEnabled && r.taskRequiresDrain(superset, taskTypeRotate)) ||
 		(initEnabled && r.taskRequiresDrain(superset, taskTypeInit))
-	if isMaintenancePageEnabled(superset) && needsDrain {
-		ready, err := r.reconcileMaintenancePageUp(ctx, superset)
-		if err != nil {
-			return 0, false, fmt.Errorf("reconciling maintenance page: %w", err)
-		}
-		if !ready {
-			superset.Status.Lifecycle.Phase = lifecyclePhaseDraining
-			return taskRequeueInterval, false, nil
-		}
-		// Switch Service selector to maintenance pods before drain begins.
-		if err := r.reconcileWebServerService(ctx, superset); err != nil {
-			return 0, false, fmt.Errorf("switching web-server Service to maintenance: %w", err)
-		}
+	if !isMaintenancePageEnabled(superset) || !needsDrain {
+		return lifecycleComplete(), nil
 	}
-
-	// Drain components if any enabled task requires it.
-	if requeueAfter, drained, err := r.drainIfNeeded(ctx, superset, cloneEnabled, migrateEnabled, rotateEnabled, initEnabled); err != nil {
-		return 0, false, err
-	} else if !drained {
-		return requeueAfter, false, nil
+	ready, err := r.reconcileMaintenancePageUp(ctx, superset)
+	if err != nil {
+		return lifecycleResult{}, fmt.Errorf("reconciling maintenance page: %w", err)
 	}
-
-	// Orchestrate lifecycle pipeline: clone → migrate → rotate → init.
-	if requeueAfter, complete, err := r.runLifecyclePipeline(ctx, superset, cloneEnabled, migrateEnabled, rotateEnabled, initEnabled, imageChanged, configChecksum, topLevel, saName); err != nil {
-		return 0, false, err
-	} else if !complete {
-		return requeueAfter, false, nil
+	if !ready {
+		superset.Status.Lifecycle.Phase = lifecyclePhaseDraining
+		return lifecycleWait(), nil
 	}
-
-	// All tasks complete.
-	return 0, true, r.finalizeLifecycle(ctx, superset, currentImage)
+	if err := r.reconcileWebServerService(ctx, superset); err != nil {
+		return lifecycleResult{}, fmt.Errorf("switching web-server Service to maintenance: %w", err)
+	}
+	return lifecycleComplete(), nil
 }
 
 // finalizeLifecycle updates status and clears approval annotations after all
@@ -229,7 +276,7 @@ func (r *SupersetReconciler) runLifecyclePipeline(
 	configChecksum string,
 	topLevel *resolution.SharedInput,
 	saName string,
-) (time.Duration, bool, error) {
+) (lifecycleResult, error) {
 	incomingChecksum := string(superset.UID)
 
 	if cloneEnabled {
@@ -237,12 +284,12 @@ func (r *SupersetReconciler) runLifecyclePipeline(
 
 		cloneCmd := r.buildCloneCommand(superset)
 		taskChecksum := r.computeStepChecksum(incomingChecksum, taskTypeClone, cloneCmd, r.cloneInputs(superset))
-		requeueAfter, complete, err := r.reconcileLifecycleTask(ctx, superset, taskTypeClone, suffixClone, cloneCmd, taskChecksum, configChecksum, topLevel, saName)
+		result, err := r.reconcileLifecycleTask(ctx, superset, taskTypeClone, suffixClone, cloneCmd, taskChecksum, configChecksum, topLevel, saName)
 		if err != nil {
-			return 0, false, fmt.Errorf("reconciling clone task: %w", err)
+			return lifecycleResult{}, fmt.Errorf("reconciling clone task: %w", err)
 		}
-		if !complete {
-			return requeueAfter, false, nil
+		if !result.Complete {
+			return result, nil
 		}
 		incomingChecksum = r.getTaskStatusChecksum(ctx, superset, suffixClone)
 	}
@@ -257,12 +304,12 @@ func (r *SupersetReconciler) runLifecyclePipeline(
 
 		migrateCmd := defaultMigrateCommand(superset)
 		taskChecksum := r.computeStepChecksum(incomingChecksum, taskTypeMigrate, migrateCmd, r.migrateInputs(superset))
-		requeueAfter, complete, err := r.reconcileLifecycleTask(ctx, superset, taskTypeMigrate, suffixMigrate, migrateCmd, taskChecksum, configChecksum, topLevel, saName)
+		result, err := r.reconcileLifecycleTask(ctx, superset, taskTypeMigrate, suffixMigrate, migrateCmd, taskChecksum, configChecksum, topLevel, saName)
 		if err != nil {
-			return 0, false, fmt.Errorf("reconciling migrate task: %w", err)
+			return lifecycleResult{}, fmt.Errorf("reconciling migrate task: %w", err)
 		}
-		if !complete {
-			return requeueAfter, false, nil
+		if !result.Complete {
+			return result, nil
 		}
 		incomingChecksum = r.getTaskStatusChecksum(ctx, superset, suffixMigrate)
 	}
@@ -272,12 +319,12 @@ func (r *SupersetReconciler) runLifecyclePipeline(
 
 		rotateCmd := defaultRotateCommand(superset)
 		taskChecksum := r.computeStepChecksum(incomingChecksum, taskTypeRotate, rotateCmd, r.rotateInputs(superset))
-		requeueAfter, complete, err := r.reconcileLifecycleTask(ctx, superset, taskTypeRotate, suffixRotate, rotateCmd, taskChecksum, configChecksum, topLevel, saName)
+		result, err := r.reconcileLifecycleTask(ctx, superset, taskTypeRotate, suffixRotate, rotateCmd, taskChecksum, configChecksum, topLevel, saName)
 		if err != nil {
-			return 0, false, fmt.Errorf("reconciling rotate task: %w", err)
+			return lifecycleResult{}, fmt.Errorf("reconciling rotate task: %w", err)
 		}
-		if !complete {
-			return requeueAfter, false, nil
+		if !result.Complete {
+			return result, nil
 		}
 		incomingChecksum = r.getTaskStatusChecksum(ctx, superset, suffixRotate)
 	}
@@ -290,30 +337,30 @@ func (r *SupersetReconciler) runLifecyclePipeline(
 
 		initCmd := defaultInitCommand(superset)
 		taskChecksum := r.computeStepChecksum(incomingChecksum, taskTypeInit, initCmd, r.initInputs(superset, configChecksum))
-		requeueAfter, complete, err := r.reconcileLifecycleTask(ctx, superset, taskTypeInit, suffixInit, initCmd, taskChecksum, configChecksum, topLevel, saName)
+		result, err := r.reconcileLifecycleTask(ctx, superset, taskTypeInit, suffixInit, initCmd, taskChecksum, configChecksum, topLevel, saName)
 		if err != nil {
-			return 0, false, fmt.Errorf("reconciling init task: %w", err)
+			return lifecycleResult{}, fmt.Errorf("reconciling init task: %w", err)
 		}
-		if !complete {
-			return requeueAfter, false, nil
+		if !result.Complete {
+			return result, nil
 		}
 	}
 
-	return 0, true, nil
+	return lifecycleComplete(), nil
 }
 
 // checkUpgradeGates handles version comparison, downgrade blocking, and supervised approval.
-// Returns (requeueAfter, gated) — if gated is true, the caller should return early.
+// Returns (result, gated) — if gated is true, the caller should return early with result.
 func (r *SupersetReconciler) checkUpgradeGates(
 	ctx context.Context,
 	superset *supersetv1alpha1.Superset,
 	imageChanged bool,
 	lastImage, currentImage string,
-) (time.Duration, bool) {
+) (lifecycleResult, bool) {
 	log := logf.FromContext(ctx)
 
 	if !imageChanged || lastImage == "" {
-		return 0, false
+		return lifecycleResult{}, false
 	}
 
 	oldTag := tagFromImageRef(lastImage)
@@ -335,7 +382,7 @@ func (r *SupersetReconciler) checkUpgradeGates(
 		}
 		r.Recorder.Eventf(superset, nil, corev1.EventTypeWarning, "DowngradeBlocked", "Lifecycle",
 			"Downgrade from %s to %s is not supported", oldTag, newTag)
-		return -1, true
+		return lifecycleTerminal(), true
 	}
 
 	// Set upgrade context only once (preserve StartedAt across reconciles).
@@ -362,15 +409,13 @@ func (r *SupersetReconciler) checkUpgradeGates(
 				superset.Generation)
 			superset.Status.Phase = phaseAwaitingApproval
 			superset.Status.Lifecycle.Phase = lifecyclePhaseAwaitingApproval
-			return 0, true
+			return lifecycleResult{}, true
 		}
 	}
 
-	return 0, false
+	return lifecycleResult{}, false
 }
 
-// reconcileTask creates or updates a single SupersetLifecycleTask child CR and polls its status.
-// Returns (requeueAfter, taskComplete, error).
 // reconcileLifecycleTask creates or manages a single lifecycle task CR and polls its status.
 // This is the unified task reconciler for all task types (clone, migrate, init).
 // The checksum is pre-computed by the caller (strategy-aware + upstream propagation).
@@ -384,7 +429,7 @@ func (r *SupersetReconciler) reconcileLifecycleTask(
 	configChecksum string,
 	topLevel *resolution.SharedInput,
 	saName string,
-) (time.Duration, bool, error) {
+) (lifecycleResult, error) {
 	log := logf.FromContext(ctx)
 	childName := superset.Name + suffix
 
@@ -409,7 +454,7 @@ func (r *SupersetReconciler) reconcileLifecycleTask(
 			}
 			if storedChecksum != "" && storedChecksum == taskChecksum {
 				log.Info("Task already completed in previous lifecycle run (no CR, inputs unchanged)", "task", taskType)
-				return 0, true, nil
+				return lifecycleComplete(), nil
 			}
 		}
 
@@ -425,7 +470,7 @@ func (r *SupersetReconciler) reconcileLifecycleTask(
 			},
 		}
 		if err := controllerutil.SetControllerReference(superset, child, r.Scheme); err != nil {
-			return 0, false, fmt.Errorf("setting controller reference on %s: %w", childName, err)
+			return lifecycleResult{}, fmt.Errorf("setting controller reference on %s: %w", childName, err)
 		}
 		child.Spec.FlatComponentSpec = flatSpec
 		child.Spec.Type = taskType
@@ -439,26 +484,26 @@ func (r *SupersetReconciler) reconcileLifecycleTask(
 		if renderedConfig != "" {
 			resourceBaseName := childName
 			if err := reconcileParentOwnedConfigMap(ctx, r.Client, r.Scheme, superset, renderedConfig, resourceBaseName); err != nil {
-				return 0, false, fmt.Errorf("reconciling ConfigMap for lifecycle task %s: %w", childName, err)
+				return lifecycleResult{}, fmt.Errorf("reconciling ConfigMap for lifecycle task %s: %w", childName, err)
 			}
 		}
 
 		if err := r.Create(ctx, child); err != nil {
-			return 0, false, fmt.Errorf("creating SupersetLifecycleTask %s: %w", childName, err)
+			return lifecycleResult{}, fmt.Errorf("creating SupersetLifecycleTask %s: %w", childName, err)
 		}
 		log.Info("Created lifecycle task CR", "task", taskType)
 		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
 			metav1.ConditionFalse, "TaskInProgress", fmt.Sprintf("%s task is in progress", taskType), superset.Generation)
-		return taskRequeueInterval, false, nil
+		return lifecycleWait(), nil
 	}
 	if err != nil {
-		return 0, false, fmt.Errorf("fetching SupersetLifecycleTask %s: %w", childName, err)
+		return lifecycleResult{}, fmt.Errorf("fetching SupersetLifecycleTask %s: %w", childName, err)
 	}
 
 	// Task CR is being deleted — wait for GC to finish.
 	if child.DeletionTimestamp != nil {
 		log.Info("Task CR is being deleted, waiting for GC", "task", taskType)
-		return taskRequeueInterval, false, nil
+		return lifecycleWait(), nil
 	}
 
 	// Project status to parent.
@@ -497,14 +542,14 @@ func (r *SupersetReconciler) reconcileLifecycleTask(
 			}
 			superset.Status.Lifecycle.LastCompletedChecksums[taskType] = taskChecksum
 			log.Info("Task complete (checksum match, skipping)", "task", taskType)
-			return 0, true, nil
+			return lifecycleComplete(), nil
 		}
 		log.Info("Task completed for previous inputs, deleting to re-run", "task", taskType,
 			"statusChecksum", child.Status.ConfigChecksum, "expectedChecksum", taskChecksum)
 		if err := r.Delete(ctx, child); err != nil {
-			return 0, false, fmt.Errorf("deleting stale task CR %s: %w", childName, err)
+			return lifecycleResult{}, fmt.Errorf("deleting stale task CR %s: %w", childName, err)
 		}
-		return taskRequeueInterval, false, nil
+		return lifecycleWait(), nil
 
 	case taskStateFailed:
 		if child.Status.Attempts >= maxRetries {
@@ -513,23 +558,23 @@ func (r *SupersetReconciler) reconcileLifecycleTask(
 				setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
 					metav1.ConditionFalse, "TaskFailed", fmt.Sprintf("%s: %s", taskType, child.Status.Message), superset.Generation)
 				superset.Status.Phase = phaseInitializing
-				return -1, false, nil
+				return lifecycleTerminal(), nil
 			}
 			log.Info("Task failed for previous inputs, deleting to re-run", "task", taskType)
 			if err := r.Delete(ctx, child); err != nil {
-				return 0, false, fmt.Errorf("deleting stale task CR %s: %w", childName, err)
+				return lifecycleResult{}, fmt.Errorf("deleting stale task CR %s: %w", childName, err)
 			}
-			return taskRequeueInterval, false, nil
+			return lifecycleWait(), nil
 		}
 		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
 			metav1.ConditionFalse, "TaskRetrying", fmt.Sprintf("%s task is retrying", taskType), superset.Generation)
-		return taskRequeueInterval, false, nil
+		return lifecycleWait(), nil
 
 	default:
 		log.Info("Task not yet complete", "task", taskType, "state", child.Status.State)
 		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
 			metav1.ConditionFalse, "TaskInProgress", fmt.Sprintf("%s task is in progress", taskType), superset.Generation)
-		return taskRequeueInterval, false, nil
+		return lifecycleWait(), nil
 	}
 }
 
@@ -667,6 +712,9 @@ func (r *SupersetReconciler) taskPodRetention(superset *supersetv1alpha1.Superse
 // isTaskEnabled returns true if the task is part of the lifecycle pipeline.
 // A task is enabled when its spec exists (presence = enabled) and Disabled != true.
 // Clone and rotate require their spec to be set; migrate/init are enabled by default.
+// Clone is additionally gated on a valid CronSchedule: an invalid expression
+// surfaces as a ScheduleValid=False condition + event, and the task is treated
+// as disabled (the stale CR is pruned) until the expression is corrected.
 func (r *SupersetReconciler) isTaskEnabled(superset *supersetv1alpha1.Superset, taskType string) bool {
 	if superset.Spec.Lifecycle == nil {
 		return taskType != taskTypeClone && taskType != taskTypeRotate
@@ -676,7 +724,10 @@ func (r *SupersetReconciler) isTaskEnabled(superset *supersetv1alpha1.Superset, 
 		if superset.Spec.Lifecycle.Clone == nil {
 			return false
 		}
-		return superset.Spec.Lifecycle.Clone.Disabled == nil || !*superset.Spec.Lifecycle.Clone.Disabled
+		if superset.Spec.Lifecycle.Clone.Disabled != nil && *superset.Spec.Lifecycle.Clone.Disabled {
+			return false
+		}
+		return cloneScheduleIsValid(superset.Spec.Lifecycle.Clone.CronSchedule)
 	case taskTypeRotate:
 		if superset.Spec.Lifecycle.Rotate == nil {
 			return false

--- a/internal/controller/reconcile_test.go
+++ b/internal/controller/reconcile_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -863,7 +864,7 @@ func TestReconcile_InitChecksumChangesOnImageAndCommand(t *testing.T) {
 
 	ctx := context.Background()
 	topLevel := convertTopLevelSpec(&superset.Spec)
-	_, _, err := r.reconcileLifecycle(ctx, superset, computeChecksum("base"), topLevel, resolveServiceAccountName(superset))
+	_, err := r.reconcileLifecycle(ctx, superset, computeChecksum("base"), topLevel, resolveServiceAccountName(superset))
 	if err != nil {
 		t.Fatalf("initial reconcileLifecycle: %v", err)
 	}
@@ -893,7 +894,7 @@ func TestReconcile_InitChecksumChangesOnImageAndCommand(t *testing.T) {
 
 	// Reconcile — parent sees checksum mismatch → deletes old CR.
 	topLevel = convertTopLevelSpec(&updated.Spec)
-	_, _, err = r.reconcileLifecycle(ctx, updated, computeChecksum("base"), topLevel, resolveServiceAccountName(updated))
+	_, err = r.reconcileLifecycle(ctx, updated, computeChecksum("base"), topLevel, resolveServiceAccountName(updated))
 	if err != nil {
 		t.Fatalf("updated reconcileLifecycle: %v", err)
 	}
@@ -931,7 +932,7 @@ func TestReconcile_InitChecksum_StableWhenAutoscalingChanges(t *testing.T) {
 
 	ctx := context.Background()
 	topLevel := convertTopLevelSpec(&superset.Spec)
-	_, _, err := r.reconcileLifecycle(ctx, superset, computeChecksum("base"), topLevel, resolveServiceAccountName(superset))
+	_, err := r.reconcileLifecycle(ctx, superset, computeChecksum("base"), topLevel, resolveServiceAccountName(superset))
 	if err != nil {
 		t.Fatalf("initial reconcileLifecycle: %v", err)
 	}
@@ -954,7 +955,7 @@ func TestReconcile_InitChecksum_StableWhenAutoscalingChanges(t *testing.T) {
 	}
 
 	topLevel = convertTopLevelSpec(&updated.Spec)
-	_, _, err = r.reconcileLifecycle(ctx, updated, computeChecksum("base"), topLevel, resolveServiceAccountName(updated))
+	_, err = r.reconcileLifecycle(ctx, updated, computeChecksum("base"), topLevel, resolveServiceAccountName(updated))
 	if err != nil {
 		t.Fatalf("updated reconcileLifecycle: %v", err)
 	}
@@ -1340,6 +1341,128 @@ func TestReconcile_InitTerminalFailure_NoRequeue(t *testing.T) {
 
 	if result.RequeueAfter != 0 {
 		t.Errorf("expected no requeue for terminal init failure, got RequeueAfter=%v", result.RequeueAfter)
+	}
+}
+
+// TestReconcile_ScheduledCloneTerminalFailure_RequeuesForNextTick verifies
+// that a scheduled clone task which has permanently failed still wakes up
+// on the next cron tick, rather than requiring a spec change to recover.
+func TestReconcile_ScheduledCloneTerminalFailure_RequeuesForNextTick(t *testing.T) {
+	scheme := testScheme(t)
+
+	// 14:30 with hourly cron at :00 ⇒ next tick at 15:00 ⇒ ~30 min requeue.
+	now := time.Date(2026, 5, 11, 14, 30, 0, 0, time.UTC)
+
+	cronExpr := "0 * * * *"
+	spec := minimalSupersetSpec()
+	spec.Lifecycle = &supersetv1alpha1.LifecycleSpec{
+		Clone: &supersetv1alpha1.CloneTaskSpec{
+			SchedulableBaseTaskSpec: supersetv1alpha1.SchedulableBaseTaskSpec{
+				CronSchedule: &cronExpr,
+			},
+			Source: supersetv1alpha1.CloneSourceSpec{
+				Host:     "prod-db",
+				Database: "superset",
+				Username: "reader",
+			},
+		},
+	}
+	// Supply a structured metastore so the clone target env vars are happy.
+	host := "target-db"
+	db := "superset"
+	user := "app"
+	spec.Metastore = &supersetv1alpha1.MetastoreSpec{
+		Host: &host, Database: &db, Username: &user,
+	}
+
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "uid-test-sched"},
+		Spec:       spec,
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(superset).
+		WithStatusSubresource(&supersetv1alpha1.Superset{}, &supersetv1alpha1.SupersetLifecycleTask{}).
+		Build()
+
+	r := &SupersetReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: events.NewFakeRecorder(10),
+		Now:      func() time.Time { return now },
+	}
+
+	// First reconcile creates the clone task CR.
+	doReconcile(t, r, "test")
+
+	ctx := context.Background()
+	cloneCR := &supersetv1alpha1.SupersetLifecycleTask{}
+	if err := c.Get(ctx, types.NamespacedName{Name: "test-clone", Namespace: "default"}, cloneCR); err != nil {
+		t.Fatalf("get clone CR: %v", err)
+	}
+
+	// Simulate permanent failure with matching checksum.
+	cloneCR.Status.State = "Failed"
+	cloneCR.Status.Attempts = defaultMaxRetries
+	cloneCR.Status.Message = "pg_dump exited non-zero"
+	cloneCR.Status.ConfigChecksum = cloneCR.Spec.ConfigChecksum
+	if err := c.Status().Update(ctx, cloneCR); err != nil {
+		t.Fatalf("update clone status: %v", err)
+	}
+
+	// Second reconcile: terminal failure + active cron schedule ⇒ requeue at next tick.
+	result, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Fatal("expected a requeue for the next scheduled tick after terminal clone failure, got 0")
+	}
+	// Expect roughly 30 minutes until 15:00 (the implementation adds a 1s buffer).
+	expected := 30*time.Minute + time.Second
+	if result.RequeueAfter != expected {
+		t.Errorf("expected requeue %v, got %v", expected, result.RequeueAfter)
+	}
+}
+
+// TestReconcile_NoopStatusWritesAreSkipped verifies that two back-to-back
+// reconciles on a settled Superset do not churn the resourceVersion when
+// no observable status field has changed.
+func TestReconcile_NoopStatusWritesAreSkipped(t *testing.T) {
+	scheme := testScheme(t)
+
+	// Lifecycle disabled keeps the reconcile path short and deterministic.
+	spec := minimalSupersetSpec()
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "uid-noop-1"},
+		Spec:       spec,
+	}
+
+	c := reconcileOnce(t, scheme, superset).Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+
+	// First reconcile populates status. Second reconcile should be a no-op.
+	doReconcile(t, r, "test")
+
+	ctx := context.Background()
+	after1 := &supersetv1alpha1.Superset{}
+	if err := c.Get(ctx, types.NamespacedName{Name: "test", Namespace: "default"}, after1); err != nil {
+		t.Fatalf("get after first reconcile: %v", err)
+	}
+
+	doReconcile(t, r, "test")
+
+	after2 := &supersetv1alpha1.Superset{}
+	if err := c.Get(ctx, types.NamespacedName{Name: "test", Namespace: "default"}, after2); err != nil {
+		t.Fatalf("get after second reconcile: %v", err)
+	}
+
+	if after1.ResourceVersion != after2.ResourceVersion {
+		t.Errorf("expected no-op reconcile to leave resourceVersion unchanged, got %q → %q",
+			after1.ResourceVersion, after2.ResourceVersion)
 	}
 }
 

--- a/internal/controller/schedule.go
+++ b/internal/controller/schedule.go
@@ -129,3 +129,15 @@ func (r *SupersetReconciler) validateSchedules(superset *supersetv1alpha1.Supers
 }
 
 const conditionTypeScheduleValid = "ScheduleValid"
+
+// cloneScheduleIsValid returns true if cronSchedule is unset, empty, or a
+// valid cron expression. An invalid expression causes the caller to treat
+// the clone as disabled until the user corrects it. The matching user-facing
+// signal (condition + event) is set by validateSchedules earlier in the
+// reconcile.
+func cloneScheduleIsValid(cronSchedule *string) bool {
+	if cronSchedule == nil || *cronSchedule == "" {
+		return true
+	}
+	return schedule.Validate(*cronSchedule) == nil
+}

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -19,14 +19,31 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	supersetv1alpha1 "github.com/apache/superset-kubernetes-operator/api/v1alpha1"
 )
+
+// patchStatusIfChanged issues a status MergeFrom patch iff the two status
+// values are not semantically equal. origObj is the deep copy of obj
+// captured before mutation; origStatus and currentStatus are the compared
+// status values (typically obj.Status before/after mutation).
+//
+// This avoids bumping resourceVersion on reconciles where no observable
+// status field changed, cutting down on self-enqueued reconciles.
+func patchStatusIfChanged(ctx context.Context, c client.Client, obj client.Object, origObj client.Object, origStatus, currentStatus any) error {
+	if equality.Semantic.DeepEqual(origStatus, currentStatus) {
+		return nil
+	}
+	return c.Status().Patch(ctx, obj, client.MergeFrom(origObj))
+}
 
 // setCondition sets a condition on a conditions slice, replacing any existing
 // condition of the same type.

--- a/internal/controller/superset_controller.go
+++ b/internal/controller/superset_controller.go
@@ -87,6 +87,10 @@ func (r *SupersetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 
+	// Capture the server-side status for diffing; all subsequent status writes
+	// are guarded by equality.Semantic.DeepEqual to avoid reconcile churn.
+	origSuperset := superset.DeepCopy()
+
 	// Handle suspend.
 	if superset.Spec.Suspend != nil && *superset.Spec.Suspend {
 		log.Info("Reconciliation suspended", "name", superset.Name)
@@ -94,7 +98,7 @@ func (r *SupersetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			metav1.ConditionTrue, "Suspended", "Reconciliation is suspended", superset.Generation)
 		superset.Status.Phase = phaseSuspended
 		superset.Status.ObservedGeneration = superset.Generation
-		return ctrl.Result{}, r.Status().Update(ctx, superset)
+		return ctrl.Result{}, patchStatusIfChanged(ctx, r.Client, superset, origSuperset, origSuperset.Status, superset.Status)
 	}
 
 	// Clear Suspended condition when not suspended.
@@ -132,22 +136,27 @@ func (r *SupersetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	topLevel := convertTopLevelSpec(&superset.Spec)
 	saName := resolveServiceAccountName(superset)
 
-	requeueAfter, lifecycleComplete, err := r.reconcileLifecycle(ctx, superset, configChecksum, topLevel, saName)
+	lifecycleRes, err := r.reconcileLifecycle(ctx, superset, configChecksum, topLevel, saName)
 	if err != nil {
 		r.Recorder.Eventf(superset, nil, corev1.EventTypeWarning, "ReconcileError", "Reconcile", "Failed to reconcile Init: %v", err)
 		return ctrl.Result{}, fmt.Errorf("reconciling Init: %w", err)
 	}
-	if !lifecycleComplete {
+	if !lifecycleRes.Complete {
 		// Update status before returning.
-		if statusErr := r.Status().Update(ctx, superset); statusErr != nil {
+		if statusErr := patchStatusIfChanged(ctx, r.Client, superset, origSuperset, origSuperset.Status, superset.Status); statusErr != nil {
 			return ctrl.Result{}, fmt.Errorf("updating status during init: %w", statusErr)
 		}
-		if requeueAfter < 0 {
-			// Terminal failure — only a spec change (watch event) can recover.
+		if lifecycleRes.TerminalFailure {
+			// Even on terminal failure, wake up for the next scheduled run
+			// (e.g., cron-driven clone) if one is configured.
+			if next := r.nextScheduleRequeue(superset); next > 0 {
+				return ctrl.Result{RequeueAfter: next}, nil
+			}
+			// No schedule; only a spec change (watch event) can recover.
 			return ctrl.Result{}, nil
 		}
-		if requeueAfter > 0 {
-			return ctrl.Result{RequeueAfter: requeueAfter}, nil
+		if lifecycleRes.RequeueAfter > 0 {
+			return ctrl.Result{RequeueAfter: lifecycleRes.RequeueAfter}, nil
 		}
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
@@ -156,7 +165,7 @@ func (r *SupersetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// creating components. Component creation triggers watch events that cause
 	// concurrent reconciles — if we defer this to Phase 5, a conflict there
 	// loses the checksums and the next reconcile re-enters lifecycle.
-	if statusErr := r.Status().Update(ctx, superset); statusErr != nil {
+	if statusErr := patchStatusIfChanged(ctx, r.Client, superset, origSuperset, origSuperset.Status, superset.Status); statusErr != nil {
 		return ctrl.Result{}, fmt.Errorf("updating status after lifecycle: %w", statusErr)
 	}
 
@@ -185,7 +194,7 @@ func (r *SupersetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		_ = r.deleteMaintenanceResources(ctx, superset)
 	}
 	if !maintenanceCleared {
-		if statusErr := r.Status().Update(ctx, superset); statusErr != nil {
+		if statusErr := patchStatusIfChanged(ctx, r.Client, superset, origSuperset, origSuperset.Status, superset.Status); statusErr != nil {
 			return ctrl.Result{}, fmt.Errorf("updating status during maintenance return: %w", statusErr)
 		}
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
@@ -209,7 +218,7 @@ func (r *SupersetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	// Phase 5: Update aggregate status.
 	superset.Status.ConfigChecksum = configChecksum
-	if err := r.updateStatus(ctx, superset); err != nil {
+	if err := r.updateStatus(ctx, superset, origSuperset); err != nil {
 		return ctrl.Result{}, fmt.Errorf("updating status: %w", err)
 	}
 
@@ -315,7 +324,7 @@ func isOwnedBy(obj, owner client.Object) bool {
 
 // --- Status aggregation ---
 
-func (r *SupersetReconciler) updateStatus(ctx context.Context, superset *supersetv1alpha1.Superset) error {
+func (r *SupersetReconciler) updateStatus(ctx context.Context, superset *supersetv1alpha1.Superset, origSuperset *supersetv1alpha1.Superset) error {
 	superset.Status.ObservedGeneration = superset.Generation
 	superset.Status.Version = superset.Spec.Image.Tag
 
@@ -354,7 +363,7 @@ func (r *SupersetReconciler) updateStatus(ctx context.Context, superset *superse
 		superset.Status.Phase = phaseDegraded
 	}
 
-	return r.Status().Update(ctx, superset)
+	return patchStatusIfChanged(ctx, r.Client, superset, origSuperset, origSuperset.Status, superset.Status)
 }
 
 // getChildStatus reads a child CR's status using unstructured API.

--- a/internal/controller/supersetlifecycletask_controller.go
+++ b/internal/controller/supersetlifecycletask_controller.go
@@ -44,12 +44,20 @@ type SupersetLifecycleTaskReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder events.EventRecorder
+	// Now lets tests inject a deterministic clock for backoff timing.
+	Now func() time.Time
+}
+
+func (r *SupersetLifecycleTaskReconciler) now() time.Time {
+	if r.Now != nil {
+		return r.Now()
+	}
+	return time.Now()
 }
 
 // +kubebuilder:rbac:groups=superset.apache.org,resources=supersetlifecycletasks,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=superset.apache.org,resources=supersetlifecycletasks/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;delete
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch;update
 
 func (r *SupersetLifecycleTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -63,6 +71,9 @@ func (r *SupersetLifecycleTaskReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 
+	// Capture the server-side status for diffing; only patch if something changed.
+	origTaskCR := taskCR.DeepCopy()
+
 	log.Info("Reconciling SupersetLifecycleTask", "name", taskCR.Name)
 
 	// Run the init pod lifecycle.
@@ -72,9 +83,10 @@ func (r *SupersetLifecycleTaskReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, fmt.Errorf("reconciling init pod: %w", err)
 	}
 
-	// Update status.
+	// Update status only if something actually changed. ObservedGeneration
+	// is a frequent reason for a diff but is itself a meaningful update.
 	taskCR.Status.ObservedGeneration = taskCR.Generation
-	if err := r.Status().Update(ctx, taskCR); err != nil {
+	if err := patchStatusIfChanged(ctx, r.Client, taskCR, origTaskCR, origTaskCR.Status, taskCR.Status); err != nil {
 		return ctrl.Result{}, fmt.Errorf("updating status: %w", err)
 	}
 
@@ -109,6 +121,17 @@ func (r *SupersetLifecycleTaskReconciler) reconcileInitPod(ctx context.Context, 
 	if taskCR.Status.State == "" {
 		taskCR.Status.State = initStatePending
 		taskCR.Status.Image = image
+	}
+
+	// Honor backoff: if NextAttemptAt has been set from a previous failure
+	// and hasn't passed yet, wait without creating a pod. This prevents the
+	// Pod-delete owner watch from enqueuing a reconcile that bypasses the
+	// exponential backoff.
+	if taskCR.Status.NextAttemptAt != nil {
+		if remaining := taskCR.Status.NextAttemptAt.Sub(r.now()); remaining > 0 {
+			return ctrl.Result{RequeueAfter: remaining}, nil
+		}
+		taskCR.Status.NextAttemptAt = nil
 	}
 
 	// Look for an existing pod for this init task.
@@ -169,11 +192,14 @@ func (r *SupersetLifecycleTaskReconciler) reconcileInitPod(ctx context.Context, 
 			}
 
 			// Not exhausted -- delete the failed pod before retry.
+			backoff := calculateBackoff(taskCR.Status.Attempts)
+			next := metav1.NewTime(r.now().Add(backoff))
+			taskCR.Status.NextAttemptAt = &next
+
 			if err := r.Delete(ctx, existingPod); client.IgnoreNotFound(err) != nil {
 				return ctrl.Result{}, err
 			}
 
-			backoff := calculateBackoff(taskCR.Status.Attempts)
 			taskCR.Status.State = initStatePending
 			r.Recorder.Eventf(taskCR, nil, corev1.EventTypeWarning, "InitRetry", "Reconcile",
 				"Init failed (attempt %d/%d), retrying in %s", taskCR.Status.Attempts, maxRetries, backoff)
@@ -198,10 +224,12 @@ func (r *SupersetLifecycleTaskReconciler) reconcileInitPod(ctx context.Context, 
 							metav1.ConditionFalse, "InitTimedOut", taskCR.Status.Message, taskCR.Generation)
 						return ctrl.Result{}, nil
 					}
+					backoff := calculateBackoff(taskCR.Status.Attempts)
+					next := metav1.NewTime(r.now().Add(backoff))
+					taskCR.Status.NextAttemptAt = &next
 					if err := r.Delete(ctx, existingPod); client.IgnoreNotFound(err) != nil {
 						return ctrl.Result{}, err
 					}
-					backoff := calculateBackoff(taskCR.Status.Attempts)
 					taskCR.Status.State = initStatePending
 					return ctrl.Result{RequeueAfter: backoff}, nil
 				}
@@ -381,7 +409,6 @@ func (r *SupersetLifecycleTaskReconciler) SetupWithManager(mgr ctrl.Manager) err
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&supersetv1alpha1.SupersetLifecycleTask{}).
 		Owns(&corev1.Pod{}).
-		Owns(&corev1.ConfigMap{}).
 		Named("supersetlifecycletask").
 		Complete(r)
 }

--- a/internal/controller/supersetlifecycletask_controller_test.go
+++ b/internal/controller/supersetlifecycletask_controller_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -619,6 +620,125 @@ func TestInitReconcile_PodFailed_Retries(t *testing.T) {
 	}
 	if updatedCR.Status.State != initStatePending {
 		t.Errorf("expected state Pending (for retry), got %s", updatedCR.Status.State)
+	}
+}
+
+// TestInitReconcile_BackoffGatePreventsImmediateRecreate verifies that after a
+// pod fails and the controller schedules a retry via Status.NextAttemptAt, a
+// subsequent reconcile triggered within the backoff window (e.g., by the
+// Pod-delete owner watch) does not create a new Pod — it waits until the
+// backoff deadline passes.
+func TestInitReconcile_BackoffGatePreventsImmediateRecreate(t *testing.T) {
+	scheme := testScheme(t)
+	initCR := minimalInitCR()
+	initCR.Status.State = initStateRunning
+	initCR.Status.Attempts = 0
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-init-abc",
+			Namespace: "default",
+			Labels: map[string]string{
+				labelInitInstance: "test-init",
+				labelInitTask:     initTaskName,
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"}}},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(initCR, pod).
+		WithStatusSubresource(initCR).
+		Build()
+
+	frozen := time.Unix(1_700_000_000, 0).UTC()
+	r := &SupersetLifecycleTaskReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: events.NewFakeRecorder(10),
+		Now:      func() time.Time { return frozen },
+	}
+
+	// First reconcile: observes failure, schedules NextAttemptAt, deletes the pod.
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-init", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	if result.RequeueAfter <= 0 {
+		t.Fatalf("expected backoff requeue after failure, got %v", result.RequeueAfter)
+	}
+
+	afterFailCR := &supersetv1alpha1.SupersetLifecycleTask{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test-init", Namespace: "default"}, afterFailCR); err != nil {
+		t.Fatalf("get after fail: %v", err)
+	}
+	if afterFailCR.Status.NextAttemptAt == nil {
+		t.Fatal("expected NextAttemptAt to be set after failure")
+	}
+	if !afterFailCR.Status.NextAttemptAt.After(frozen) {
+		t.Errorf("expected NextAttemptAt to be in the future (now=%v), got %v", frozen, afterFailCR.Status.NextAttemptAt.Time)
+	}
+
+	// Second reconcile (still at `frozen` — delete-event race): must not create
+	// a new pod and must continue to requeue until the backoff expires.
+	result2, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-init", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("race reconcile: %v", err)
+	}
+	if result2.RequeueAfter <= 0 {
+		t.Errorf("expected positive requeue within backoff window, got %v", result2.RequeueAfter)
+	}
+
+	podList := &corev1.PodList{}
+	if err := c.List(context.Background(), podList, client.InNamespace("default"),
+		client.MatchingLabels{labelInitInstance: "test-init", labelInitTask: initTaskName}); err != nil {
+		t.Fatalf("list pods: %v", err)
+	}
+	// No live pod should exist (the failed one was deleted, no new one created).
+	for _, p := range podList.Items {
+		if p.DeletionTimestamp == nil {
+			t.Errorf("expected no live pod during backoff, found %s", p.Name)
+		}
+	}
+
+	// Advance past backoff; next reconcile should clear NextAttemptAt and
+	// create a new pod.
+	r.Now = func() time.Time { return afterFailCR.Status.NextAttemptAt.Add(time.Second) }
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-init", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("post-backoff reconcile: %v", err)
+	}
+
+	afterRetryCR := &supersetv1alpha1.SupersetLifecycleTask{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test-init", Namespace: "default"}, afterRetryCR); err != nil {
+		t.Fatalf("get after retry: %v", err)
+	}
+	if afterRetryCR.Status.NextAttemptAt != nil {
+		t.Errorf("expected NextAttemptAt to be cleared after pod recreated, got %v", afterRetryCR.Status.NextAttemptAt)
+	}
+	if err := c.List(context.Background(), podList, client.InNamespace("default"),
+		client.MatchingLabels{labelInitInstance: "test-init", labelInitTask: initTaskName}); err != nil {
+		t.Fatalf("list pods after retry: %v", err)
+	}
+	live := 0
+	for _, p := range podList.Items {
+		if p.DeletionTimestamp == nil {
+			live++
+		}
+	}
+	if live != 1 {
+		t.Errorf("expected exactly 1 live pod after backoff expires, found %d", live)
 	}
 }
 

--- a/internal/controller/supersetlifecycletask_controller_test.go
+++ b/internal/controller/supersetlifecycletask_controller_test.go
@@ -229,7 +229,7 @@ func TestGetInitRetentionPolicy(t *testing.T) {
 		{
 			"default",
 			&supersetv1alpha1.SupersetLifecycleTask{},
-			"Retain",
+			"RetainOnFailure",
 		},
 		{
 			"retain",
@@ -458,6 +458,9 @@ func TestInitReconcile_PodSucceeded_RetentionDeferredUntilNextReconcile(t *testi
 	initCR.Status.State = initStateRunning
 	now := metav1.Now()
 	initCR.Status.StartedAt = &now
+	// Pin retention to Retain so this test isolates the "deferred retention"
+	// semantics from whatever the chart default happens to be.
+	initCR.Spec.PodRetention = &supersetv1alpha1.PodRetentionSpec{Policy: strPtr("Retain")}
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -504,7 +507,7 @@ func TestInitReconcile_PodSucceeded_RetentionDeferredUntilNextReconcile(t *testi
 		t.Fatalf("reconcile 2: %v", err)
 	}
 
-	// Pod should still exist (default retention = Retain).
+	// Pod should still exist (explicit Retain policy above).
 	if err := c.List(context.Background(), podList); err != nil {
 		t.Fatalf("list pods: %v", err)
 	}
@@ -1154,7 +1157,7 @@ func TestApplyRetentionPolicy(t *testing.T) {
 		phase      corev1.PodPhase
 		wantDelete bool
 	}{
-		{"Default/Succeeded", nil, corev1.PodSucceeded, false},
+		{"Default/Succeeded", nil, corev1.PodSucceeded, true},
 		{"Default/Failed", nil, corev1.PodFailed, false},
 		{"Delete/Succeeded", strPtr("Delete"), corev1.PodSucceeded, true},
 		{"Delete/Failed", strPtr("Delete"), corev1.PodFailed, true},


### PR DESCRIPTION
## Summary

Addresses the findings from two rounds of external review covering both lifecycle reconcile correctness and the operator's own metrics endpoint. On the controller side: persisted retry backoff, scheduled-failure recovery, and a status patch-if-changed helper close several reconcile loops where bare-Pod ownership semantics were diverging from intent. On the observability side: the Kustomize cert-manager overlay and the Helm chart now both ship a working path from "self-signed default" to "cert-manager-managed mTLS for Prometheus scraping," with the documentation matching what's actually wired.

No CRD field deletions; one additive status field (`NextAttemptAt`).

## Details

### Lifecycle correctness

- **Pod-delete events no longer bypass exponential backoff.** Persist `SupersetLifecycleTaskStatus.NextAttemptAt` on failure/timeout. The controller refuses to create a new Pod until that timestamp passes, even when the Pod-delete owner watch enqueues an early reconcile.
- **Scheduled clone failures requeue at the next cron tick.** Replaced the negative-duration sentinel returned by `reconcileLifecycle` with an explicit `lifecycleResult{RequeueAfter, Complete, TerminalFailure}` struct; the parent now combines `TerminalFailure` with `nextScheduleRequeue` so a permanently-failed scheduled task still wakes up.
- **No-op reconciles stop bumping `resourceVersion`.** New `patchStatusIfChanged` helper deep-copies the original status, diff-checks via `equality.Semantic.DeepEqual`, and sends a `MergeFrom` patch only when something actually changed. Wired in at all six status-write sites (5 parent + 1 task).
- **Removed the misleading `Owns(&corev1.ConfigMap{})` watch** on the task controller — lifecycle ConfigMaps are owned by the parent, so the watch was inert. Dropped the matching unused RBAC marker.
- **Invalid cron schedules now gate clone execution.** `isTaskEnabled` returns `false` for clone when the schedule fails `schedule.Validate`, so `pruneDisabledTasks` deletes the stale CR. The user-facing signal (`ScheduleValid=False` condition + Warning event) is preserved. - **Stale lifecycle docs updated** — pipeline references in `docs/user-guide/lifecycle.md` now correctly include rotate.

### Operator metrics TLS

- **New Helm ServiceMonitor template**, gated on `metrics.serviceMonitor.enabled` (default off). The `tlsConfig` value is free-form, so users can pass CA/serverName for cert-manager TLS without a chart fork.
- **Helm chart can mount a cert-manager-issued Secret** when `metrics.certSecretName` is set: adds the volume, volumeMount, and `--metrics-cert-path*` args to the manager container. Without it, the chart keeps the controller-runtime self-signed flow.
- **Kustomize cert-manager overlay actually works.** Added `config/certmanager/{certificate-metrics.yaml, kustomization.yaml, kustomizeconfig.yaml}` — Issuer + Certificate producing `metrics-server-cert`, plus a `nameReference` config so Kustomize rewrites `issuerRef.name` after `namePrefix`. Rewrote `cert_metrics_manager_patch.yaml` so it creates `volumeMounts` / `volumes` instead of appending to non-existent arrays. Added the `[CERTMANAGER]`, `[METRICS-WITH-CERTS]`, and full `[PROMETHEUS-WITH-CERTS]` replacements in `config/default/kustomization.yaml`.
- **Dropped `cert` / `keySecret` from the ServiceMonitor TLS config** in both the Kustomize patch and the Helm docs example. The metrics endpoint authenticates scrapers via bearer token (TokenReview), not mTLS, so `ca` + `serverName` is sufficient and avoids spreading the serving private key into Prometheus pods.
- **New `## Operator Metrics` section** in `docs/user-guide/networking-and-monitoring.md` covering RBAC, the out-of-box self-signed flow, and concrete cert-manager setups for both install paths.