### PR TITLE
chore: pre-0.1.0 sweep (renovate, k8s version docs, e2e logging)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ published [kind](https://kind.sigs.k8s.io/) node image. The newest Kubernetes
 release gets best-effort coverage via a non-blocking CI lane until kind ships
 its node image.
 
+Older releases are likely to work but are not tested. The practical minimum is
+**Kubernetes 1.25**: the operator's CRD validation is implemented entirely with
+[CEL validation rules](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules),
+which are enabled by default as beta from 1.25 and graduated to GA in 1.29. On
+clusters older than 1.25 the CRD still installs, but these rules are silently
+ignored — meaning the operator's secret-handling and configuration-safety checks
+are not enforced. Horizontal Pod Autoscaling additionally requires the
+`autoscaling/v2` API (Kubernetes 1.23+).
+
 ## Quick Start
 
 Install the operator via Helm:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,8 @@ Superset instance using dev mode.
 
 ## Prerequisites
 
-- Kubernetes v1.28+ cluster
+- Kubernetes 1.25+ (1.34 is officially tested; 1.29+ recommended so CEL
+  validation is GA — see [supported versions](user-guide/installation.md#supported-kubernetes-versions))
 - Helm 3
 - A PostgreSQL database accessible from the cluster
 

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -45,6 +45,15 @@ published [kind](https://kind.sigs.k8s.io/) node image. The newest Kubernetes
 release gets best-effort coverage via a non-blocking CI lane until kind ships
 its node image.
 
+Older releases are likely to work but are not tested. The practical minimum is
+**Kubernetes 1.25**: the operator's CRD validation is implemented entirely with
+[CEL validation rules](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules),
+which are enabled by default as beta from 1.25 and graduated to GA in 1.29. On
+clusters older than 1.25 the CRD still installs, but these rules are silently
+ignored — meaning the operator's secret-handling and configuration-safety checks
+are not enforced. Horizontal Pod Autoscaling additionally requires the
+`autoscaling/v2` API (Kubernetes 1.23+).
+
 ## 1. Install the operator
 
 ```bash

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "minimumReleaseAge": "7 days",
-  "schedule": ["before 7am"],
   "labels": ["dependencies"],
   "packageRules": [
     {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -133,9 +133,9 @@ var _ = Describe("Manager", Ordered, func() {
 			cmd = exec.Command("kubectl", "describe", "pod", controllerPodName, "-n", namespace)
 			podDescription, err := utils.Run(cmd)
 			if err == nil {
-				fmt.Println("Pod description:\n", podDescription)
+				_, _ = fmt.Fprintf(GinkgoWriter, "Pod description:\n%s", podDescription)
 			} else {
-				fmt.Println("Failed to describe controller pod")
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to describe controller pod: %s", err)
 			}
 		}
 	})


### PR DESCRIPTION
## Summary

A small pre-0.1.0 cleanup pass. The main change loosens the Renovate update schedule so dependency PRs are no longer confined to a daily window. While preparing for the release I also did a sweep of the codebase and docs and fixed a few things that stuck out: a stale Kubernetes minimum-version claim in the docs and two inconsistent log calls in the e2e suite.

## Details

**Renovate** (`renovate.json`)
- Removed `"schedule": ["before 7am"]` so Renovate can open and update PRs at any time of day. With no `schedule` key, Renovate defaults to "at any time". The 7-day `minimumReleaseAge` safety delay is intentionally left in place.

**Kubernetes version docs** (`docs/getting-started.md`, `README.md`, `docs/user-guide/installation.md`)
- `getting-started.md` claimed "v1.28+", which didn't match the tested matrix (1.34/1.35) or the actual feature floor. Corrected to "1.25+ (1.34 officially tested; 1.29+ recommended)".
- Added a minimum-version paragraph to the README and installation guide explaining *why* 1.25 is the practical floor: the operator's validation layer is entirely CEL (`x-kubernetes-validations`), which is beta-on-by-default from 1.25 and GA in 1.29 — below 1.25 the CRD installs but the rules are silently ignored, so secret-handling and config-safety checks aren't enforced. HPA also requires `autoscaling/v2` (1.23+).
- The new prose is placed outside the `make supported-versions` sentinel blocks so the generator won't overwrite it. The getting-started cross-reference points at the in-docs installation page (not README) so it resolves on the docs site.

**e2e logging** (`test/e2e/e2e_test.go`)
- Replaced two `fmt.Println` calls in the failure-dump block with `fmt.Fprintf(GinkgoWriter, ...)`, matching the surrounding code so the output is captured by Ginkgo in CI.