### PR TITLE
ci: make kind release notes the sole source of truth for kindest/node digests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,8 +211,9 @@ test-integration: manifests generate fmt vet setup-envtest ## Run integration te
 # CertManager is installed by default; skip with:
 # - CERT_MANAGER_INSTALL_SKIP=true
 KIND_CLUSTER ?= superset-kubernetes-operator-test-e2e
-# Keep in sync with the first entry of .github/supported-k8s.json (Renovate manages the digest).
-KIND_NODE_IMAGE ?= kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f
+# Derived from .github/supported-k8s.json (the canonical kindest/node pin,
+# regenerated from the kind release notes by `make sync-supported-versions`).
+KIND_NODE_IMAGE ?= $(shell jq -r '.supported[0].node_image' .github/supported-k8s.json)
 
 .PHONY: setup-test-e2e
 setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist

--- a/renovate.json
+++ b/renovate.json
@@ -25,15 +25,6 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Track kindest/node image digests in .github/supported-k8s.json",
-      "managerFilePatterns": ["/^\\.github/supported-k8s\\.json$/"],
-      "matchStrings": [
-        "\"node_image\":\\s*\"(?<depName>kindest/node):(?<currentValue>[^@\"]+)@(?<currentDigest>sha256:[a-f0-9]+)\""
-      ],
-      "datasourceTemplate": "docker"
-    },
-    {
-      "customType": "regex",
       "description": "Track sigs.k8s.io/kind release pin and matching sha256 in workflows",
       "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
       "matchStrings": [

--- a/scripts/sync-supported-versions.sh
+++ b/scripts/sync-supported-versions.sh
@@ -23,6 +23,11 @@
 #   - `next`      = {minor, version} of the newest stable Kubernetes release if
 #                   its minor isn't already in `supported`; otherwise null.
 #
+# The kind GitHub release notes are the sole source of truth for node-image
+# digests. Docker Hub re-pushes of the `kindest/node:vX.Y.Z` tag are
+# intentionally ignored: a new digest there does not represent a kind release,
+# and tracking it would conflict with this script.
+#
 # Usage:
 #   sync-supported-versions.sh [--check|--write]
 #


### PR DESCRIPTION
## Summary

- Drop Renovate's `kindest/node` digest customManager. Docker Hub periodically re-pushes the `kindest/node:vX.Y.Z` tag with a new digest, which Renovate treated as an update and proposed against `.github/supported-k8s.json` — but `scripts/sync-supported-versions.sh` derives digests from the kind GitHub release notes, so every such PR fails `make verify-supported-versions` and reverts on `make sync-supported-versions`.
- Make `.github/supported-k8s.json` (regenerated from kind release notes) the single source of truth: derive `KIND_NODE_IMAGE` in the Makefile via `jq` instead of a hardcoded duplicate that Renovate never actually managed despite the comment claiming it did.
- Document the policy in the sync-script header so future contributors don't reintroduce a Docker-Hub-tracking manager.

## Details

The kind release notes pin a specific `kindest/node:vX.Y.Z@sha256:…` per minor — this is the digest kind itself was released and tested against. Docker Hub tag re-pushes are not kind releases, so following them produces churn without value and conflicts with the release-notes-driven sync script.

After this change:

- Renovate continues to bump `KIND_VERSION` in `.github/workflows/test.yaml` (the other customManager is preserved). The `kubernetes-sigs/kind` `packageRule` already prompts the reviewer to run `make sync-supported-versions && make codegen` after a kind bump.
- `KIND_NODE_IMAGE` in the Makefile is derived from `.github/supported-k8s.json` at evaluation time, eliminating a second place that could drift.
- The currently-open `renovate/kindest-node-v1.35.0` PR (and any future Docker-Hub-tag-rebump PRs) can be closed and won't reopen.