### PR TITLE
docs: pre-0.1.0 release-audit cleanup (versions, RBAC, tags)

### DIFF
--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -15,11 +15,12 @@ spec:
       scheme: https
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
-        # TODO(user): The option insecureSkipVerify: true is not recommended for production since it disables
-        # certificate verification, exposing the system to potential man-in-the-middle attacks.
-        # For production environments, it is recommended to use cert-manager for automatic TLS certificate management.
-        # To apply this configuration, enable cert-manager and use the patch located at config/prometheus/servicemonitor_tls_patch.yaml,
-        # which securely references the certificate from the 'metrics-server-cert' secret.
+        # Note: insecureSkipVerify: true disables certificate verification,
+        # exposing scrapes to potential man-in-the-middle attacks. It ships
+        # enabled so Prometheus can scrape the manager's self-signed serving
+        # certificate out of the box. For production, enable cert-manager and
+        # apply the patch at config/prometheus/servicemonitor_tls_patch.yaml,
+        # which references the certificate from the 'metrics-server-cert' secret.
         insecureSkipVerify: true
   selector:
     matchLabels:

--- a/config/samples/superset_v1alpha1_superset_prod.yaml
+++ b/config/samples/superset_v1alpha1_superset_prod.yaml
@@ -29,7 +29,7 @@ metadata:
   name: superset
 spec:
   image:
-    tag: "6.0.1"
+    tag: "6.1.0"
   secretKeyFrom:
     name: superset-secret
     key: secret-key

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,11 +33,13 @@ Superset instance using dev mode.
 ```bash
 helm install superset-operator \
   oci://ghcr.io/apache/superset-kubernetes-operator/charts/superset-operator \
-  --version 0.0.0-dev \
+  --version <version> \
   --namespace superset-operator-system \
-  --create-namespace \
-  --set image.pullPolicy=Always
+  --create-namespace
 ```
+
+Replace `<version>` with a published chart version (e.g., `0.1.0`); see
+[Downloads](reference/downloads.md) for published tags.
 
 ## 2. Deploy Superset
 
@@ -52,7 +54,7 @@ metadata:
 spec:
   environment: Development
   image:
-    tag: "6.0.1"
+    tag: "6.1.0"
   secretKey: thisIsNotSecure_changeInProduction!
   metastore:
     uri: postgresql+psycopg2://superset:superset@postgres:5432/superset

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,7 +91,7 @@ metadata:
   name: my-superset
 spec:
   image:
-    tag: "6.0.1"
+    tag: "6.1.0"
   secretKeyFrom:
     name: superset-secret
     key: secret-key

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -269,7 +269,7 @@ across namespaces. Each permission is justified below:
 | `serviceaccounts` | CRUD | Creates per-instance ServiceAccount for pod identity |
 | `pods` | get, list, watch | Reads Job pods to verify drain progress and component readiness |
 | `jobs` | CRUD | Manages deterministic lifecycle task Jobs |
-| `events` | create, patch | Records reconciliation events |
+| `events` | create, patch, update | Records reconciliation events |
 | `deployments` | CRUD | Manages component Deployments |
 | `horizontalpodautoscalers` | CRUD | Manages HPA for scalable components |
 | `poddisruptionbudgets` | CRUD | Manages PDBs for availability |
@@ -277,7 +277,8 @@ across namespaces. Each permission is justified below:
 | `httproutes` | CRUD | Optional Gateway API support |
 | `servicemonitors` | CRUD | Optional Prometheus integration |
 | `tokenreviews`, `subjectaccessreviews` | create | Metrics endpoint auth/authz (controller-runtime secure metrics) |
-| `supersets` + `supersets/status` | get, list, watch, update, patch + status update | Reads `Superset` CRs and updates status |
+| `supersets` | get, list, watch | Reads `Superset` CRs (no write access to the CR spec) |
+| `supersets/status` | get, update, patch | Updates reconciliation status only |
 
 The operator does **not** request:
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -56,7 +56,7 @@ Use `secretKeyFrom` and `metastore.uriFrom` to reference Kubernetes Secrets. The
 ```yaml
 spec:
   image:
-    tag: "6.0.1"
+    tag: "6.1.0"
   secretKeyFrom:
     name: superset-secret
     key: secret-key
@@ -836,7 +836,7 @@ podTemplate                         → PodSpec-level
 ```yaml
 spec:
   image:
-    tag: "6.0.1"
+    tag: "6.1.0"
   webServer:
     replicas: 2
 ```

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -156,7 +156,7 @@ metadata:
   name: my-superset
 spec:
   image:
-    tag: "6.0.1"
+    tag: "6.1.0"
 
   secretKeyFrom:
     name: superset-secrets
@@ -224,7 +224,7 @@ metadata:
   name: my-superset
 spec:
   image:
-    tag: "6.0.1"
+    tag: "6.1.0"
 
   secretKeyFrom:
     name: superset-secrets


### PR DESCRIPTION
## Summary

Pre-release cleanup surfaced by a full release-readiness audit ahead of the 0.1.0 vote. The audit found the codebase, Helm-chart feature parity, and security posture all in good shape with no release blockers — this PR fixes only the genuine loose ends it turned up. All changes are documentation/cosmetic; there are no code or API changes.

The headline non-issue worth recording: the `0.0.0-dev` strings in `Makefile` and `Chart.yaml` are intentional placeholders that `scripts/release-rc.sh` auto-bumps from its `<version>` argument, so they are not release blockers.

## Details

- **`docs/getting-started.md`** — the Helm install example hardcoded `--version 0.0.0-dev`, which is never a published chart version and was inconsistent with `README.md`, `installation.md`, and `downloads.md`. Replaced with a `<version>` placeholder plus a pointer to Downloads.
- **`docs/reference/security.md`** — corrected an inaccuracy in the RBAC justification table. It collapsed `supersets` + `supersets/status` into one row that read as though the operator can `update`/`patch` the CR spec. The actual grants are `get;list;watch` on `supersets` and `get;update;patch` on `supersets/status` only; split into two rows. Also added the missing `update` verb on `events` to match the generated `role.yaml`.
- **`config/prometheus/monitor.yaml`** — reworded the leftover kubebuilder scaffold `TODO(user):` comment into intentional guidance, keeping the `insecureSkipVerify` rationale and the cert-manager patch pointer.
- **Superset image tag refresh** (`6.0.1` → `6.1.0`) across the docs examples and the production sample.