### PR TITLE
docs: prefer typed featureFlags field and tone down landing-page copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ spec:
   webServer: {}
 ```
 
-> **Note**: The example above uses `environment: Development` for simplicity. In production (the default), use `secretKeyFrom` and `metastore.uriFrom` to reference Kubernetes Secrets. See the [User Guide](https://apache.github.io/superset-kubernetes-operator/user-guide/configuration/) and the [sample manifests](config/samples/) for production-ready examples.
+> **Note**: The example above uses `environment: Development` for simplicity. In production (the default), use `secretKeyFrom` and `metastore.uriFrom` to reference Kubernetes Secrets. See the [User Guide](https://apache.github.io/superset-kubernetes-operator/user-guide/configuration/) and the [sample manifests](config/samples/) for production examples.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ under the License.
 
 A Kubernetes operator for deploying and managing [Apache Superset](https://superset.apache.org/) on Kubernetes. Read the [documentation](https://apache.github.io/superset-kubernetes-operator/) to get started. Built with the Go-based [Operator SDK](https://sdk.operatorframework.io/).
 
-The operator is designed to make running Superset on Kubernetes as painless as possible. It works well out of the box with production-ready defaults, and every default is overridable when you need more control.
+The operator manages the full Superset lifecycle: database migrations, configuration rendering, component deployment, scaling, and networking. Defaults are tuned for typical deployments; presets, deployment-template fields, and a raw Python escape hatch let you override them where needed.
 
 ## Quick Start
 

--- a/docs/architecture/internals.md
+++ b/docs/architecture/internals.md
@@ -361,7 +361,7 @@ drain, the parent:
 > tunnel to a specific pod, not through the Service selector. When that pod is
 > deleted during drain, the tunnel breaks with a "lost connection to pod" error.
 > This does not affect Ingress/Gateway users — they route through EndpointSlices
-> and see seamless transitions. Restart port-forward to reconnect to the
+> and are unaffected. Restart port-forward to reconnect to the
 > maintenance pod.
 
 ### Alternatives Considered

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -255,7 +255,7 @@ spec:
       name: db-credentials
       key: password
   config: |
-    FEATURE_FLAGS = {"DASHBOARD_RBAC": True}
+    ROW_LIMIT = 10000
   celeryWorker:
     config: |
       CELERY_ANNOTATIONS = {"tasks.add": {"rate_limit": "10/s"}}
@@ -268,7 +268,7 @@ The celery worker's `superset_config.py` contains all three sections:
 SQLALCHEMY_DATABASE_URI = f"postgresql+psycopg2://..."  # assembled from env vars
 
 # Base config (spec.config)
-FEATURE_FLAGS = {"DASHBOARD_RBAC": True}
+ROW_LIMIT = 10000
 
 # Component config
 CELERY_ANNOTATIONS = {"tasks.add": {"rate_limit": "10/s"}}

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,9 +28,9 @@ The operator manages the full Superset lifecycle: database migrations, configura
 
 ## Features
 
-- **Sane defaults** — production-ready settings out of the box that adapt automatically to your workload
-- **Automatic config rendering** — structured fields for metastore, Valkey, Gunicorn, and Celery generate correct `superset_config.py` per component; config changes trigger rolling restarts
-- **Full control** — every default is overridable, from high-level presets down to individual container fields, with a raw Python escape hatch for anything not covered
+- **Sensible defaults** — defaults adjust based on the components and presets you configure
+- **Automatic config rendering** — structured fields for metastore, Valkey, Gunicorn, and Celery generate `superset_config.py` per component; config changes trigger rolling restarts
+- **Configurable** — defaults can be overridden at the preset, deployment-template, or container level, with a raw Python escape hatch in `spec.config`/`spec.<component>.config` for settings not surfaced as typed fields
 - **Component toggle** — enable CeleryWorker, CeleryBeat, CeleryFlower, WebsocketServer, or McpServer by setting their spec; omit to disable
 - **Maintenance-backed upgrades** — when database migrations need to run, the operator drains components, runs the lifecycle tasks, and restores traffic only after the new version is healthy; an optional maintenance page can serve users during the window when configured
 - **Lifecycle automation** — database cloning, schema migrations, secret key rotation, and application init run as sequenced tasks with automatic change detection and checksum-based re-execution
@@ -58,8 +58,8 @@ spec:
     database: superset
     username: superset
     password: superset
-  config: |
-    FEATURE_FLAGS = {"ENABLE_TEMPLATE_PROCESSING": True}
+  featureFlags:
+    ENABLE_TEMPLATE_PROCESSING: true
   webServer:
     replicas: 2
   mcpServer: {}
@@ -86,8 +86,8 @@ spec:
     uriFrom:
       name: db-credentials
       key: connection-string
-  config: |
-    FEATURE_FLAGS = {"ENABLE_TEMPLATE_PROCESSING": True}
+  featureFlags:
+    ENABLE_TEMPLATE_PROCESSING: true
   webServer:
     replicas: 2
   mcpServer: {}

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ The operator manages the full Superset lifecycle: database migrations, configura
 - **Maintenance-backed upgrades** — when database migrations need to run, the operator drains components, runs the lifecycle tasks, and restores traffic only after the new version is healthy; an optional maintenance page can serve users during the window when configured
 - **Lifecycle automation** — database cloning, schema migrations, secret key rotation, and application init run as sequenced tasks with automatic change detection and checksum-based re-execution
 - **Networking** — Gateway API (HTTPRoute) and Ingress support with per-component routing
-- **Production hardening** — HPA with custom metrics, PodDisruptionBudgets, NetworkPolicies, Prometheus ServiceMonitor
+- **Scaling and resilience** — HPA with custom metrics, PodDisruptionBudgets, NetworkPolicies, Prometheus ServiceMonitor
 - **Flexible install scope** — cluster-scoped (default) or namespace-scoped; the namespace-scoped Helm install renders no manager `ClusterRole` at all, so it works on restricted clusters that forbid cluster-scoped RBAC
 
 ## What it looks like

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -40,8 +40,8 @@ spec:
   secretKey: thisIsNotSecure_changeInProduction!
   metastore:
     uri: postgresql+psycopg2://superset:superset@postgres:5432/superset
-  config: |
-    FEATURE_FLAGS = {"ENABLE_TEMPLATE_PROCESSING": True}
+  featureFlags:
+    ENABLE_TEMPLATE_PROCESSING: true
   webServer: {}
   lifecycle:
     init:
@@ -64,8 +64,10 @@ spec:
     uriFrom:
       name: db-credentials
       key: connection-string
+  featureFlags:
+    DASHBOARD_RBAC: true
+    ALERT_REPORTS: true
   config: |
-    FEATURE_FLAGS = {"DASHBOARD_RBAC": True, "ALERT_REPORTS": True}
     ROW_LIMIT = 10000
   webServer: {}
 ```
@@ -301,8 +303,8 @@ The operator exposes a curated set of knobs as typed CRD fields — anything tie
 spec:
   # Base config: appended to ALL Python components
   config: |
-    FEATURE_FLAGS = {"ENABLE_TEMPLATE_PROCESSING": True}
     ROW_LIMIT = 10000
+    LOG_LEVEL = "INFO"
 
   # Component config: appended after base config for this component only
   celeryWorker:
@@ -310,7 +312,7 @@ spec:
       CELERY_ANNOTATIONS = {"tasks.add": {"rate_limit": "10/s"}}
 ```
 
-Both fields are **concatenated**, not mutually exclusive. In this example, the celery worker's `superset_config.py` contains the operator-generated configs (`SECRET_KEY`, structured DB URI if applicable), then the base config (FEATURE_FLAGS, ROW_LIMIT), then the component config (CELERY_ANNOTATIONS). The web server receives only the operator-generated configs and the base config, since it has no component-specific `config` field set.
+Both fields are **concatenated**, not mutually exclusive. In this example, the celery worker's `superset_config.py` contains the operator-generated configs (`SECRET_KEY`, structured DB URI if applicable), then the base config (`ROW_LIMIT`, `LOG_LEVEL`), then the component config (`CELERY_ANNOTATIONS`). The web server receives only the operator-generated configs and the base config, since it has no component-specific `config` field set.
 
 See [Config Rendering Pipeline](../architecture/overview.md#config-rendering-pipeline) for the full rendering order and an example of the generated output.
 

--- a/docs/user-guide/migration.md
+++ b/docs/user-guide/migration.md
@@ -249,8 +249,8 @@ spec:
   valkey:
     host: valkey
     port: 6379
-  config: |
-    FEATURE_FLAGS = {"ALERT_REPORTS": True}
+  featureFlags:
+    ALERT_REPORTS: true
   webServer:
     replicas: 2
   celeryWorker:

--- a/docs/user-guide/networking-and-monitoring.md
+++ b/docs/user-guide/networking-and-monitoring.md
@@ -129,7 +129,7 @@ subjects:
     namespace: monitoring
 ```
 
-**TLS — out of the box.** The operator generates a self-signed certificate at
+**TLS by default.** The operator generates a self-signed certificate at
 startup, so scrapers connect over HTTPS with `insecureSkipVerify: true`. This
 is the default in both the Kustomize ServiceMonitor (`config/prometheus/monitor.yaml`)
 and the Helm chart. It's fine for a trusted cluster but not for


### PR DESCRIPTION
## Summary

- Switched docs examples that demonstrated feature-flag setup via raw `config: | FEATURE_FLAGS = {...}` to use the typed `spec.featureFlags` field, so the docs stop steering readers toward the escape hatch when a typed field exists.
- Where an example exists specifically to demonstrate the raw Python `config:` escape hatch, swapped the `FEATURE_FLAGS` line for a non-typed setting (`ROW_LIMIT`, `LOG_LEVEL`) so the example doesn't model a use case the typed field already covers.
- Tightened a few intro/landing paragraphs in `README.md` and `docs/index.md` that read like marketing copy ("painless as possible", "production-ready settings out of the box", "every default is overridable"), bringing them closer to the project's matter-of-fact docs convention.