### PR TITLE
test: expand unit coverage for pure helper functions

### DIFF
--- a/internal/common/types_test.go
+++ b/internal/common/types_test.go
@@ -1,0 +1,55 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPtr(t *testing.T) {
+	t.Run("string", func(t *testing.T) {
+		s := "hello"
+		p := Ptr(s)
+		assert.NotNil(t, p)
+		assert.Equal(t, s, *p)
+	})
+
+	t.Run("int32", func(t *testing.T) {
+		var n int32 = 7
+		p := Ptr(n)
+		assert.NotNil(t, p)
+		assert.Equal(t, n, *p)
+	})
+
+	t.Run("bool zero value is still addressable", func(t *testing.T) {
+		b := false
+		p := Ptr(b)
+		assert.NotNil(t, p)
+		assert.False(t, *p)
+	})
+
+	t.Run("returns a distinct pointer per call", func(t *testing.T) {
+		n := 1
+		a := Ptr(n)
+		b := Ptr(n)
+		assert.NotSame(t, a, b)
+	})
+}

--- a/internal/config/gunicorn_test.go
+++ b/internal/config/gunicorn_test.go
@@ -78,6 +78,36 @@ func TestResolveGunicorn_FieldOverrides(t *testing.T) {
 	assert.Equal(t, int32(120), g.Timeout)
 }
 
+func TestResolveGunicorn_AllFieldOverrides(t *testing.T) {
+	// Every overridable field set to a non-default value, on top of a preset
+	// whose worker/thread defaults must be replaced by the explicit values.
+	g := ResolveGunicorn(&v1alpha1.GunicornSpec{
+		Preset:                ptr(PresetBalanced),
+		Workers:               ptr(int32(3)),
+		Threads:               ptr(int32(5)),
+		WorkerClass:           ptr("sync"),
+		Timeout:               ptr(int32(90)),
+		KeepAlive:             ptr(int32(7)),
+		MaxRequests:           ptr(int32(1000)),
+		MaxRequestsJitter:     ptr(int32(50)),
+		LimitRequestLine:      ptr(int32(8190)),
+		LimitRequestFieldSize: ptr(int32(16380)),
+		LogLevel:              ptr("debug"),
+	})
+
+	assert.False(t, g.Disabled)
+	assert.Equal(t, int32(3), g.Workers)
+	assert.Equal(t, int32(5), g.Threads)
+	assert.Equal(t, "sync", g.WorkerClass)
+	assert.Equal(t, int32(90), g.Timeout)
+	assert.Equal(t, int32(7), g.KeepAlive)
+	assert.Equal(t, int32(1000), g.MaxRequests)
+	assert.Equal(t, int32(50), g.MaxRequestsJitter)
+	assert.Equal(t, int32(8190), g.LimitRequestLine)
+	assert.Equal(t, int32(16380), g.LimitRequestFieldSize)
+	assert.Equal(t, "debug", g.LogLevel)
+}
+
 func TestResolveGunicorn_EnvVars(t *testing.T) {
 	g := ResolveGunicorn(nil)
 	envs := g.EnvVars()

--- a/internal/controller/bootstrap_test.go
+++ b/internal/controller/bootstrap_test.go
@@ -1,0 +1,45 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShellQuote(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{name: "empty string", arg: "", want: "''"},
+		{name: "plain word", arg: "hello", want: "'hello'"},
+		{name: "value with spaces", arg: "a b c", want: "'a b c'"},
+		{name: "value with shell metacharacters", arg: "a;b|c&d", want: "'a;b|c&d'"},
+		{name: "embedded single quote", arg: "it's", want: `'it'"'"'s'`},
+		{name: "only a single quote", arg: "'", want: `''"'"''`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shellQuote(tt.arg))
+		})
+	}
+}

--- a/internal/controller/config_test.go
+++ b/internal/controller/config_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package controller
 
 import (
+	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -650,4 +651,56 @@ func TestCollectSecretEnvVars_Valkey(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestBuildInitCommand(t *testing.T) {
+	loadExamples := true
+	noLoadExamples := false
+
+	tests := []struct {
+		name       string
+		init       *supersetv1alpha1.InitTaskSpec
+		wantScript string
+	}{
+		{
+			name:       "nil init runs plain superset init",
+			init:       nil,
+			wantScript: "superset init",
+		},
+		{
+			name:       "empty init runs plain superset init",
+			init:       &supersetv1alpha1.InitTaskSpec{},
+			wantScript: "superset init",
+		},
+		{
+			name:       "admin user appends create-admin",
+			init:       &supersetv1alpha1.InitTaskSpec{AdminUser: &supersetv1alpha1.AdminUserSpec{}},
+			wantScript: `superset init && (superset fab create-admin --username "$SUPERSET_OPERATOR__ADMIN_USERNAME" --password "$SUPERSET_OPERATOR__ADMIN_PASSWORD" --firstname "$SUPERSET_OPERATOR__ADMIN_FIRST_NAME" --lastname "$SUPERSET_OPERATOR__ADMIN_LAST_NAME" --email "$SUPERSET_OPERATOR__ADMIN_EMAIL" || true)`,
+		},
+		{
+			name:       "load examples true appends load-examples",
+			init:       &supersetv1alpha1.InitTaskSpec{LoadExamples: &loadExamples},
+			wantScript: "superset init && superset load-examples",
+		},
+		{
+			name:       "load examples false is a no-op",
+			init:       &supersetv1alpha1.InitTaskSpec{LoadExamples: &noLoadExamples},
+			wantScript: "superset init",
+		},
+		{
+			name:       "admin user and load examples both append in order",
+			init:       &supersetv1alpha1.InitTaskSpec{AdminUser: &supersetv1alpha1.AdminUserSpec{}, LoadExamples: &loadExamples},
+			wantScript: `superset init && (superset fab create-admin --username "$SUPERSET_OPERATOR__ADMIN_USERNAME" --password "$SUPERSET_OPERATOR__ADMIN_PASSWORD" --firstname "$SUPERSET_OPERATOR__ADMIN_FIRST_NAME" --lastname "$SUPERSET_OPERATOR__ADMIN_LAST_NAME" --email "$SUPERSET_OPERATOR__ADMIN_EMAIL" || true) && superset load-examples`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildInitCommand(tt.init)
+			want := []string{"/bin/sh", "-c", tt.wantScript}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("buildInitCommand() =\n  %#v\nwant\n  %#v", got, want)
+			}
+		})
+	}
 }

--- a/internal/controller/initpod_test.go
+++ b/internal/controller/initpod_test.go
@@ -1,0 +1,71 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestCalculateBackoff(t *testing.T) {
+	tests := []struct {
+		name    string
+		attempt int32
+		want    time.Duration
+	}{
+		{name: "attempt 1", attempt: 1, want: 10 * time.Second},
+		{name: "attempt 2", attempt: 2, want: 20 * time.Second},
+		{name: "attempt 3", attempt: 3, want: 40 * time.Second},
+		{name: "attempt 4", attempt: 4, want: 80 * time.Second},
+		{name: "attempt 5", attempt: 5, want: 160 * time.Second},
+		{name: "attempt 6 caps at 300s", attempt: 6, want: 300 * time.Second},
+		{name: "attempt 10 stays capped", attempt: 10, want: 300 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, calculateBackoff(tt.attempt))
+		})
+	}
+}
+
+func TestShouldDeletePod(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy string
+		phase  corev1.PodPhase
+		want   bool
+	}{
+		{name: "Delete always deletes succeeded", policy: retentionDelete, phase: corev1.PodSucceeded, want: true},
+		{name: "Delete always deletes failed", policy: retentionDelete, phase: corev1.PodFailed, want: true},
+		{name: "Retain never deletes succeeded", policy: retentionRetain, phase: corev1.PodSucceeded, want: false},
+		{name: "Retain never deletes failed", policy: retentionRetain, phase: corev1.PodFailed, want: false},
+		{name: "RetainOnFailure deletes succeeded", policy: retentionRetainOnFail, phase: corev1.PodSucceeded, want: true},
+		{name: "RetainOnFailure keeps failed", policy: retentionRetainOnFail, phase: corev1.PodFailed, want: false},
+		{name: "RetainOnFailure deletes running", policy: retentionRetainOnFail, phase: corev1.PodRunning, want: true},
+		{name: "unknown policy deletes (safe default)", policy: "Bogus", phase: corev1.PodFailed, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ShouldDeletePod(tt.policy, tt.phase))
+		})
+	}
+}

--- a/internal/controller/lifecycle_defaults_test.go
+++ b/internal/controller/lifecycle_defaults_test.go
@@ -1,0 +1,160 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	supersetv1alpha1 "github.com/apache/superset-kubernetes-operator/api/v1alpha1"
+)
+
+func TestTaskMaxRetriesValue(t *testing.T) {
+	r := &SupersetReconciler{}
+
+	t.Run("defaults when unset", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{
+			Lifecycle: &supersetv1alpha1.LifecycleSpec{Migrate: &supersetv1alpha1.MigrateTaskSpec{}},
+		}}
+		assert.Equal(t, defaultMaxRetries, r.taskMaxRetriesValue(superset, taskTypeMigrate))
+	})
+
+	t.Run("defaults when lifecycle nil", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{}
+		assert.Equal(t, defaultMaxRetries, r.taskMaxRetriesValue(superset, taskTypeMigrate))
+	})
+
+	t.Run("uses explicit value", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{
+			Lifecycle: &supersetv1alpha1.LifecycleSpec{Migrate: &supersetv1alpha1.MigrateTaskSpec{
+				BaseTaskSpec: supersetv1alpha1.BaseTaskSpec{MaxRetries: int32Ptr(7)},
+			}},
+		}}
+		assert.Equal(t, int32(7), r.taskMaxRetriesValue(superset, taskTypeMigrate))
+	})
+
+	t.Run("defaults for unknown task type", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{}
+		assert.Equal(t, defaultMaxRetries, r.taskMaxRetriesValue(superset, "Bogus"))
+	})
+}
+
+func TestTaskTimeoutValue(t *testing.T) {
+	r := &SupersetReconciler{}
+
+	t.Run("defaults when unset", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{
+			Lifecycle: &supersetv1alpha1.LifecycleSpec{Migrate: &supersetv1alpha1.MigrateTaskSpec{}},
+		}}
+		assert.Equal(t, defaultInitTimeout, r.taskTimeoutValue(superset, taskTypeMigrate))
+	})
+
+	t.Run("uses explicit value", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{
+			Lifecycle: &supersetv1alpha1.LifecycleSpec{Migrate: &supersetv1alpha1.MigrateTaskSpec{
+				BaseTaskSpec: supersetv1alpha1.BaseTaskSpec{
+					Timeout: &metav1.Duration{Duration: 90 * time.Second},
+				},
+			}},
+		}}
+		assert.Equal(t, 90*time.Second, r.taskTimeoutValue(superset, taskTypeMigrate))
+	})
+
+	t.Run("defaults for unknown task type", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{}
+		assert.Equal(t, defaultInitTimeout, r.taskTimeoutValue(superset, "Bogus"))
+	})
+}
+
+func TestTaskRetentionPolicyValue(t *testing.T) {
+	r := &SupersetReconciler{}
+
+	t.Run("defaults when unset", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{
+			Lifecycle: &supersetv1alpha1.LifecycleSpec{},
+		}}
+		assert.Equal(t, defaultRetentionPolicy, r.taskRetentionPolicyValue(superset, taskTypeInit))
+	})
+
+	t.Run("uses lifecycle-level policy", func(t *testing.T) {
+		policy := retentionDelete
+		superset := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{
+			Lifecycle: &supersetv1alpha1.LifecycleSpec{
+				PodRetention: &supersetv1alpha1.PodRetentionSpec{Policy: &policy},
+			},
+		}}
+		assert.Equal(t, retentionDelete, r.taskRetentionPolicyValue(superset, taskTypeInit))
+	})
+
+	t.Run("clone-specific policy overrides lifecycle-level", func(t *testing.T) {
+		lifecyclePolicy := retentionRetain
+		clonePolicy := retentionDelete
+		superset := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{
+			Lifecycle: &supersetv1alpha1.LifecycleSpec{
+				PodRetention: &supersetv1alpha1.PodRetentionSpec{Policy: &lifecyclePolicy},
+				Clone: &supersetv1alpha1.CloneTaskSpec{
+					PodRetention: &supersetv1alpha1.PodRetentionSpec{Policy: &clonePolicy},
+				},
+			},
+		}}
+		assert.Equal(t, retentionDelete, r.taskRetentionPolicyValue(superset, taskTypeClone))
+	})
+}
+
+func TestGetUpgradeMode(t *testing.T) {
+	t.Run("defaults to Automatic when lifecycle nil", func(t *testing.T) {
+		assert.Equal(t, upgradeModeAutomatic, getUpgradeMode(&supersetv1alpha1.Superset{}))
+	})
+
+	t.Run("defaults to Automatic when unset", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{
+			Lifecycle: &supersetv1alpha1.LifecycleSpec{},
+		}}
+		assert.Equal(t, upgradeModeAutomatic, getUpgradeMode(superset))
+	})
+
+	t.Run("returns Supervised when set", func(t *testing.T) {
+		mode := upgradeModeSupervised
+		superset := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{
+			Lifecycle: &supersetv1alpha1.LifecycleSpec{UpgradeMode: &mode},
+		}}
+		assert.Equal(t, upgradeModeSupervised, getUpgradeMode(superset))
+	})
+}
+
+func TestSuffixForTaskType(t *testing.T) {
+	tests := []struct {
+		taskType string
+		want     string
+	}{
+		{taskTypeClone, suffixClone},
+		{taskTypeMigrate, suffixMigrate},
+		{taskTypeRotate, suffixRotate},
+		{taskTypeInit, suffixInit},
+		{"Bogus", "-bogus"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.taskType, func(t *testing.T) {
+			assert.Equal(t, tt.want, suffixForTaskType(tt.taskType))
+		})
+	}
+}

--- a/internal/controller/lifecycle_job_test.go
+++ b/internal/controller/lifecycle_job_test.go
@@ -20,9 +20,11 @@ package controller
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -337,4 +339,53 @@ func lifecycleTaskJobForRetention(name, checksum string, conditionType batchv1.J
 		}}
 	}
 	return job
+}
+
+func TestTruncateFailureMessage(t *testing.T) {
+	t.Run("short message is unchanged", func(t *testing.T) {
+		assert.Equal(t, "boom", truncateFailureMessage("boom"))
+	})
+	t.Run("message at the limit is unchanged", func(t *testing.T) {
+		msg := strings.Repeat("x", maxTerminationMessageLen)
+		assert.Equal(t, msg, truncateFailureMessage(msg))
+	})
+	t.Run("over-limit message is truncated with ellipsis", func(t *testing.T) {
+		msg := strings.Repeat("x", maxTerminationMessageLen+10)
+		got := truncateFailureMessage(msg)
+		assert.Equal(t, strings.Repeat("x", maxTerminationMessageLen)+"...", got)
+		assert.Len(t, got, maxTerminationMessageLen+3)
+	})
+}
+
+func TestJobFailureMessage(t *testing.T) {
+	failed := func(reason, message string) *batchv1.Job {
+		return &batchv1.Job{Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+			Type:    batchv1.JobFailed,
+			Status:  corev1.ConditionTrue,
+			Reason:  reason,
+			Message: message,
+		}}}}
+	}
+
+	t.Run("prefers the condition message", func(t *testing.T) {
+		assert.Equal(t, "pods failed", jobFailureMessage(failed("BackoffLimitExceeded", "pods failed")))
+	})
+	t.Run("falls back to the reason when message empty", func(t *testing.T) {
+		assert.Equal(t, "BackoffLimitExceeded", jobFailureMessage(failed("BackoffLimitExceeded", "")))
+	})
+	t.Run("default when failed condition has neither", func(t *testing.T) {
+		assert.Equal(t, "Job failed", jobFailureMessage(failed("", "")))
+	})
+	t.Run("default when no failed condition present", func(t *testing.T) {
+		job := &batchv1.Job{Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+			Type:   batchv1.JobComplete,
+			Status: corev1.ConditionTrue,
+		}}}}
+		assert.Equal(t, "Job failed", jobFailureMessage(job))
+	})
+	t.Run("truncates long condition messages", func(t *testing.T) {
+		long := strings.Repeat("x", maxTerminationMessageLen+5)
+		got := jobFailureMessage(failed("BackoffLimitExceeded", long))
+		assert.Len(t, got, maxTerminationMessageLen+3)
+	})
 }

--- a/internal/controller/lifecycle_predicates_test.go
+++ b/internal/controller/lifecycle_predicates_test.go
@@ -1,0 +1,171 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	supersetv1alpha1 "github.com/apache/superset-kubernetes-operator/api/v1alpha1"
+)
+
+func TestTaskStatusForType(t *testing.T) {
+	migrateRef := &supersetv1alpha1.TaskRefStatus{State: taskStateComplete}
+
+	t.Run("nil when lifecycle status absent", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{}
+		assert.Nil(t, taskStatusForType(superset, taskTypeMigrate))
+	})
+
+	t.Run("nil for unknown task type", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{
+			Status: supersetv1alpha1.SupersetStatus{Lifecycle: &supersetv1alpha1.LifecycleStatus{}},
+		}
+		assert.Nil(t, taskStatusForType(superset, "Bogus"))
+	})
+
+	t.Run("returns the addressed task ref", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{
+			Status: supersetv1alpha1.SupersetStatus{Lifecycle: &supersetv1alpha1.LifecycleStatus{
+				Migrate: migrateRef,
+			}},
+		}
+		assert.Same(t, migrateRef, taskStatusForType(superset, taskTypeMigrate))
+	})
+}
+
+func TestTaskTerminalFailedForChecksum(t *testing.T) {
+	r := &SupersetReconciler{}
+	const checksum = "sha256:abc"
+
+	supersetWithMigrate := func(ref *supersetv1alpha1.TaskRefStatus) *supersetv1alpha1.Superset {
+		return &supersetv1alpha1.Superset{
+			Status: supersetv1alpha1.SupersetStatus{Lifecycle: &supersetv1alpha1.LifecycleStatus{Migrate: ref}},
+		}
+	}
+
+	t.Run("false when no task ref", func(t *testing.T) {
+		assert.False(t, r.taskTerminalFailedForChecksum(supersetWithMigrate(nil), taskTypeMigrate, checksum))
+	})
+
+	t.Run("false when not failed", func(t *testing.T) {
+		ref := &supersetv1alpha1.TaskRefStatus{State: taskStateComplete, CompletedChecksum: checksum}
+		assert.False(t, r.taskTerminalFailedForChecksum(supersetWithMigrate(ref), taskTypeMigrate, checksum))
+	})
+
+	t.Run("false when failed for a different checksum", func(t *testing.T) {
+		ref := &supersetv1alpha1.TaskRefStatus{State: taskStateFailed, CompletedChecksum: "other", Attempts: 5, MaxRetries: 3}
+		assert.False(t, r.taskTerminalFailedForChecksum(supersetWithMigrate(ref), taskTypeMigrate, checksum))
+	})
+
+	t.Run("false when retries remain", func(t *testing.T) {
+		ref := &supersetv1alpha1.TaskRefStatus{State: taskStateFailed, CompletedChecksum: checksum, Attempts: 2, MaxRetries: 3}
+		assert.False(t, r.taskTerminalFailedForChecksum(supersetWithMigrate(ref), taskTypeMigrate, checksum))
+	})
+
+	t.Run("true when failed at max retries", func(t *testing.T) {
+		ref := &supersetv1alpha1.TaskRefStatus{State: taskStateFailed, CompletedChecksum: checksum, Attempts: 3, MaxRetries: 3}
+		assert.True(t, r.taskTerminalFailedForChecksum(supersetWithMigrate(ref), taskTypeMigrate, checksum))
+	})
+
+	t.Run("falls back to default max retries when ref MaxRetries is zero", func(t *testing.T) {
+		// defaultMaxRetries is 3; Attempts at the default ceiling is terminal.
+		ref := &supersetv1alpha1.TaskRefStatus{State: taskStateFailed, CompletedChecksum: checksum, Attempts: defaultMaxRetries}
+		assert.True(t, r.taskTerminalFailedForChecksum(supersetWithMigrate(ref), taskTypeMigrate, checksum))
+	})
+}
+
+func TestTaskNeedsRun(t *testing.T) {
+	r := &SupersetReconciler{}
+	const checksum = "sha256:abc"
+
+	t.Run("true when no status at all", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{}
+		assert.True(t, r.taskNeedsRun(superset, taskTypeMigrate, checksum))
+	})
+
+	t.Run("false when complete for the same checksum", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{
+			Status: supersetv1alpha1.SupersetStatus{Lifecycle: &supersetv1alpha1.LifecycleStatus{
+				Migrate: &supersetv1alpha1.TaskRefStatus{State: taskStateComplete, CompletedChecksum: checksum},
+			}},
+		}
+		assert.False(t, r.taskNeedsRun(superset, taskTypeMigrate, checksum))
+	})
+
+	t.Run("true when complete for a different checksum", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{
+			Status: supersetv1alpha1.SupersetStatus{Lifecycle: &supersetv1alpha1.LifecycleStatus{
+				Migrate: &supersetv1alpha1.TaskRefStatus{State: taskStateComplete, CompletedChecksum: "stale"},
+			}},
+		}
+		assert.True(t, r.taskNeedsRun(superset, taskTypeMigrate, checksum))
+	})
+
+	t.Run("false when terminally failed for the same checksum", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{
+			Status: supersetv1alpha1.SupersetStatus{Lifecycle: &supersetv1alpha1.LifecycleStatus{
+				Migrate: &supersetv1alpha1.TaskRefStatus{
+					State: taskStateFailed, CompletedChecksum: checksum, Attempts: 3, MaxRetries: 3,
+				},
+			}},
+		}
+		assert.False(t, r.taskNeedsRun(superset, taskTypeMigrate, checksum))
+	})
+
+	t.Run("uses LastCompletedChecksums when no task ref", func(t *testing.T) {
+		matched := &supersetv1alpha1.Superset{
+			Status: supersetv1alpha1.SupersetStatus{Lifecycle: &supersetv1alpha1.LifecycleStatus{
+				LastCompletedChecksums: map[string]string{taskTypeMigrate: checksum},
+			}},
+		}
+		assert.False(t, r.taskNeedsRun(matched, taskTypeMigrate, checksum))
+
+		drifted := &supersetv1alpha1.Superset{
+			Status: supersetv1alpha1.SupersetStatus{Lifecycle: &supersetv1alpha1.LifecycleStatus{
+				LastCompletedChecksums: map[string]string{taskTypeMigrate: "stale"},
+			}},
+		}
+		assert.True(t, r.taskNeedsRun(drifted, taskTypeMigrate, checksum))
+	})
+}
+
+func TestResolveLifecycleImage(t *testing.T) {
+	parent := &supersetv1alpha1.ImageSpec{Repository: "apache/superset", Tag: "4.0.0"}
+	newRepo := "internal/superset"
+	newTag := "4.1.0"
+
+	tests := []struct {
+		name     string
+		override *supersetv1alpha1.ImageOverrideSpec
+		want     string
+	}{
+		{name: "nil override uses parent", override: nil, want: "apache/superset:4.0.0"},
+		{name: "empty override uses parent", override: &supersetv1alpha1.ImageOverrideSpec{}, want: "apache/superset:4.0.0"},
+		{name: "repository override", override: &supersetv1alpha1.ImageOverrideSpec{Repository: &newRepo}, want: "internal/superset:4.0.0"},
+		{name: "tag override", override: &supersetv1alpha1.ImageOverrideSpec{Tag: &newTag}, want: "apache/superset:4.1.0"},
+		{name: "both overridden", override: &supersetv1alpha1.ImageOverrideSpec{Repository: &newRepo, Tag: &newTag}, want: "internal/superset:4.1.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, resolveLifecycleImage(parent, tt.override))
+		})
+	}
+}

--- a/internal/controller/networking_test.go
+++ b/internal/controller/networking_test.go
@@ -610,3 +610,25 @@ func TestDeleteByLabels_SkipsUnlabeledResource(t *testing.T) {
 }
 
 func pathTypePtr(pt networkingv1.PathType) *networkingv1.PathType { return &pt }
+
+func TestResolveServicePort(t *testing.T) {
+	custom := int32(9000)
+	tests := []struct {
+		name        string
+		svc         *supersetv1alpha1.ComponentServiceSpec
+		defaultPort int32
+		want        gatewayv1.PortNumber
+	}{
+		{"nil service", nil, 8088, 8088},
+		{"nil port", &supersetv1alpha1.ComponentServiceSpec{}, 8088, 8088},
+		{"custom port", &supersetv1alpha1.ComponentServiceSpec{Port: &custom}, 8088, 9000},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveServicePort(tt.svc, tt.defaultPort)
+			if got != tt.want {
+				t.Errorf("resolveServicePort() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/controller/serviceaccount_test.go
+++ b/internal/controller/serviceaccount_test.go
@@ -1,0 +1,77 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	supersetv1alpha1 "github.com/apache/superset-kubernetes-operator/api/v1alpha1"
+)
+
+func TestResolveServiceAccountName(t *testing.T) {
+	tests := []struct {
+		name string
+		sa   *supersetv1alpha1.ServiceAccountSpec
+		want string
+	}{
+		{
+			name: "nil spec defaults to parent name",
+			sa:   nil,
+			want: "test",
+		},
+		{
+			name: "create=true with explicit name uses the name",
+			sa:   &supersetv1alpha1.ServiceAccountSpec{Create: boolPtr(true), Name: "custom-sa"},
+			want: "custom-sa",
+		},
+		{
+			name: "create=true without name defaults to parent name",
+			sa:   &supersetv1alpha1.ServiceAccountSpec{Create: boolPtr(true)},
+			want: "test",
+		},
+		{
+			name: "create unset with name uses the name",
+			sa:   &supersetv1alpha1.ServiceAccountSpec{Name: "custom-sa"},
+			want: "custom-sa",
+		},
+		{
+			name: "create=false with name references the existing SA",
+			sa:   &supersetv1alpha1.ServiceAccountSpec{Create: boolPtr(false), Name: "external-sa"},
+			want: "external-sa",
+		},
+		{
+			name: "create=false without name yields empty (pod default SA)",
+			sa:   &supersetv1alpha1.ServiceAccountSpec{Create: boolPtr(false)},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			superset := &supersetv1alpha1.Superset{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec:       supersetv1alpha1.SupersetSpec{ServiceAccount: tt.sa},
+			}
+			assert.Equal(t, tt.want, resolveServiceAccountName(superset))
+		})
+	}
+}

--- a/internal/controller/status_test.go
+++ b/internal/controller/status_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -411,4 +412,135 @@ func hasComponentResource(resources []supersetv1alpha1.ComponentResourceStatus, 
 		}
 	}
 	return false
+}
+
+func TestEffectiveAutoscalingForStatus(t *testing.T) {
+	componentAS := &supersetv1alpha1.AutoscalingSpec{MinReplicas: int32Ptr(3)}
+	topAS := &supersetv1alpha1.AutoscalingSpec{MinReplicas: int32Ptr(2)}
+
+	t.Run("per-component value wins", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{Autoscaling: topAS}}
+		got := effectiveAutoscalingForStatus(superset, &componentAccessor{autoscaling: componentAS})
+		assert.Same(t, componentAS, got)
+	})
+
+	t.Run("falls back to top-level", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{Autoscaling: topAS}}
+		got := effectiveAutoscalingForStatus(superset, &componentAccessor{})
+		assert.Same(t, topAS, got)
+	})
+
+	t.Run("nil when neither set", func(t *testing.T) {
+		assert.Nil(t, effectiveAutoscalingForStatus(&supersetv1alpha1.Superset{}, nil))
+	})
+}
+
+func TestEffectivePDBForStatus(t *testing.T) {
+	componentPDB := &supersetv1alpha1.PDBSpec{}
+	topPDB := &supersetv1alpha1.PDBSpec{}
+
+	t.Run("per-component value wins", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{PodDisruptionBudget: topPDB}}
+		assert.Same(t, componentPDB, effectivePDBForStatus(superset, &componentAccessor{pdb: componentPDB}))
+	})
+
+	t.Run("falls back to top-level", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{PodDisruptionBudget: topPDB}}
+		assert.Same(t, topPDB, effectivePDBForStatus(superset, &componentAccessor{}))
+	})
+
+	t.Run("nil when neither set", func(t *testing.T) {
+		assert.Nil(t, effectivePDBForStatus(&supersetv1alpha1.Superset{}, nil))
+	})
+}
+
+func TestDesiredReplicasForStatus(t *testing.T) {
+	webDesc := &componentDescriptor{componentType: common.ComponentWebServer}
+	beatDesc := &componentDescriptor{componentType: common.ComponentCeleryBeat}
+
+	t.Run("celery beat is always a singleton", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{Replicas: int32Ptr(5)}}
+		assert.Equal(t, celeryBeatSingletonReplica, desiredReplicasForStatus(superset, beatDesc, &componentAccessor{}))
+	})
+
+	t.Run("autoscaling minReplicas takes precedence", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{Replicas: int32Ptr(5)}}
+		accessor := &componentAccessor{autoscaling: &supersetv1alpha1.AutoscalingSpec{MinReplicas: int32Ptr(3)}}
+		assert.Equal(t, int32(3), desiredReplicasForStatus(superset, webDesc, accessor))
+	})
+
+	t.Run("autoscaling without minReplicas defaults to 1", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{Replicas: int32Ptr(5)}}
+		accessor := &componentAccessor{autoscaling: &supersetv1alpha1.AutoscalingSpec{}}
+		assert.Equal(t, int32(1), desiredReplicasForStatus(superset, webDesc, accessor))
+	})
+
+	t.Run("per-component replicas win over top-level", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{Replicas: int32Ptr(5)}}
+		assert.Equal(t, int32(2), desiredReplicasForStatus(superset, webDesc, &componentAccessor{replicas: int32Ptr(2)}))
+	})
+
+	t.Run("falls back to top-level replicas", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{Replicas: int32Ptr(4)}}
+		assert.Equal(t, int32(4), desiredReplicasForStatus(superset, webDesc, &componentAccessor{}))
+	})
+
+	t.Run("defaults to 1 when nothing is set", func(t *testing.T) {
+		assert.Equal(t, int32(1), desiredReplicasForStatus(&supersetv1alpha1.Superset{}, webDesc, &componentAccessor{}))
+	})
+}
+
+func TestComponentPhaseAndMessage(t *testing.T) {
+	t.Run("scaled to zero is Ready", func(t *testing.T) {
+		phase, msg := componentPhaseAndMessage(&appsv1.Deployment{}, 0)
+		assert.Equal(t, componentPhaseReady, phase)
+		assert.Equal(t, "Scaled to zero", msg)
+	})
+
+	t.Run("all replicas ready is Ready with no message", func(t *testing.T) {
+		deploy := &appsv1.Deployment{Status: appsv1.DeploymentStatus{
+			ReadyReplicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2,
+		}}
+		phase, msg := componentPhaseAndMessage(deploy, 2)
+		assert.Equal(t, componentPhaseReady, phase)
+		assert.Empty(t, msg)
+	})
+
+	t.Run("unobserved generation is Progressing", func(t *testing.T) {
+		deploy := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Generation: 2},
+			Status:     appsv1.DeploymentStatus{ObservedGeneration: 1},
+		}
+		phase, msg := componentPhaseAndMessage(deploy, 2)
+		assert.Equal(t, componentPhaseProgressing, phase)
+		assert.Equal(t, "Deployment has not observed the latest generation", msg)
+	})
+
+	t.Run("progress deadline exceeded is Unavailable", func(t *testing.T) {
+		deploy := &appsv1.Deployment{Status: appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{{
+				Type:    appsv1.DeploymentProgressing,
+				Status:  corev1.ConditionFalse,
+				Reason:  "ProgressDeadlineExceeded",
+				Message: "deadline exceeded",
+			}},
+		}}
+		phase, msg := componentPhaseAndMessage(deploy, 2)
+		assert.Equal(t, componentPhaseUnavailable, phase)
+		assert.Equal(t, "deadline exceeded", msg)
+	})
+
+	t.Run("partially ready is Progressing", func(t *testing.T) {
+		deploy := &appsv1.Deployment{Status: appsv1.DeploymentStatus{ReadyReplicas: 1}}
+		phase, msg := componentPhaseAndMessage(deploy, 3)
+		assert.Equal(t, componentPhaseProgressing, phase)
+		assert.Equal(t, "1 of 3 replicas are ready", msg)
+	})
+
+	t.Run("no replicas ready is Unavailable", func(t *testing.T) {
+		deploy := &appsv1.Deployment{Status: appsv1.DeploymentStatus{ReadyReplicas: 0}}
+		phase, msg := componentPhaseAndMessage(deploy, 3)
+		assert.Equal(t, componentPhaseUnavailable, phase)
+		assert.Equal(t, "0 of 3 replicas are ready", msg)
+	})
 }


### PR DESCRIPTION
## Summary

This PR closes targeted gaps in unit-test coverage by adding table-driven tests for pure, cluster-independent helper functions that were under-permuted. The motivation was the Codecov project figure (~83%) and a review of where coverage was genuinely thin.

The analysis found coverage is strong where it matters most (`internal/resolution` 99%, `internal/config` 95%), and that the controller's reconcile paths are additionally covered by the envtest integration suite. The real blind spots were exactly what our testing guidelines reserve unit tests for: business-logic helpers with many input permutations (backoff math, retention-policy matrices, failure-message formatting, preset/field-override resolution, default getters). These are deterministic, need no fake client or envtest, and were the lowest-risk way to raise coverage.

23 previously under-covered pure functions are now at 100% unit coverage. Package coverage moves: `internal/common` 83.3% → 100%, `internal/config` 95.0% → 97.8%, `internal/controller` 81.8% → 84.5% (unit-only; the merged unit+integration figure rises correspondingly). No production code changed, and Codecov configuration is unchanged (coverage remains informational, per our documented stance).

## Details

New test files:
- `internal/common/types_test.go` — `Ptr`
- `internal/controller/initpod_test.go` — `calculateBackoff` (exponential + 300s cap), `ShouldDeletePod` (retention-policy × pod-phase matrix)
- `internal/controller/serviceaccount_test.go` — `resolveServiceAccountName` (create/name precedence)
- `internal/controller/lifecycle_defaults_test.go` — `taskMaxRetriesValue`, `taskTimeoutValue`, `taskRetentionPolicyValue`, `getUpgradeMode`, `suffixForTaskType`
- `internal/controller/lifecycle_predicates_test.go` — `taskNeedsRun`, `taskTerminalFailedForChecksum`, `taskStatusForType`, `resolveLifecycleImage`
- `internal/controller/bootstrap_test.go` — `shellQuote`

Extended existing tables:
- `internal/config/gunicorn_test.go` — all ten `ResolveGunicorn` field overrides
- `internal/controller/config_test.go` — `buildInitCommand` (adminUser × loadExamples permutations)
- `internal/controller/lifecycle_job_test.go` — `truncateFailureMessage`, `jobFailureMessage`
- `internal/controller/networking_test.go` — `resolveServicePort`
- `internal/controller/status_test.go` — `desiredReplicasForStatus`, `componentPhaseAndMessage`, `effectiveAutoscalingForStatus`, `effectivePDBForStatus`

All tests follow the project conventions: table-driven with `t.Run` subtests, assert on observable outputs, and each case guards a plausible regression. The `*SupersetReconciler` helpers are exercised with a zero-value reconciler (no fake client). New unit files are untagged so they don't depend on `strPtr` (which lives in an integration-tagged file).