### PR TITLE
chore(deps): add gomodtidy to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   "packageRules": [
     {
       "matchManagers": ["gomod"],
+      "postUpdateOptions": ["gomodTidy"],
       "groupName": "Go dependencies"
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,6 @@
     },
     {
       "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions",
       "pinDigests": true
     }
   ]


### PR DESCRIPTION
## Summary

Add a Renovate post update option to run `go mod tidy` after bumps to clean up `go.sum`. Also remove GHA grouping as individual actions may be blocked by the ASF allowlist.