### PR TITLE
fix(ci): source kind binary checksum from kind release asset

### DIFF
--- a/.github/supported-k8s.json
+++ b/.github/supported-k8s.json
@@ -1,4 +1,6 @@
 {
+  "kind_version": "v0.31.0",
+  "kind_checksum": "eb244cbafcc157dff60cf68693c14c9a75c4e6e6fedaf9cd71c58117cb93e3fa",
   "supported": [
     {
       "minor": "1.35",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,10 +24,9 @@ on:
 permissions:
   contents: read
 
-env:
-  # kind version + checksum are bumped in lockstep by Renovate (see renovate.json).
-  KIND_VERSION: v0.31.0
-  KIND_CHECKSUM: eb244cbafcc157dff60cf68693c14c9a75c4e6e6fedaf9cd71c58117cb93e3fa
+# kind_version + kind_checksum live in .github/supported-k8s.json and are kept
+# in sync with the kind release by `scripts/sync-supported-versions.sh`. The
+# install steps below read them via jq.
 
 jobs:
   unit-integration:
@@ -85,6 +84,8 @@ jobs:
           go-version-file: go.mod
       - name: Install kind
         run: |
+          KIND_VERSION=$(jq -r .kind_version .github/supported-k8s.json)
+          KIND_CHECKSUM=$(jq -r .kind_checksum .github/supported-k8s.json)
           curl -fsSLo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
           echo "${KIND_CHECKSUM}  ./kind" | sha256sum -c -
           chmod +x ./kind
@@ -111,6 +112,8 @@ jobs:
           go-version-file: go.mod
       - name: Install kind
         run: |
+          KIND_VERSION=$(jq -r .kind_version .github/supported-k8s.json)
+          KIND_CHECKSUM=$(jq -r .kind_checksum .github/supported-k8s.json)
           curl -fsSLo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
           echo "${KIND_CHECKSUM}  ./kind" | sha256sum -c -
           chmod +x ./kind

--- a/renovate.json
+++ b/renovate.json
@@ -25,10 +25,10 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Track sigs.k8s.io/kind release pin and matching sha256 in workflows",
-      "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
+      "description": "Track sigs.k8s.io/kind release pin in supported-k8s.json",
+      "managerFilePatterns": ["/^\\.github/supported-k8s\\.json$/"],
       "matchStrings": [
-        "KIND_VERSION:\\s*(?<currentValue>v[0-9.]+)\\s*\\n\\s*KIND_CHECKSUM:\\s*(?<currentDigest>[a-f0-9]+)"
+        "\"kind_version\":\\s*\"(?<currentValue>v[0-9.]+)\""
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "kubernetes-sigs/kind"

--- a/scripts/sync-supported-versions.sh
+++ b/scripts/sync-supported-versions.sh
@@ -14,19 +14,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Sync .github/supported-k8s.json with the kindest/node images published
-# by the currently pinned kind release (read from .github/workflows/test.yaml),
-# and compute `next` from upstream Kubernetes releases:
+# Sync .github/supported-k8s.json with the kind release pinned in the same
+# file (`kind_version`), and compute `next` from upstream Kubernetes releases:
 #
-#   - `supported` = the two newest Kubernetes minors that the pinned kind
-#     release ships node images for (highest patch per minor).
-#   - `next`      = {minor, version} of the newest stable Kubernetes release if
-#                   its minor isn't already in `supported`; otherwise null.
+#   - `kind_checksum` = SHA-256 of the `kind-linux-amd64` binary, taken from
+#                       the matching `.sha256sum` asset on the kind release.
+#   - `supported`     = the two newest Kubernetes minors that the pinned kind
+#                       release ships node images for (highest patch per minor).
+#   - `next`          = {minor, version} of the newest stable Kubernetes release
+#                       if its minor isn't already in `supported`; otherwise null.
 #
-# The kind GitHub release notes are the sole source of truth for node-image
-# digests. Docker Hub re-pushes of the `kindest/node:vX.Y.Z` tag are
-# intentionally ignored: a new digest there does not represent a kind release,
-# and tracking it would conflict with this script.
+# The kind GitHub release is the sole source of truth: node-image digests come
+# from the release notes body, and the kind binary checksum comes from the
+# release's `kind-linux-amd64.sha256sum` asset. Docker Hub re-pushes of the
+# `kindest/node:vX.Y.Z` tag are intentionally ignored: a new digest there does
+# not represent a kind release, and tracking it would conflict with this script.
 #
 # Usage:
 #   sync-supported-versions.sh [--check|--write]
@@ -40,7 +42,6 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SOURCE="${REPO_ROOT}/.github/supported-k8s.json"
-WORKFLOW="${REPO_ROOT}/.github/workflows/test.yaml"
 
 mode="${1:---check}"
 case "${mode}" in --check|--write) ;; *) echo "usage: $0 [--check|--write]" >&2; exit 2 ;; esac
@@ -48,14 +49,26 @@ case "${mode}" in --check|--write) ;; *) echo "usage: $0 [--check|--write]" >&2;
 command -v jq >/dev/null   || { echo "jq required" >&2; exit 1; }
 command -v curl >/dev/null || { echo "curl required" >&2; exit 1; }
 
-KIND_VERSION="$(awk '/^[[:space:]]*KIND_VERSION:/ {print $2; exit}' "${WORKFLOW}")"
-[ -n "${KIND_VERSION}" ] || { echo "could not read KIND_VERSION from ${WORKFLOW}" >&2; exit 1; }
+KIND_VERSION="$(jq -r '.kind_version // ""' "${SOURCE}")"
+[ -n "${KIND_VERSION}" ] || { echo "could not read kind_version from ${SOURCE}" >&2; exit 1; }
 
 api="https://api.github.com/repos/kubernetes-sigs/kind/releases/tags/${KIND_VERSION}"
 auth=()
 [ -n "${GITHUB_TOKEN:-}" ] && auth=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
 
-body="$(curl -fsSL ${auth[@]+"${auth[@]}"} -H 'Accept: application/vnd.github+json' "${api}" | jq -r .body)"
+release="$(curl -fsSL ${auth[@]+"${auth[@]}"} -H 'Accept: application/vnd.github+json' "${api}")"
+body="$(printf '%s' "${release}" | jq -r .body)"
+
+# Resolve the kind-linux-amd64.sha256sum asset's download URL via the API
+# (works even when releases are behind authenticated CDNs locally) and parse
+# out the 64-hex digest. The .sha256sum file has the format "<sha>  <name>".
+sha_url="$(printf '%s' "${release}" \
+  | jq -r '.assets[] | select(.name == "kind-linux-amd64.sha256sum") | .browser_download_url')"
+[ -n "${sha_url}" ] || { echo "kind release ${KIND_VERSION} has no kind-linux-amd64.sha256sum asset" >&2; exit 1; }
+
+KIND_CHECKSUM="$(curl -fsSL ${auth[@]+"${auth[@]}"} "${sha_url}" | awk '{print $1; exit}')"
+printf '%s' "${KIND_CHECKSUM}" | grep -Eq '^[a-f0-9]{64}$' \
+  || { echo "unexpected sha256sum content from ${sha_url}: ${KIND_CHECKSUM}" >&2; exit 1; }
 
 # Extract the highest-patch node image per Kubernetes minor, then take the
 # top two minors. Format per row: "MINOR FULL_IMAGE".
@@ -84,10 +97,12 @@ newest_k8s_minor="$(printf '%s' "${newest_k8s}" | sed -E 's|^v([0-9]+\.[0-9]+).*
 
 new_json="$(
   jq --argjson sup "${new_supported}" \
+     --arg     kindChecksum "${KIND_CHECKSUM}" \
      --arg     k8sMinor "${newest_k8s_minor}" \
      --arg     k8sVersion "${newest_k8s}" '
     def to_v: split(".") | map(tonumber);
-    (.supported = $sup)
+    (.kind_checksum = $kindChecksum)
+    | (.supported = $sup)
     | ([.supported[].minor | to_v] | max) as $topSupported
     | ($k8sMinor | to_v) as $k8s
     | if $k8s > $topSupported


### PR DESCRIPTION
## Summary

Fixes a latent bug in the Renovate custom manager added in #77 that broke kind release bumps. PR #81 ("update kubernetes-sigs/kind digest to a323333") replaced `KIND_CHECKSUM` with the kind tag's git commit SHA (40 hex), causing `sha256sum -c -` in the e2e Install kind step to fail with *"no properly formatted checksum lines found"*.

The previous regex manager captured `KIND_CHECKSUM` as `currentDigest` on the `github-releases` datasource — but that datasource only exposes the **git commit SHA** of the release tag, never the SHA-256 of any release artifact. The bug was dormant since #77 because no kind release fired the manager.

#83 is unrelated to this break: it only refactored the `kindest/node` digest manager.

## Details

Applies #83's "kind release is the single source of truth" principle to the kind binary checksum:

- `.github/supported-k8s.json` gains `kind_version` and `kind_checksum` top-level fields. `.github/workflows/test.yaml` drops its `env:` block; both Install kind steps read both values via `jq` from the JSON.
- `scripts/sync-supported-versions.sh` now reads `kind_version` from the JSON (instead of from the workflow), fetches the matching `kind-linux-amd64.sha256sum` asset from the kind GitHub release, validates the 64-hex digest, and writes `kind_checksum` alongside the existing `supported` and `next` fields. The script's source of truth for the digest is the same artifact CI verifies against — deterministic by construction.
- `renovate.json`'s custom manager now matches only `kind_version` in the JSON (no `currentDigest`). Renovate bumps the version; the existing prBodyNotes already direct reviewers to run `make sync-supported-versions && make codegen`, which now also regenerates `kind_checksum`. The `verify-supported-versions` CI gate keeps the JSON honest.

After this lands, close #81; Renovate's next scheduled run will open a clean version-only PR.