### PR TITLE
refactor: rename lifecycle conditions and tidying

### DIFF
--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -28,12 +28,13 @@ import (
 
 // Condition type constants for Superset resources.
 const (
-	ConditionTypeReady        = "Ready"
-	ConditionTypeProgressing  = "Progressing"
-	ConditionTypeDegraded     = "Degraded"
-	ConditionTypeSuspended    = "Suspended"
-	ConditionTypeInitComplete = "InitComplete"
-	ConditionTypeAvailable    = "Available"
+	ConditionTypeReady             = "Ready"
+	ConditionTypeProgressing       = "Progressing"
+	ConditionTypeDegraded          = "Degraded"
+	ConditionTypeSuspended         = "Suspended"
+	ConditionTypeAvailable         = "Available"
+	ConditionTypeTaskComplete      = "TaskComplete"      // on SupersetLifecycleTask
+	ConditionTypeLifecycleComplete = "LifecycleComplete" // on Superset (aggregate lifecycle gate)
 )
 
 // --- Image types ---

--- a/api/v1alpha1/superset_types.go
+++ b/api/v1alpha1/superset_types.go
@@ -790,7 +790,9 @@ type ComponentRefStatus struct {
 	Ready string `json:"ready"`
 	// Reference to the child CR.
 	Ref string `json:"ref"`
-	// Config checksum on the child.
+	// Checksum stamped on the child CR's spec by the parent. Drives rolling
+	// restarts; surfaced here so users can see which revision each child is
+	// reconciling against.
 	// +optional
 	ConfigChecksum string `json:"configChecksum,omitempty"`
 }

--- a/docs/architecture/internals.md
+++ b/docs/architecture/internals.md
@@ -388,9 +388,9 @@ status:
     - type: Available
       status: "True"
       reason: AllComponentsReady
-    - type: InitComplete
+    - type: LifecycleComplete
       status: "True"
-      reason: InitComplete
+      reason: LifecycleComplete
     - type: Suspended
       status: "False"
 ```

--- a/docs/contributing/development-guidelines.md
+++ b/docs/contributing/development-guidelines.md
@@ -232,7 +232,7 @@ the `#`-comment form:
 
 ### Do
 
-- **Use shared helpers** from `child_reconciler.go` (`reconcileChildConfigMap`, `reconcileChildDeployment`, `reconcileChildService`, `reconcileScaling`, `updateChildStatus`, `buildChecksumAnnotations`)
+- **Use shared helpers** from `child_reconciler.go` (`reconcileChildDeployment`, `reconcileChildService`, `reconcileScaling`, `updateChildStatus`, `buildChecksumAnnotations`). ConfigMaps are owned by the parent — use `reconcileParentOwnedConfigMap` from `superset_controller.go`.
 - **Use `componentLabels(component, instance)`** for consistent label generation
 - **Stamp `parentLabels(parentName)` on all parent-owned resources** (ServiceAccount, Ingress, HTTPRoute, ServiceMonitor) — this enables label-based cleanup
 - **Use `controllerutil.CreateOrUpdate`** for idempotent reconciliation

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -284,7 +284,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `ready` _string_ | "2/2" format showing ready vs desired replicas. |  |  |
 | `ref` _string_ | Reference to the child CR. |  |  |
-| `configChecksum` _string_ | Config checksum on the child. |  | Optional: \{\} <br /> |
+| `configChecksum` _string_ | Checksum stamped on the child CR's spec by the parent. Drives rolling<br />restarts; surfaced here so users can see which revision each child is<br />reconciling against. |  | Optional: \{\} <br /> |
 
 
 #### ComponentServiceSpec

--- a/internal/config/renderer.go
+++ b/internal/config/renderer.go
@@ -115,6 +115,10 @@ type ConfigInput struct {
 
 	// Per-component raw Python from component.config.
 	ComponentConfig string
+
+	// Resolved web-server container port. Zero means "use default". Only
+	// consulted for the web-server component; ignored elsewhere.
+	WebServerPort int32
 }
 
 // RenderConfig generates the superset_config.py content for a given component type.
@@ -176,7 +180,11 @@ func RenderConfig(componentType ComponentType, input *ConfigInput) string {
 
 	// Web server port (web server only).
 	if componentType == ComponentWebServer {
-		fmt.Fprintf(&b, "SUPERSET_WEBSERVER_PORT = %d\n", common.PortWebServer)
+		port := input.WebServerPort
+		if port == 0 {
+			port = common.PortWebServer
+		}
+		fmt.Fprintf(&b, "SUPERSET_WEBSERVER_PORT = %d\n", port)
 	}
 
 	b.WriteString("\n")

--- a/internal/config/renderer_test.go
+++ b/internal/config/renderer_test.go
@@ -41,6 +41,17 @@ func TestRenderConfig_WebServer(t *testing.T) {
 	assertContains(t, result, "WEBSERVER_THREADS = 16")
 }
 
+func TestRenderConfig_WebServer_CustomPort(t *testing.T) {
+	input := &ConfigInput{
+		MetastoreMode: MetastoreNone,
+		WebServerPort: 9090,
+	}
+
+	result := RenderConfig(ComponentWebServer, input)
+	assertContains(t, result, "SUPERSET_WEBSERVER_PORT = 9090")
+	assertNotContains(t, result, "SUPERSET_WEBSERVER_PORT = 8088")
+}
+
 func TestRenderConfig_PassthroughMetastore(t *testing.T) {
 	input := &ConfigInput{
 		MetastoreMode: MetastorePassthrough,

--- a/internal/controller/component_descriptors.go
+++ b/internal/controller/component_descriptors.go
@@ -51,7 +51,6 @@ type componentAccessor struct {
 // componentDescriptor captures all per-component variation needed to
 // reconcile a child CR from the parent Superset controller.
 type componentDescriptor struct {
-	suffix          string
 	componentType   naming.ComponentType
 	hasPythonConfig bool
 	kind            string
@@ -64,7 +63,7 @@ type componentDescriptor struct {
 }
 
 // childName returns the child CR name, which is always the parent name.
-func (d *componentDescriptor) childName(spec *supersetv1alpha1.SupersetSpec, parentName string) string {
+func (d *componentDescriptor) childName(_ *supersetv1alpha1.SupersetSpec, parentName string) string {
 	return parentName
 }
 
@@ -154,6 +153,16 @@ func (r *SupersetReconciler) reconcileComponent(
 	}
 
 	if accessor == nil {
+		// Component removed from spec: delete the parent-owned ConfigMap too.
+		// Child CR deletion cascades Deployments/Services via ownerRefs, but the
+		// ConfigMap is owned by the parent and would otherwise linger until the
+		// parent CR itself is deleted.
+		if desc.hasPythonConfig {
+			orphanBase := naming.ResourceBaseName(superset.Name, desc.componentType)
+			if err := reconcileParentOwnedConfigMap(ctx, r.Client, r.Scheme, superset, "", orphanBase); err != nil {
+				return fmt.Errorf("pruning ConfigMap for disabled %s: %w", desc.componentType, err)
+			}
+		}
 		return nil
 	}
 
@@ -170,6 +179,9 @@ func (r *SupersetReconciler) reconcileComponent(
 		compConfigInput := buildConfigInput(&superset.Spec)
 		if accessor.config != nil {
 			compConfigInput.ComponentConfig = *accessor.config
+		}
+		if desc.componentType == naming.ComponentWebServer {
+			compConfigInput.WebServerPort = resolveWebServerPort(superset)
 		}
 
 		// Compute SQLALCHEMY_ENGINE_OPTIONS per component.
@@ -286,7 +298,6 @@ func extractScalable(s *supersetv1alpha1.ScalableComponentSpec, config *string, 
 }
 
 var webServerDescriptor = &componentDescriptor{
-	suffix:          naming.SuffixWebServer,
 	componentType:   naming.ComponentWebServer,
 	hasPythonConfig: true,
 	kind:            "SupersetWebServer",
@@ -314,7 +325,6 @@ var webServerDescriptor = &componentDescriptor{
 }
 
 var celeryWorkerDescriptor = &componentDescriptor{
-	suffix:          naming.SuffixCeleryWorker,
 	componentType:   naming.ComponentCeleryWorker,
 	hasPythonConfig: true,
 	kind:            "SupersetCeleryWorker",
@@ -341,7 +351,6 @@ var celeryWorkerDescriptor = &componentDescriptor{
 }
 
 var celeryBeatDescriptor = &componentDescriptor{
-	suffix:          naming.SuffixCeleryBeat,
 	componentType:   naming.ComponentCeleryBeat,
 	hasPythonConfig: true,
 	kind:            "SupersetCeleryBeat",
@@ -373,7 +382,6 @@ var celeryBeatDescriptor = &componentDescriptor{
 }
 
 var celeryFlowerDescriptor = &componentDescriptor{
-	suffix:          naming.SuffixCeleryFlower,
 	componentType:   naming.ComponentCeleryFlower,
 	hasPythonConfig: true,
 	kind:            "SupersetCeleryFlower",
@@ -398,7 +406,6 @@ var celeryFlowerDescriptor = &componentDescriptor{
 }
 
 var mcpServerDescriptor = &componentDescriptor{
-	suffix:          naming.SuffixMcpServer,
 	componentType:   naming.ComponentMcpServer,
 	hasPythonConfig: true,
 	kind:            "SupersetMcpServer",
@@ -425,7 +432,6 @@ var mcpServerDescriptor = &componentDescriptor{
 }
 
 var websocketServerDescriptor = &componentDescriptor{
-	suffix:          naming.SuffixWebsocketServer,
 	componentType:   naming.ComponentWebsocketServer,
 	hasPythonConfig: false,
 	kind:            "SupersetWebsocketServer",

--- a/internal/controller/drain.go
+++ b/internal/controller/drain.go
@@ -72,7 +72,7 @@ func (r *SupersetReconciler) drainIfNeeded(
 		return lifecycleResult{}, fmt.Errorf("draining components: %w", err)
 	}
 	if !drained {
-		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
+		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeLifecycleComplete,
 			metav1.ConditionFalse, "Draining", "Scaling components to zero before lifecycle tasks", superset.Generation)
 		return lifecycleWait(), nil
 	}

--- a/internal/controller/lifecycle.go
+++ b/internal/controller/lifecycle.go
@@ -121,7 +121,7 @@ func (r *SupersetReconciler) reconcileLifecycle(
 		if err := r.cleanupMaintenanceResources(ctx, superset); err != nil {
 			return lifecycleResult{}, fmt.Errorf("cleaning up maintenance resources: %w", err)
 		}
-		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
+		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeLifecycleComplete,
 			metav1.ConditionTrue, "LifecycleDisabled", "Lifecycle tasks are disabled", superset.Generation)
 		superset.Status.Lifecycle = nil
 		return lifecycleComplete(), nil
@@ -162,7 +162,7 @@ func (r *SupersetReconciler) reconcileLifecycle(
 	// If no tasks are enabled, lifecycle is complete.
 	if !cloneEnabled && !migrateEnabled && !rotateEnabled && !initEnabled {
 		superset.Status.Lifecycle.Phase = lifecyclePhaseComplete
-		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
+		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeLifecycleComplete,
 			metav1.ConditionTrue, "LifecycleComplete", "Lifecycle tasks completed successfully", superset.Generation)
 		return lifecycleComplete(), nil
 	}
@@ -172,7 +172,7 @@ func (r *SupersetReconciler) reconcileLifecycle(
 	// deletion on reconciles triggered by child CR creation.
 	if r.allTasksStillComplete(superset, cloneEnabled, migrateEnabled, rotateEnabled, initEnabled, configChecksum) {
 		superset.Status.Lifecycle.Phase = lifecyclePhaseComplete
-		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
+		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeLifecycleComplete,
 			metav1.ConditionTrue, "LifecycleComplete", "Lifecycle tasks completed successfully", superset.Generation)
 		return lifecycleComplete(), nil
 	}
@@ -261,7 +261,7 @@ func (r *SupersetReconciler) finalizeLifecycle(
 		}
 	}
 
-	setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
+	setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeLifecycleComplete,
 		metav1.ConditionTrue, "LifecycleComplete", "Lifecycle tasks completed successfully", superset.Generation)
 	return nil
 }
@@ -369,7 +369,7 @@ func (r *SupersetReconciler) checkUpgradeGates(
 
 	if direction == DirectionDowngrade {
 		log.Info("Downgrade detected, blocking lifecycle", "from", oldTag, "to", newTag)
-		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
+		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeLifecycleComplete,
 			metav1.ConditionFalse, "DowngradeBlocked",
 			fmt.Sprintf("Downgrade from %s to %s is not supported. Alembic migrations are forward-only.", oldTag, newTag),
 			superset.Generation)
@@ -400,7 +400,7 @@ func (r *SupersetReconciler) checkUpgradeGates(
 		annotations := superset.GetAnnotations()
 		if annotations == nil || annotations[annotationApproveUpgrade] != "true" {
 			log.Info("Upgrade awaiting approval")
-			setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
+			setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeLifecycleComplete,
 				metav1.ConditionFalse, "AwaitingApproval",
 				fmt.Sprintf("Upgrade from %s to %s detected. Approve with: kubectl annotate superset %s %s=true",
 					superset.Status.Lifecycle.Upgrade.FromVersion,
@@ -492,7 +492,7 @@ func (r *SupersetReconciler) reconcileLifecycleTask(
 			return lifecycleResult{}, fmt.Errorf("creating SupersetLifecycleTask %s: %w", childName, err)
 		}
 		log.Info("Created lifecycle task CR", "task", taskType)
-		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
+		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeLifecycleComplete,
 			metav1.ConditionFalse, "TaskInProgress", fmt.Sprintf("%s task is in progress", taskType), superset.Generation)
 		return lifecycleWait(), nil
 	}
@@ -555,7 +555,7 @@ func (r *SupersetReconciler) reconcileLifecycleTask(
 		if child.Status.Attempts >= maxRetries {
 			if child.Status.ConfigChecksum == taskChecksum {
 				log.Info("Task permanently failed", "task", taskType)
-				setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
+				setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeLifecycleComplete,
 					metav1.ConditionFalse, "TaskFailed", fmt.Sprintf("%s: %s", taskType, child.Status.Message), superset.Generation)
 				superset.Status.Phase = phaseInitializing
 				return lifecycleTerminal(), nil
@@ -566,13 +566,13 @@ func (r *SupersetReconciler) reconcileLifecycleTask(
 			}
 			return lifecycleWait(), nil
 		}
-		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
+		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeLifecycleComplete,
 			metav1.ConditionFalse, "TaskRetrying", fmt.Sprintf("%s task is retrying", taskType), superset.Generation)
 		return lifecycleWait(), nil
 
 	default:
 		log.Info("Task not yet complete", "task", taskType, "state", child.Status.State)
-		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
+		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeLifecycleComplete,
 			metav1.ConditionFalse, "TaskInProgress", fmt.Sprintf("%s task is in progress", taskType), superset.Generation)
 		return lifecycleWait(), nil
 	}

--- a/internal/controller/maintenance.go
+++ b/internal/controller/maintenance.go
@@ -78,7 +78,7 @@ func (r *SupersetReconciler) reconcileMaintenancePageUp(
 ) (bool, error) {
 	log := logf.FromContext(ctx)
 	spec := superset.Spec.Lifecycle.MaintenancePage
-	port := resolveWebServerContainerPort(superset.Spec.WebServer)
+	port := resolveWebServerPort(superset)
 
 	// Step 1: Reconcile ConfigMap (managed mode only).
 	if !isCustomMode(spec) {

--- a/internal/controller/maintenance_test.go
+++ b/internal/controller/maintenance_test.go
@@ -94,36 +94,64 @@ func TestRenderNginxConf_UsesDefaultPort(t *testing.T) {
 	}
 }
 
-func TestResolveWebServerContainerPort_Default(t *testing.T) {
-	ws := &supersetv1alpha1.WebServerComponentSpec{}
-	port := resolveWebServerContainerPort(ws)
+func TestResolveWebServerPort_Default(t *testing.T) {
+	s := &supersetv1alpha1.Superset{
+		Spec: supersetv1alpha1.SupersetSpec{
+			WebServer: &supersetv1alpha1.WebServerComponentSpec{},
+		},
+	}
+	port := resolveWebServerPort(s)
 	if port != common.PortWebServer {
 		t.Errorf("expected default port %d, got %d", common.PortWebServer, port)
 	}
 }
 
-func TestResolveWebServerContainerPort_CustomPort(t *testing.T) {
-	ws := &supersetv1alpha1.WebServerComponentSpec{
-		ScalableComponentSpec: supersetv1alpha1.ScalableComponentSpec{
-			PodTemplate: &supersetv1alpha1.PodTemplate{
-				Container: &supersetv1alpha1.ContainerTemplate{
-					Ports: []corev1.ContainerPort{
-						{Name: "http", ContainerPort: 9090},
+func TestResolveWebServerPort_ComponentOverride(t *testing.T) {
+	s := &supersetv1alpha1.Superset{
+		Spec: supersetv1alpha1.SupersetSpec{
+			WebServer: &supersetv1alpha1.WebServerComponentSpec{
+				ScalableComponentSpec: supersetv1alpha1.ScalableComponentSpec{
+					PodTemplate: &supersetv1alpha1.PodTemplate{
+						Container: &supersetv1alpha1.ContainerTemplate{
+							Ports: []corev1.ContainerPort{
+								{Name: "http", ContainerPort: 9090},
+							},
+						},
 					},
 				},
 			},
 		},
 	}
-	port := resolveWebServerContainerPort(ws)
+	port := resolveWebServerPort(s)
 	if port != 9090 {
 		t.Errorf("expected custom port 9090, got %d", port)
 	}
 }
 
-func TestResolveWebServerContainerPort_Nil(t *testing.T) {
-	port := resolveWebServerContainerPort(nil)
+func TestResolveWebServerPort_TopLevelOverride(t *testing.T) {
+	s := &supersetv1alpha1.Superset{
+		Spec: supersetv1alpha1.SupersetSpec{
+			PodTemplate: &supersetv1alpha1.PodTemplate{
+				Container: &supersetv1alpha1.ContainerTemplate{
+					Ports: []corev1.ContainerPort{
+						{Name: "http", ContainerPort: 7070},
+					},
+				},
+			},
+			WebServer: &supersetv1alpha1.WebServerComponentSpec{},
+		},
+	}
+	port := resolveWebServerPort(s)
+	if port != 7070 {
+		t.Errorf("expected top-level port 7070 inherited, got %d", port)
+	}
+}
+
+func TestResolveWebServerPort_NoWebServer(t *testing.T) {
+	s := &supersetv1alpha1.Superset{}
+	port := resolveWebServerPort(s)
 	if port != common.PortWebServer {
-		t.Errorf("expected default port %d for nil spec, got %d", common.PortWebServer, port)
+		t.Errorf("expected default port %d for nil WebServer, got %d", common.PortWebServer, port)
 	}
 }
 

--- a/internal/controller/networking.go
+++ b/internal/controller/networking.go
@@ -34,6 +34,7 @@ import (
 
 	supersetv1alpha1 "github.com/apache/superset-kubernetes-operator/api/v1alpha1"
 	"github.com/apache/superset-kubernetes-operator/internal/common"
+	"github.com/apache/superset-kubernetes-operator/internal/resolution"
 )
 
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;create;update;patch;delete
@@ -116,7 +117,7 @@ func (r *SupersetReconciler) reconcileWebServerService(ctx context.Context, supe
 	}
 
 	svcSpec := superset.Spec.WebServer.Service
-	containerPort := resolveWebServerContainerPort(superset.Spec.WebServer)
+	containerPort := resolveWebServerPort(superset)
 	webServerLabels := componentLabels(string(common.ComponentWebServer), superset.Name)
 
 	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, svc, func() error {
@@ -141,11 +142,23 @@ func (r *SupersetReconciler) reconcileWebServerService(ctx context.Context, supe
 	return err
 }
 
-// resolveWebServerContainerPort returns the container port for the web-server,
-// falling back to the default if not overridden.
-func resolveWebServerContainerPort(ws *supersetv1alpha1.WebServerComponentSpec) int32 {
-	if ws != nil && ws.PodTemplate != nil && ws.PodTemplate.Container != nil && len(ws.PodTemplate.Container.Ports) > 0 {
-		return ws.PodTemplate.Container.Ports[0].ContainerPort
+// resolveWebServerPort returns the resolved web-server container port, taking
+// into account top-level and per-component pod template port overrides. Mirrors
+// the port resolution used by the generic child Service reconciler so the
+// parent-owned web-server Service, the rendered SUPERSET_WEBSERVER_PORT, and
+// the child CR's container port all agree.
+func resolveWebServerPort(superset *supersetv1alpha1.Superset) int32 {
+	if superset == nil || superset.Spec.WebServer == nil {
+		return common.PortWebServer
+	}
+	topLevel := convertTopLevelSpec(&superset.Spec)
+	accessor := webServerDescriptor.extract(&superset.Spec)
+	flat := resolution.ResolveChildSpec(
+		common.ComponentWebServer, topLevel, convertComponent(accessor),
+		nil, &resolution.OperatorInjected{},
+	)
+	if flat != nil && flat.PodTemplate != nil && flat.PodTemplate.Container != nil && len(flat.PodTemplate.Container.Ports) > 0 {
+		return flat.PodTemplate.Container.Ports[0].ContainerPort
 	}
 	return common.PortWebServer
 }

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -51,7 +51,7 @@ func setCondition(conditions *[]metav1.Condition, conditionType string, status m
 	now := metav1.Now()
 	for i, c := range *conditions {
 		if c.Type == conditionType {
-			if c.Status != status || c.Reason != reason || c.ObservedGeneration != observedGeneration {
+			if c.Status != status || c.Reason != reason || c.Message != message || c.ObservedGeneration != observedGeneration {
 				transitionTime := c.LastTransitionTime
 				if c.Status != status {
 					transitionTime = now

--- a/internal/controller/status_test.go
+++ b/internal/controller/status_test.go
@@ -96,6 +96,22 @@ func TestSetCondition_ReasonChangePreservesTransitionTime(t *testing.T) {
 	}
 }
 
+func TestSetCondition_MessageChangeUpdatesMessageNotTransitionTime(t *testing.T) {
+	ts := metav1.Now()
+	conditions := []metav1.Condition{
+		{Type: supersetv1alpha1.ConditionTypeReady, Status: metav1.ConditionFalse, Reason: "NotReady", Message: "old diagnostic", LastTransitionTime: ts, ObservedGeneration: 1},
+	}
+
+	setCondition(&conditions, supersetv1alpha1.ConditionTypeReady, metav1.ConditionFalse, "NotReady", "new diagnostic", 1)
+
+	if conditions[0].Message != "new diagnostic" {
+		t.Errorf("expected message updated to %q, got %q", "new diagnostic", conditions[0].Message)
+	}
+	if !conditions[0].LastTransitionTime.Equal(&ts) {
+		t.Errorf("expected LastTransitionTime preserved when only message changes")
+	}
+}
+
 func TestUpdateComponentStatusFromDeployment(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/controller/superset_controller.go
+++ b/internal/controller/superset_controller.go
@@ -387,10 +387,15 @@ func (r *SupersetReconciler) getChildStatus(ctx context.Context, namespace, chil
 
 	// Read the status.ready field from the unstructured object.
 	ready, _, _ := unstructured.NestedString(obj.Object, "status", "ready")
+	// Config checksum is stamped on child spec by the parent and drives
+	// rolling restarts. Surfacing it on parent status lets users confirm
+	// that a change has propagated to each child.
+	configChecksum, _, _ := unstructured.NestedString(obj.Object, "spec", "configChecksum")
 
 	return &supersetv1alpha1.ComponentRefStatus{
-		Ready: ready,
-		Ref:   kind + "/" + childName,
+		Ready:          ready,
+		Ref:            kind + "/" + childName,
+		ConfigChecksum: configChecksum,
 	}
 }
 

--- a/internal/controller/supersetlifecycletask_controller.go
+++ b/internal/controller/supersetlifecycletask_controller.go
@@ -171,8 +171,8 @@ func (r *SupersetLifecycleTaskReconciler) reconcileInitPod(ctx context.Context, 
 			taskCR.Status.Message = "Completed successfully"
 			taskCR.Status.ConfigChecksum = taskCR.Spec.ConfigChecksum
 
-			setCondition(&taskCR.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
-				metav1.ConditionTrue, "InitComplete", "Initialization completed successfully", taskCR.Generation)
+			setCondition(&taskCR.Status.Conditions, supersetv1alpha1.ConditionTypeTaskComplete,
+				metav1.ConditionTrue, "TaskComplete", "Task completed successfully", taskCR.Generation)
 
 			return ctrl.Result{}, nil
 
@@ -184,10 +184,10 @@ func (r *SupersetLifecycleTaskReconciler) reconcileInitPod(ctx context.Context, 
 			if taskCR.Status.Attempts >= maxRetries {
 				taskCR.Status.State = initStateFailed
 				taskCR.Status.ConfigChecksum = taskCR.Spec.ConfigChecksum
-				r.Recorder.Eventf(taskCR, nil, corev1.EventTypeWarning, "InitFailed", "Reconcile",
-					"Init failed after %d attempts: %s", taskCR.Status.Attempts, taskCR.Status.Message)
-				setCondition(&taskCR.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
-					metav1.ConditionFalse, "InitFailed", taskCR.Status.Message, taskCR.Generation)
+				r.Recorder.Eventf(taskCR, nil, corev1.EventTypeWarning, "TaskFailed", "Reconcile",
+					"Task failed after %d attempts: %s", taskCR.Status.Attempts, taskCR.Status.Message)
+				setCondition(&taskCR.Status.Conditions, supersetv1alpha1.ConditionTypeTaskComplete,
+					metav1.ConditionFalse, "TaskFailed", taskCR.Status.Message, taskCR.Generation)
 				return ctrl.Result{}, nil
 			}
 
@@ -201,27 +201,27 @@ func (r *SupersetLifecycleTaskReconciler) reconcileInitPod(ctx context.Context, 
 			}
 
 			taskCR.Status.State = initStatePending
-			r.Recorder.Eventf(taskCR, nil, corev1.EventTypeWarning, "InitRetry", "Reconcile",
-				"Init failed (attempt %d/%d), retrying in %s", taskCR.Status.Attempts, maxRetries, backoff)
-			setCondition(&taskCR.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
-				metav1.ConditionFalse, "InitRetrying", fmt.Sprintf("Retrying after attempt %d", taskCR.Status.Attempts), taskCR.Generation)
+			r.Recorder.Eventf(taskCR, nil, corev1.EventTypeWarning, "TaskRetry", "Reconcile",
+				"Task failed (attempt %d/%d), retrying in %s", taskCR.Status.Attempts, maxRetries, backoff)
+			setCondition(&taskCR.Status.Conditions, supersetv1alpha1.ConditionTypeTaskComplete,
+				metav1.ConditionFalse, "TaskRetrying", fmt.Sprintf("Retrying after attempt %d", taskCR.Status.Attempts), taskCR.Generation)
 			return ctrl.Result{RequeueAfter: backoff}, nil
 
 		case corev1.PodRunning, corev1.PodPending:
 			taskCR.Status.State = initStateRunning
 			// Check timeout.
 			if taskCR.Status.StartedAt != nil {
-				if time.Since(taskCR.Status.StartedAt.Time) > timeout {
+				if r.now().Sub(taskCR.Status.StartedAt.Time) > timeout {
 					log.Info("Init pod timed out", "timeout", timeout)
 					taskCR.Status.Message = fmt.Sprintf("Timed out after %s", timeout)
 					taskCR.Status.Attempts++
 					if taskCR.Status.Attempts >= maxRetries {
 						taskCR.Status.State = initStateFailed
 						taskCR.Status.ConfigChecksum = taskCR.Spec.ConfigChecksum
-						r.Recorder.Eventf(taskCR, nil, corev1.EventTypeWarning, "InitFailed", "Reconcile",
-							"Init timed out after %d attempts", taskCR.Status.Attempts)
-						setCondition(&taskCR.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
-							metav1.ConditionFalse, "InitTimedOut", taskCR.Status.Message, taskCR.Generation)
+						r.Recorder.Eventf(taskCR, nil, corev1.EventTypeWarning, "TaskFailed", "Reconcile",
+							"Task timed out after %d attempts", taskCR.Status.Attempts)
+						setCondition(&taskCR.Status.Conditions, supersetv1alpha1.ConditionTypeTaskComplete,
+							metav1.ConditionFalse, "TaskTimedOut", taskCR.Status.Message, taskCR.Generation)
 						return ctrl.Result{}, nil
 					}
 					backoff := calculateBackoff(taskCR.Status.Attempts)
@@ -234,8 +234,8 @@ func (r *SupersetLifecycleTaskReconciler) reconcileInitPod(ctx context.Context, 
 					return ctrl.Result{RequeueAfter: backoff}, nil
 				}
 			}
-			setCondition(&taskCR.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
-				metav1.ConditionFalse, "InitInProgress", "Initialization is in progress", taskCR.Generation)
+			setCondition(&taskCR.Status.Conditions, supersetv1alpha1.ConditionTypeTaskComplete,
+				metav1.ConditionFalse, "TaskInProgress", "Task is in progress", taskCR.Generation)
 			return ctrl.Result{RequeueAfter: initRequeueInterval}, nil
 		}
 
@@ -275,11 +275,11 @@ func (r *SupersetLifecycleTaskReconciler) reconcileInitPod(ctx context.Context, 
 	taskCR.Status.Image = image
 	taskCR.Status.Message = ""
 
-	r.Recorder.Eventf(taskCR, nil, corev1.EventTypeNormal, "InitStarted", "Reconcile",
-		"Started init pod: %s", pod.Name)
+	r.Recorder.Eventf(taskCR, nil, corev1.EventTypeNormal, "TaskStarted", "Reconcile",
+		"Started task pod: %s", pod.Name)
 
-	setCondition(&taskCR.Status.Conditions, supersetv1alpha1.ConditionTypeInitComplete,
-		metav1.ConditionFalse, "InitInProgress", "Initialization is in progress", taskCR.Generation)
+	setCondition(&taskCR.Status.Conditions, supersetv1alpha1.ConditionTypeTaskComplete,
+		metav1.ConditionFalse, "TaskInProgress", "Task is in progress", taskCR.Generation)
 
 	return ctrl.Result{RequeueAfter: initRequeueInterval}, nil
 }


### PR DESCRIPTION
## Summary

Groups seven small cleanups into one PR. The only breaking change is the condition-type rename (item 1) — the rest are internal fixes, status plumbing, and documentation hygiene.

## Details

1. **Rename `InitComplete` condition** — split the misleading shared condition into two:
   - `SupersetLifecycleTask.status.conditions`: `InitComplete` → **`TaskComplete`**
   - `Superset.status.conditions`: `InitComplete` → **`LifecycleComplete`**
   The old name was a holdover from when the operator had only an "init" task. After the `SupersetInit → SupersetTask` refactor it was firing with "Initialization completed successfully" messages on clone, migrate, and rotate tasks — a lie. Event reasons (`InitStarted`/`InitFailed`/`InitRetry`) and condition reasons/messages were renamed to `TaskStarted`/`TaskFailed`/`TaskRetry` for consistency.
2. **Thread the injected clock through the task timeout branch.** `supersetlifecycletask_controller.go` now uses `r.now().Sub(...)` instead of `time.Since(...)`, matching the rest of the package and making timeout behaviour deterministic under a fake clock.
3. **Prune parent-owned Python ConfigMaps when a component is removed from spec.** Previously `reconcileComponent` returned early when the accessor was nil and the `{parent}-{component}` ConfigMap lingered until the parent CR itself was deleted.
4. **Unify the web-server port path.** A new `resolveWebServerPort(superset)` helper resolves the first container port from the merged top-level + component-level pod template (using the same resolution engine as the generic child Service path). It's now used consistently by:
   - the parent-owned web-server Service selector/port,
   - the maintenance page,
   - the rendered `SUPERSET_WEBSERVER_PORT` in `superset_config.py` (via a new `ConfigInput.WebServerPort` field).
   Previously a user-specified container port could desync from the Service target and the rendered config. Tests added in `renderer_test.go` and `maintenance_test.go` (top-level, component, and default cases).
5. **Populate `status.components.*.configChecksum`** by reading `spec.configChecksum` from each child CR via unstructured. The field was advertised in the API but left silently empty, making per-component rollout tracking impossible from `kubectl`.
6. **Housekeeping**: removed the unused `componentDescriptor.suffix` field (sub-resource suffixes flow through `naming.ResourceBaseName` from `componentType`), and fixed the stale `reconcileChildConfigMap` reference in the contributor docs — the current design has parent-owned ConfigMaps.
7. **Include `Message` in the `setCondition` update predicate.** Stale diagnostic messages could otherwise persist when status/reason/generation were unchanged. `LastTransitionTime` is still preserved on message-only edits.