### PR TITLE
test: close controller coverage gaps

### DIFF
--- a/internal/config/engine_options_test.go
+++ b/internal/config/engine_options_test.go
@@ -132,6 +132,63 @@ func TestComputeEngineOptions_PerComponentOverridesTopLevel(t *testing.T) {
 	assert.Equal(t, int32(4), result.PoolSize) // performance: workers
 }
 
+func TestApplyExplicitOverrides_NilSpec(t *testing.T) {
+	// Nil spec must leave the result untouched (early return).
+	result := &EngineOptionsInput{PoolSize: 7, MaxOverflow: 2, PoolRecycle: 100, PoolPrePing: true, PoolTimeout: 9}
+	applyExplicitOverrides(result, nil)
+	assert.Equal(t, int32(7), result.PoolSize)
+	assert.Equal(t, int32(2), result.MaxOverflow)
+	assert.Equal(t, int32(100), result.PoolRecycle)
+	assert.True(t, result.PoolPrePing)
+	assert.Equal(t, int32(9), result.PoolTimeout)
+}
+
+func TestApplyExplicitOverrides_EachFieldSetVsNil(t *testing.T) {
+	t.Run("all fields set override the baseline", func(t *testing.T) {
+		result := &EngineOptionsInput{PoolSize: 1, MaxOverflow: -1, PoolRecycle: 3600}
+		spec := &v1alpha1.SQLAlchemyEngineOptionsSpec{
+			PoolSize:    ptr(int32(20)),
+			MaxOverflow: ptr(int32(5)),
+			PoolRecycle: ptr(int32(900)),
+			PoolPrePing: ptr(true),
+			PoolTimeout: ptr(int32(45)),
+		}
+		applyExplicitOverrides(result, spec)
+		assert.Equal(t, int32(20), result.PoolSize)
+		assert.Equal(t, int32(5), result.MaxOverflow)
+		assert.Equal(t, int32(900), result.PoolRecycle)
+		assert.True(t, result.PoolPrePing)
+		assert.Equal(t, int32(45), result.PoolTimeout)
+	})
+
+	t.Run("nil fields preserve the baseline", func(t *testing.T) {
+		// An empty spec (every field nil) must not change anything.
+		result := &EngineOptionsInput{PoolSize: 3, MaxOverflow: -1, PoolRecycle: 3600, PoolPrePing: false, PoolTimeout: 11}
+		applyExplicitOverrides(result, &v1alpha1.SQLAlchemyEngineOptionsSpec{})
+		assert.Equal(t, int32(3), result.PoolSize)
+		assert.Equal(t, int32(-1), result.MaxOverflow)
+		assert.Equal(t, int32(3600), result.PoolRecycle)
+		assert.False(t, result.PoolPrePing)
+		assert.Equal(t, int32(11), result.PoolTimeout)
+	})
+
+	t.Run("only PoolTimeout set leaves others at baseline", func(t *testing.T) {
+		result := &EngineOptionsInput{PoolSize: 3, MaxOverflow: -1, PoolRecycle: 3600}
+		applyExplicitOverrides(result, &v1alpha1.SQLAlchemyEngineOptionsSpec{PoolTimeout: ptr(int32(30))})
+		assert.Equal(t, int32(30), result.PoolTimeout)
+		assert.Equal(t, int32(3), result.PoolSize)
+		assert.Equal(t, int32(-1), result.MaxOverflow)
+		assert.Equal(t, int32(3600), result.PoolRecycle)
+	})
+
+	t.Run("only PoolPrePing set leaves others at baseline", func(t *testing.T) {
+		result := &EngineOptionsInput{PoolSize: 3}
+		applyExplicitOverrides(result, &v1alpha1.SQLAlchemyEngineOptionsSpec{PoolPrePing: ptr(true)})
+		assert.True(t, result.PoolPrePing)
+		assert.Equal(t, int32(3), result.PoolSize)
+	})
+}
+
 func TestFullPipeline_WebServerPerformance(t *testing.T) {
 	g := ResolveGunicorn(&v1alpha1.GunicornSpec{Preset: ptr(PresetPerformance)})
 	sqla := &v1alpha1.SQLAlchemyEngineOptionsSpec{Preset: ptr(PresetAggressive)}

--- a/internal/controller/checksum_test.go
+++ b/internal/controller/checksum_test.go
@@ -1,0 +1,78 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	supersetv1alpha1 "github.com/apache/superset-kubernetes-operator/api/v1alpha1"
+)
+
+func TestIsOwnedBy(t *testing.T) {
+	owner := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "parent", Namespace: "default", UID: types.UID("owner-uid")},
+	}
+
+	t.Run("matching owner UID returns true", func(t *testing.T) {
+		obj := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{UID: types.UID("someone-else")},
+					{UID: types.UID("owner-uid")},
+				},
+			},
+		}
+		assert.True(t, isOwnedBy(obj, owner))
+	})
+
+	t.Run("non-matching owner UID returns false", func(t *testing.T) {
+		obj := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{UID: types.UID("someone-else")}},
+			},
+		}
+		assert.False(t, isOwnedBy(obj, owner))
+	})
+
+	t.Run("no owner references returns false", func(t *testing.T) {
+		obj := &appsv1.Deployment{}
+		assert.False(t, isOwnedBy(obj, owner))
+	})
+}
+
+func TestComputeChecksum_Stability(t *testing.T) {
+	type payload struct {
+		A string
+		B int
+	}
+	p := payload{A: "x", B: 1}
+
+	// Same input -> same hash.
+	assert.Equal(t, computeChecksum(p), computeChecksum(p))
+	// Output carries the sha256 prefix.
+	assert.Contains(t, computeChecksum(p), "sha256:")
+	// Different input -> different hash.
+	assert.NotEqual(t, computeChecksum(p), computeChecksum(payload{A: "y", B: 1}))
+	assert.NotEqual(t, computeChecksum(p), computeChecksum(payload{A: "x", B: 2}))
+}

--- a/internal/controller/component_descriptors_test.go
+++ b/internal/controller/component_descriptors_test.go
@@ -1,0 +1,195 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	supersetv1alpha1 "github.com/apache/superset-kubernetes-operator/api/v1alpha1"
+	"github.com/apache/superset-kubernetes-operator/internal/common"
+	"github.com/apache/superset-kubernetes-operator/internal/resolution"
+)
+
+func TestConvertComponent(t *testing.T) {
+	t.Run("nil accessor returns nil", func(t *testing.T) {
+		assert.Nil(t, convertComponent(nil))
+	})
+
+	t.Run("maps fields onto the shared input", func(t *testing.T) {
+		replicas := int32(3)
+		dt := &supersetv1alpha1.DeploymentTemplate{}
+		pt := &supersetv1alpha1.PodTemplate{}
+		as := &supersetv1alpha1.AutoscalingSpec{}
+		pdb := &supersetv1alpha1.PDBSpec{}
+		a := &componentAccessor{
+			deploymentTemplate: dt,
+			podTemplate:        pt,
+			replicas:           &replicas,
+			autoscaling:        as,
+			pdb:                pdb,
+		}
+		comp := convertComponent(a)
+		require.NotNil(t, comp)
+		assert.Same(t, dt, comp.DeploymentTemplate)
+		assert.Same(t, pt, comp.PodTemplate)
+		assert.Equal(t, &replicas, comp.Replicas)
+		assert.Same(t, as, comp.Autoscaling)
+		assert.Same(t, pdb, comp.PodDisruptionBudget)
+	})
+}
+
+func TestConvertCloneComponent(t *testing.T) {
+	cmd := []string{"/bin/sh", "-c", "echo clone"}
+
+	t.Run("nil pod template builds a container-only template", func(t *testing.T) {
+		clone := &supersetv1alpha1.CloneTaskSpec{}
+		comp := convertCloneComponent(clone, cmd)
+		require.NotNil(t, comp)
+		require.NotNil(t, comp.PodTemplate)
+		require.NotNil(t, comp.PodTemplate.Container)
+		assert.Equal(t, cmd, comp.PodTemplate.Container.Command)
+	})
+
+	t.Run("existing pod template is copied, command injected", func(t *testing.T) {
+		origCmd := []string{"old"}
+		clone := &supersetv1alpha1.CloneTaskSpec{
+			PodTemplate: &supersetv1alpha1.PodTemplate{
+				Container: &supersetv1alpha1.ContainerTemplate{Command: origCmd},
+			},
+		}
+		comp := convertCloneComponent(clone, cmd)
+		assert.Equal(t, cmd, comp.PodTemplate.Container.Command)
+		// Source spec must not be mutated (copy semantics).
+		assert.Equal(t, origCmd, clone.PodTemplate.Container.Command)
+		assert.NotSame(t, clone.PodTemplate, comp.PodTemplate)
+	})
+
+	t.Run("pod template without container gets a fresh container", func(t *testing.T) {
+		clone := &supersetv1alpha1.CloneTaskSpec{
+			PodTemplate: &supersetv1alpha1.PodTemplate{},
+		}
+		comp := convertCloneComponent(clone, cmd)
+		require.NotNil(t, comp.PodTemplate.Container)
+		assert.Equal(t, cmd, comp.PodTemplate.Container.Command)
+	})
+}
+
+func TestComponentResourceConfig(t *testing.T) {
+	t.Run("known components return their config", func(t *testing.T) {
+		cases := []struct {
+			ct          common.ComponentType
+			defaultPort int32
+			hasScaling  bool
+		}{
+			{common.ComponentWebServer, 0, true},
+			{common.ComponentCeleryWorker, 0, true},
+			{common.ComponentCeleryBeat, 0, false},
+			{common.ComponentCeleryFlower, common.PortCeleryFlower, true},
+			{common.ComponentWebsocketServer, common.PortWebsocket, true},
+			{common.ComponentMcpServer, common.PortMcpServer, true},
+		}
+		for _, c := range cases {
+			cfg, ok := componentResourceConfig(c.ct)
+			require.True(t, ok, "expected config for %s", c.ct)
+			assert.Equal(t, string(c.ct), cfg.componentName)
+			assert.Equal(t, c.defaultPort, cfg.defaultPort)
+			assert.Equal(t, c.hasScaling, cfg.hasScaling)
+		}
+	})
+
+	t.Run("unknown component returns false", func(t *testing.T) {
+		_, ok := componentResourceConfig(common.ComponentType("nope"))
+		assert.False(t, ok)
+	})
+}
+
+func TestWarnEnvVarOverrides(t *testing.T) {
+	op := &resolution.OperatorInjected{
+		Env: []corev1.EnvVar{{Name: "SUPERSET_OPERATOR__SECRET_KEY", Value: "x"}},
+	}
+	envPT := func(name string) *supersetv1alpha1.PodTemplate {
+		return &supersetv1alpha1.PodTemplate{
+			Container: &supersetv1alpha1.ContainerTemplate{
+				Env: []corev1.EnvVar{{Name: name, Value: "user"}},
+			},
+		}
+	}
+
+	// Exercise the collision branch (top-level + component) and the no-collision
+	// branch. The function only logs; we assert it runs without panicking across
+	// the relevant inputs.
+	t.Run("collision on both top-level and component", func(t *testing.T) {
+		tl := &resolution.SharedInput{PodTemplate: envPT("SUPERSET_OPERATOR__SECRET_KEY")}
+		comp := &resolution.ComponentInput{SharedInput: resolution.SharedInput{PodTemplate: envPT("SUPERSET_OPERATOR__SECRET_KEY")}}
+		warnEnvVarOverrides(context.Background(), tl, comp, op)
+	})
+
+	t.Run("no collision", func(t *testing.T) {
+		tl := &resolution.SharedInput{PodTemplate: envPT("MY_OWN_VAR")}
+		comp := &resolution.ComponentInput{SharedInput: resolution.SharedInput{PodTemplate: envPT("OTHER_VAR")}}
+		warnEnvVarOverrides(context.Background(), tl, comp, op)
+	})
+
+	t.Run("nil component", func(t *testing.T) {
+		tl := &resolution.SharedInput{PodTemplate: envPT("MY_OWN_VAR")}
+		warnEnvVarOverrides(context.Background(), tl, nil, op)
+	})
+}
+
+func TestDeleteComponentResources(t *testing.T) {
+	scheme := testScheme(t)
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+	}
+
+	// A web-server component (hasPythonConfig=true, defaultPort=0 so no Service).
+	wsName := common.ResourceBaseName("test", common.ComponentWebServer)
+	deploy := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: wsName, Namespace: "default"}}
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: common.ConfigMapName(wsName), Namespace: "default"}}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(superset, deploy, cm).
+		Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+
+	err := r.deleteComponentResources(context.Background(), superset, webServerDescriptor)
+	require.NoError(t, err)
+
+	// Deployment should be gone.
+	gotDeploy := &appsv1.Deployment{}
+	err = c.Get(context.Background(), client.ObjectKey{Name: wsName, Namespace: "default"}, gotDeploy)
+	assert.True(t, errors.IsNotFound(err), "expected Deployment deleted, got %v", err)
+
+	// ConfigMap should be gone (hasPythonConfig).
+	gotCM := &corev1.ConfigMap{}
+	err = c.Get(context.Background(), client.ObjectKey{Name: common.ConfigMapName(wsName), Namespace: "default"}, gotCM)
+	assert.True(t, errors.IsNotFound(err), "expected ConfigMap deleted, got %v", err)
+}

--- a/internal/controller/component_reconciler_test.go
+++ b/internal/controller/component_reconciler_test.go
@@ -1,0 +1,206 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	supersetv1alpha1 "github.com/apache/superset-kubernetes-operator/api/v1alpha1"
+	"github.com/apache/superset-kubernetes-operator/internal/common"
+)
+
+func TestPreserveServiceAllocatedFields_ExternalNameAndHealthCheck(t *testing.T) {
+	t.Run("preserves HealthCheckNodePort", func(t *testing.T) {
+		existing := corev1.ServiceSpec{HealthCheckNodePort: 31000}
+		desired := corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP}
+		preserveServiceAllocatedFields(&desired, existing)
+		assert.Equal(t, int32(31000), desired.HealthCheckNodePort)
+	})
+
+	t.Run("clears ClusterIP for ExternalName services", func(t *testing.T) {
+		existing := corev1.ServiceSpec{ClusterIP: "10.0.0.5", ClusterIPs: []string{"10.0.0.5"}}
+		desired := corev1.ServiceSpec{Type: corev1.ServiceTypeExternalName}
+		preserveServiceAllocatedFields(&desired, existing)
+
+		assert.Empty(t, desired.ClusterIP)
+		assert.Nil(t, desired.ClusterIPs)
+		assert.Nil(t, desired.IPFamilies)
+		assert.Nil(t, desired.IPFamilyPolicy)
+	})
+}
+
+func TestReconcileComponentResources_NoServiceNoScaling(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+	owner := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "uid-1"},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(owner).Build()
+	recorder := events.NewFakeRecorder(20)
+
+	one := int32(1)
+	spec := &supersetv1alpha1.FlatComponentSpec{
+		Image:    supersetv1alpha1.ImageSpec{Repository: "apache/superset", Tag: "latest"},
+		Replicas: &one,
+	}
+	// CeleryBeat: defaultPort=0 (no Service), hasScaling=false.
+	cfg, ok := componentResourceConfig(common.ComponentCeleryBeat)
+	require.True(t, ok)
+
+	err := reconcileComponentResources(ctx, c, scheme, recorder, owner, spec, cfg, "", nil, nil, nil)
+	require.NoError(t, err)
+
+	resourceBaseName := common.ResourceBaseName("test", common.ComponentCeleryBeat)
+	// Deployment created.
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: resourceBaseName, Namespace: "default"}, &appsv1.Deployment{}))
+	// No Service created (defaultPort 0).
+	err = c.Get(ctx, client.ObjectKey{Name: resourceBaseName, Namespace: "default"}, &corev1.Service{})
+	assert.True(t, errors.IsNotFound(err), "celery-beat should not create a Service")
+}
+
+func TestReconcileComponentService_PreservesClusterIPAcrossUpdate(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+	owner := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "uid-1"},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(owner).Build()
+
+	resourceBaseName := common.ResourceBaseName("test", common.ComponentCeleryFlower)
+	componentName := string(common.ComponentCeleryFlower)
+
+	// First reconcile creates the Service.
+	require.NoError(t, reconcileComponentService(ctx, c, scheme, owner, nil, componentName, common.PortCeleryFlower, common.PortCeleryFlower, resourceBaseName))
+
+	// Simulate the API server allocating a ClusterIP.
+	svc := &corev1.Service{}
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: resourceBaseName, Namespace: "default"}, svc))
+	svc.Spec.ClusterIP = "10.20.30.40"
+	svc.Spec.ClusterIPs = []string{"10.20.30.40"}
+	require.NoError(t, c.Update(ctx, svc))
+
+	// Second reconcile must preserve the allocated ClusterIP.
+	require.NoError(t, reconcileComponentService(ctx, c, scheme, owner, nil, componentName, common.PortCeleryFlower, common.PortCeleryFlower, resourceBaseName))
+
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: resourceBaseName, Namespace: "default"}, svc))
+	assert.Equal(t, "10.20.30.40", svc.Spec.ClusterIP)
+	// Selector is the operator-managed component label set.
+	assert.Equal(t, string(common.ComponentCeleryFlower), svc.Spec.Selector[common.LabelKeyComponent])
+	// Owned by the parent.
+	assert.True(t, isOwnedBy(svc, owner))
+}
+
+func TestReconcileScaling_NoAutoscalingOrPDB(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+	owner := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "uid-1"},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(owner).Build()
+
+	resourceBaseName := common.ResourceBaseName("test", common.ComponentWebServer)
+	// With nil autoscaling/pdb, reconcileScaling should be a clean no-op (it
+	// reconciles "absent" HPA/PDB which means deleting any that exist).
+	err := reconcileScaling(ctx, c, scheme, owner, nil, nil, string(common.ComponentWebServer), resourceBaseName)
+	assert.NoError(t, err)
+}
+
+func TestReconcileComponentResources_CreatesDeploymentAndService(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+	owner := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "uid-1"},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(owner).Build()
+	recorder := events.NewFakeRecorder(20)
+
+	one := int32(1)
+	spec := &supersetv1alpha1.FlatComponentSpec{
+		Image:    supersetv1alpha1.ImageSpec{Repository: "apache/superset", Tag: "latest"},
+		Replicas: &one,
+	}
+	cfg, ok := componentResourceConfig(common.ComponentCeleryFlower)
+	require.True(t, ok)
+
+	err := reconcileComponentResources(ctx, c, scheme, recorder, owner, spec, cfg, "cfg-sum", nil, nil, nil)
+	require.NoError(t, err)
+
+	// Deployment created.
+	resourceBaseName := common.ResourceBaseName("test", common.ComponentCeleryFlower)
+	deploy := &appsv1.Deployment{}
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: resourceBaseName, Namespace: "default"}, deploy))
+	assert.True(t, isOwnedBy(deploy, owner))
+	// Config checksum stamped as a pod annotation.
+	assert.Equal(t, "cfg-sum", deploy.Spec.Template.Annotations[common.AnnotationConfigChecksum])
+
+	// Service created (flower has defaultPort > 0).
+	svc := &corev1.Service{}
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: resourceBaseName, Namespace: "default"}, svc))
+	assert.Equal(t, common.PortCeleryFlower, svc.Spec.Ports[0].Port)
+}
+
+func TestDeleteByLabels_KeepsNamedAndDeletesRest(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+	labels := map[string]string{"app": "x"}
+
+	keep := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "keep", Namespace: "default", Labels: labels}}
+	drop := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "drop", Namespace: "default", Labels: labels}}
+	unrelated := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "default", Labels: map[string]string{"app": "y"}}}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(keep, drop, unrelated).Build()
+
+	err := deleteByLabels(ctx, c, "default", labels, func() client.ObjectList { return &corev1.ServiceList{} }, "keep")
+	require.NoError(t, err)
+
+	// "keep" remains.
+	assert.NoError(t, c.Get(ctx, client.ObjectKey{Name: "keep", Namespace: "default"}, &corev1.Service{}))
+	// "drop" deleted.
+	err = c.Get(ctx, client.ObjectKey{Name: "drop", Namespace: "default"}, &corev1.Service{})
+	assert.True(t, errors.IsNotFound(err))
+	// Unrelated (different labels) untouched.
+	assert.NoError(t, c.Get(ctx, client.ObjectKey{Name: "other", Namespace: "default"}, &corev1.Service{}))
+}
+
+func TestDeleteByLabels_EmptyKeepNameDeletesAll(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+	labels := map[string]string{"app": "x"}
+	a := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "default", Labels: labels}}
+	b := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "default", Labels: labels}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(a, b).Build()
+
+	require.NoError(t, deleteByLabels(ctx, c, "default", labels, func() client.ObjectList { return &corev1.ServiceList{} }, ""))
+
+	for _, name := range []string{"a", "b"} {
+		err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: "default"}, &corev1.Service{})
+		assert.True(t, errors.IsNotFound(err), "expected %s deleted", name)
+	}
+}

--- a/internal/controller/config_test.go
+++ b/internal/controller/config_test.go
@@ -464,6 +464,54 @@ func envSliceToMap(envs []corev1.EnvVar) map[string]string {
 	return m
 }
 
+func TestResolveValkeyResults(t *testing.T) {
+	t.Run("nil spec applies defaults", func(t *testing.T) {
+		// Use a non-standard defaultDB and prefix to prove both arguments are
+		// honored (not hardcoded) and to keep the function's default parameters
+		// genuinely variable across call sites.
+		got := resolveValkeyResults(nil, 13, "custom_default_")
+		if got.Disabled {
+			t.Error("expected not disabled by default")
+		}
+		if got.Database != 13 {
+			t.Errorf("expected default database 13, got %d", got.Database)
+		}
+		if got.KeyPrefix != "custom_default_" {
+			t.Errorf("expected default key prefix, got %q", got.KeyPrefix)
+		}
+	})
+
+	t.Run("disabled true", func(t *testing.T) {
+		got := resolveValkeyResults(&supersetv1alpha1.ValkeyResultsBackendSpec{Disabled: common.Ptr(true)}, 6, "superset_results_")
+		if !got.Disabled {
+			t.Error("expected disabled=true")
+		}
+		if got.Database != 6 {
+			t.Errorf("expected default database 6, got %d", got.Database)
+		}
+	})
+
+	t.Run("database override", func(t *testing.T) {
+		got := resolveValkeyResults(&supersetv1alpha1.ValkeyResultsBackendSpec{Database: common.Ptr(int32(9))}, 6, "superset_results_")
+		if got.Database != 9 {
+			t.Errorf("expected database override 9, got %d", got.Database)
+		}
+		if got.KeyPrefix != "superset_results_" {
+			t.Errorf("expected default key prefix preserved, got %q", got.KeyPrefix)
+		}
+	})
+
+	t.Run("key prefix override", func(t *testing.T) {
+		got := resolveValkeyResults(&supersetv1alpha1.ValkeyResultsBackendSpec{KeyPrefix: common.Ptr("custom_results_")}, 6, "superset_results_")
+		if got.KeyPrefix != "custom_results_" {
+			t.Errorf("expected key prefix override, got %q", got.KeyPrefix)
+		}
+		if got.Database != 6 {
+			t.Errorf("expected default database preserved, got %d", got.Database)
+		}
+	})
+}
+
 func TestBuildConfigInput_Valkey(t *testing.T) {
 	t.Run("nil valkey", func(t *testing.T) {
 		input := buildConfigInput(&supersetv1alpha1.SupersetSpec{})

--- a/internal/controller/drain_test.go
+++ b/internal/controller/drain_test.go
@@ -409,3 +409,148 @@ func assertNoEvents(t *testing.T, recorder *events.FakeRecorder) {
 	default:
 	}
 }
+
+func TestDrainComponents_DeletesWorkloadsAndReportsDrained(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: supersetv1alpha1.SupersetSpec{
+			WebServer:    &supersetv1alpha1.WebServerComponentSpec{},
+			CeleryWorker: &supersetv1alpha1.CeleryWorkerComponentSpec{},
+		},
+	}
+
+	webDeploy := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name: common.ResourceBaseName("test", common.ComponentWebServer), Namespace: "default",
+	}}
+	workerDeploy := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name: common.ResourceBaseName("test", common.ComponentCeleryWorker), Namespace: "default",
+	}}
+	// A celery-worker Service (non-web-server) should be deleted too.
+	workerSvc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name: common.ResourceBaseName("test", common.ComponentCeleryWorker), Namespace: "default",
+	}}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(superset, webDeploy, workerDeploy, workerSvc).Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+
+	// No component pods exist, so drain completes in a single pass.
+	drained, err := r.drainComponents(ctx, superset)
+	if err != nil {
+		t.Fatalf("drainComponents: %v", err)
+	}
+	if !drained {
+		t.Fatal("expected drained=true when no component pods remain")
+	}
+
+	// Deployments deleted.
+	for _, name := range []string{
+		common.ResourceBaseName("test", common.ComponentWebServer),
+		common.ResourceBaseName("test", common.ComponentCeleryWorker),
+	} {
+		err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: "default"}, &appsv1.Deployment{})
+		if err == nil {
+			t.Errorf("expected Deployment %s deleted", name)
+		}
+	}
+	// Worker Service deleted.
+	if err := c.Get(ctx, client.ObjectKey{Name: workerSvc.Name, Namespace: "default"}, &corev1.Service{}); err == nil {
+		t.Error("expected celery-worker Service deleted during drain")
+	}
+}
+
+func TestDrainComponents_WaitsForComponentPods(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       supersetv1alpha1.SupersetSpec{WebServer: &supersetv1alpha1.WebServerComponentSpec{}},
+	}
+	// A surviving web-server pod blocks drain completion.
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "test-web-server-x", Namespace: "default",
+		Labels: map[string]string{
+			common.LabelKeyParent:    "test",
+			common.LabelKeyComponent: string(common.ComponentWebServer),
+		},
+	}}
+	// An init pod must NOT block drain.
+	initPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "test-init-y", Namespace: "default",
+		Labels: map[string]string{
+			common.LabelKeyParent:    "test",
+			common.LabelKeyComponent: string(common.ComponentInit),
+		},
+	}}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(superset, pod, initPod).Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+
+	drained, err := r.drainComponents(ctx, superset)
+	if err != nil {
+		t.Fatalf("drainComponents: %v", err)
+	}
+	if drained {
+		t.Fatal("expected drained=false while a component pod remains")
+	}
+}
+
+func TestHasExistingWebServerWorkload(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+	}
+
+	t.Run("no workload returns false", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(superset).Build()
+		r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+		has, err := r.hasExistingWebServerWorkload(ctx, superset)
+		if err != nil {
+			t.Fatalf("hasExistingWebServerWorkload: %v", err)
+		}
+		if has {
+			t.Error("expected no workload")
+		}
+	})
+
+	t.Run("deployment with replicas returns true", func(t *testing.T) {
+		one := int32(1)
+		deploy := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: common.ResourceBaseName("test", common.ComponentWebServer), Namespace: "default",
+			},
+			Spec: appsv1.DeploymentSpec{Replicas: &one},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(superset, deploy).Build()
+		r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+		has, err := r.hasExistingWebServerWorkload(ctx, superset)
+		if err != nil {
+			t.Fatalf("hasExistingWebServerWorkload: %v", err)
+		}
+		if !has {
+			t.Error("expected workload present")
+		}
+	})
+
+	t.Run("live web-server pod returns true even without deployment", func(t *testing.T) {
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name: "test-web-server-z", Namespace: "default",
+			Labels: map[string]string{
+				common.LabelKeyParent:    "test",
+				common.LabelKeyComponent: string(common.ComponentWebServer),
+			},
+		}}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(superset, pod).Build()
+		r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+		has, err := r.hasExistingWebServerWorkload(ctx, superset)
+		if err != nil {
+			t.Fatalf("hasExistingWebServerWorkload: %v", err)
+		}
+		if !has {
+			t.Error("expected live pod to count as a workload")
+		}
+	})
+}

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -58,6 +58,15 @@ func TestMergeLabels(t *testing.T) {
 	if merged2["a"] != "1" {
 		t.Errorf("expected base labels returned for nil extra, got %v", merged2)
 	}
+
+	// Both nil/empty must return a non-nil empty map (required for label selectors).
+	merged3 := mergeLabels(nil, nil)
+	if merged3 == nil {
+		t.Fatal("expected non-nil empty map for both-nil input")
+	}
+	if len(merged3) != 0 {
+		t.Errorf("expected empty map, got %v", merged3)
+	}
 }
 
 func TestMergeAnnotations(t *testing.T) {

--- a/internal/controller/initpod_test.go
+++ b/internal/controller/initpod_test.go
@@ -23,7 +23,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+
+	supersetv1alpha1 "github.com/apache/superset-kubernetes-operator/api/v1alpha1"
+	"github.com/apache/superset-kubernetes-operator/internal/common"
 )
 
 func TestCalculateBackoff(t *testing.T) {
@@ -45,6 +49,85 @@ func TestCalculateBackoff(t *testing.T) {
 			assert.Equal(t, tt.want, calculateBackoff(tt.attempt))
 		})
 	}
+}
+
+func TestBuildInitPod(t *testing.T) {
+	t.Run("minimal spec builds a never-restart pod with the superset container", func(t *testing.T) {
+		spec := &supersetv1alpha1.FlatComponentSpec{
+			Image: supersetv1alpha1.ImageSpec{
+				Repository: "apache/superset",
+				Tag:        "4.0.0",
+				PullPolicy: corev1.PullIfNotPresent,
+			},
+		}
+		pod := buildInitPod(spec)
+		assert.Equal(t, corev1.RestartPolicyNever, pod.RestartPolicy)
+		require.Len(t, pod.Containers, 1)
+		c := pod.Containers[0]
+		assert.Equal(t, common.Container, c.Name)
+		assert.Equal(t, "apache/superset:4.0.0", c.Image)
+		assert.Equal(t, corev1.PullIfNotPresent, c.ImagePullPolicy)
+		assert.Empty(t, pod.ServiceAccountName)
+	})
+
+	t.Run("propagates container and pod template fields", func(t *testing.T) {
+		runAsUser := int64(1000)
+		gracePeriod := int64(45)
+		spec := &supersetv1alpha1.FlatComponentSpec{
+			Image:              supersetv1alpha1.ImageSpec{Repository: "apache/superset", Tag: "latest"},
+			ServiceAccountName: "sa-init",
+			PodTemplate: &supersetv1alpha1.PodTemplate{
+				NodeSelector:                  map[string]string{"disktype": "ssd"},
+				TerminationGracePeriodSeconds: &gracePeriod,
+				PodSecurityContext:            &corev1.PodSecurityContext{RunAsUser: &runAsUser},
+				Volumes: []corev1.Volume{
+					{Name: "config", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+				},
+				Sidecars:       []corev1.Container{{Name: "sidecar"}},
+				InitContainers: []corev1.Container{{Name: "pre"}},
+				Container: &supersetv1alpha1.ContainerTemplate{
+					Command:      []string{"/bin/sh", "-c", "superset init"},
+					Args:         []string{"--flag"},
+					Env:          []corev1.EnvVar{{Name: "FOO", Value: "bar"}},
+					VolumeMounts: []corev1.VolumeMount{{Name: "config", MountPath: "/app/pythonpath"}},
+				},
+			},
+		}
+		pod := buildInitPod(spec)
+
+		assert.Equal(t, "sa-init", pod.ServiceAccountName)
+		assert.Equal(t, map[string]string{"disktype": "ssd"}, pod.NodeSelector)
+		require.NotNil(t, pod.TerminationGracePeriodSeconds)
+		assert.Equal(t, int64(45), *pod.TerminationGracePeriodSeconds)
+		require.NotNil(t, pod.SecurityContext)
+		assert.Equal(t, int64(1000), *pod.SecurityContext.RunAsUser)
+		assert.Len(t, pod.Volumes, 1)
+
+		// Main container is first; sidecar appended after.
+		require.Len(t, pod.Containers, 2)
+		assert.Equal(t, common.Container, pod.Containers[0].Name)
+		assert.Equal(t, []string{"/bin/sh", "-c", "superset init"}, pod.Containers[0].Command)
+		assert.Equal(t, []string{"--flag"}, pod.Containers[0].Args)
+		assert.Equal(t, "sidecar", pod.Containers[1].Name)
+
+		require.Len(t, pod.InitContainers, 1)
+		assert.Equal(t, "pre", pod.InitContainers[0].Name)
+	})
+
+	t.Run("dns policy and priority class are applied when set", func(t *testing.T) {
+		dnsPolicy := corev1.DNSClusterFirstWithHostNet
+		prio := "high"
+		spec := &supersetv1alpha1.FlatComponentSpec{
+			Image: supersetv1alpha1.ImageSpec{Repository: "apache/superset", Tag: "latest"},
+			PodTemplate: &supersetv1alpha1.PodTemplate{
+				DNSPolicy:         &dnsPolicy,
+				PriorityClassName: &prio,
+			},
+		}
+		pod := buildInitPod(spec)
+		assert.Equal(t, dnsPolicy, pod.DNSPolicy)
+		assert.Equal(t, "high", pod.PriorityClassName)
+	})
 }
 
 func TestShouldDeletePod(t *testing.T) {

--- a/internal/controller/lifecycle_defaults_test.go
+++ b/internal/controller/lifecycle_defaults_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package controller
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	supersetv1alpha1 "github.com/apache/superset-kubernetes-operator/api/v1alpha1"
+	"github.com/apache/superset-kubernetes-operator/internal/common"
 )
 
 func TestTaskMaxRetriesValue(t *testing.T) {
@@ -157,4 +159,76 @@ func TestSuffixForTaskType(t *testing.T) {
 			assert.Equal(t, tt.want, suffixForTaskType(tt.taskType))
 		})
 	}
+}
+
+func TestDefaultMigrateCommand(t *testing.T) {
+	t.Run("default db upgrade", func(t *testing.T) {
+		s := &supersetv1alpha1.Superset{}
+		got := defaultMigrateCommand(s)
+		assert.Equal(t, []string{"/bin/sh", "-c", "superset db upgrade"}, got)
+	})
+
+	t.Run("user override wins", func(t *testing.T) {
+		s := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{
+			Lifecycle: &supersetv1alpha1.LifecycleSpec{Migrate: &supersetv1alpha1.MigrateTaskSpec{
+				BaseTaskSpec: supersetv1alpha1.BaseTaskSpec{Command: []string{"superset", "db", "stamp", "head"}},
+			}},
+		}}
+		got := defaultMigrateCommand(s)
+		assert.Equal(t, []string{"superset", "db", "stamp", "head"}, got)
+	})
+
+	t.Run("bootstrap script is prepended to the default", func(t *testing.T) {
+		script := "pip install foo"
+		s := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{
+			BootstrapScript: &script,
+		}}
+		got := defaultMigrateCommand(s)
+		want := []string{"/bin/sh", "-c",
+			". '" + common.ConfigMountPath + "/" + bootstrapScriptKey + "'; superset db upgrade"}
+		assert.Equal(t, want, got)
+	})
+}
+
+func TestDefaultInitCommand(t *testing.T) {
+	t.Run("default superset init", func(t *testing.T) {
+		s := &supersetv1alpha1.Superset{}
+		got := defaultInitCommand(s)
+		assert.Equal(t, []string{"/bin/sh", "-c", "superset init"}, got)
+	})
+
+	t.Run("user override wins", func(t *testing.T) {
+		s := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{
+			Lifecycle: &supersetv1alpha1.LifecycleSpec{Init: &supersetv1alpha1.InitTaskSpec{
+				BaseTaskSpec: supersetv1alpha1.BaseTaskSpec{Command: []string{"echo", "custom"}},
+			}},
+		}}
+		got := defaultInitCommand(s)
+		assert.Equal(t, []string{"echo", "custom"}, got)
+	})
+
+	t.Run("bootstrap script is prepended to the default", func(t *testing.T) {
+		script := "pip install foo"
+		s := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{
+			BootstrapScript: &script,
+		}}
+		got := defaultInitCommand(s)
+		want := []string{"/bin/sh", "-c",
+			". '" + common.ConfigMountPath + "/" + bootstrapScriptKey + "'; superset init"}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("admin user is appended before bootstrap wrapping", func(t *testing.T) {
+		s := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{
+			Lifecycle: &supersetv1alpha1.LifecycleSpec{Init: &supersetv1alpha1.InitTaskSpec{
+				AdminUser: &supersetv1alpha1.AdminUserSpec{},
+			}},
+		}}
+		got := defaultInitCommand(s)
+		// No bootstrap, so identical to buildInitCommand output.
+		want := buildInitCommand(s.Spec.Lifecycle.Init)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("defaultInitCommand() = %#v, want %#v", got, want)
+		}
+	})
 }

--- a/internal/controller/lifecycle_job_test.go
+++ b/internal/controller/lifecycle_job_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	batchv1 "k8s.io/api/batch/v1"
@@ -387,5 +388,122 @@ func TestJobFailureMessage(t *testing.T) {
 		long := strings.Repeat("x", maxTerminationMessageLen+5)
 		got := jobFailureMessage(failed("BackoffLimitExceeded", long))
 		assert.Len(t, got, maxTerminationMessageLen)
+	})
+}
+
+func TestResetTaskStatusForRun(t *testing.T) {
+	now := metav1.Now()
+	taskRef := &supersetv1alpha1.TaskRefStatus{
+		State:             taskStateComplete,
+		StartedAt:         &now,
+		CompletedAt:       &now,
+		Attempts:          2,
+		MaxRetries:        1,
+		NextAttemptAt:     &now,
+		DesiredChecksum:   "old-desired",
+		CompletedChecksum: "old-completed",
+		Message:           "stale message",
+		Conditions:        []metav1.Condition{{Type: "Ready"}},
+	}
+
+	resetTaskStatusForRun(taskRef, "new-checksum", 5)
+
+	assert.Equal(t, taskStatePending, taskRef.State)
+	assert.Nil(t, taskRef.StartedAt)
+	assert.Nil(t, taskRef.CompletedAt)
+	assert.Zero(t, taskRef.Attempts)
+	assert.Equal(t, int32(5), taskRef.MaxRetries)
+	assert.Nil(t, taskRef.NextAttemptAt)
+	assert.Equal(t, "new-checksum", taskRef.DesiredChecksum)
+	assert.Empty(t, taskRef.CompletedChecksum)
+	assert.Empty(t, taskRef.Message)
+	assert.Nil(t, taskRef.Conditions)
+}
+
+func TestJobComplete(t *testing.T) {
+	t.Run("succeeded count marks complete", func(t *testing.T) {
+		assert.True(t, jobComplete(&batchv1.Job{Status: batchv1.JobStatus{Succeeded: 1}}))
+	})
+	t.Run("complete condition marks complete", func(t *testing.T) {
+		job := &batchv1.Job{Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+			Type: batchv1.JobComplete, Status: corev1.ConditionTrue,
+		}}}}
+		assert.True(t, jobComplete(job))
+	})
+	t.Run("complete condition that is false is not complete", func(t *testing.T) {
+		job := &batchv1.Job{Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+			Type: batchv1.JobComplete, Status: corev1.ConditionFalse,
+		}}}}
+		assert.False(t, jobComplete(job))
+	})
+	t.Run("empty status is not complete", func(t *testing.T) {
+		assert.False(t, jobComplete(&batchv1.Job{}))
+	})
+}
+
+func TestJobConditionTransitionTime(t *testing.T) {
+	transition := metav1.NewTime(metav1.Now().Add(-time.Hour))
+	job := &batchv1.Job{Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+		Type:               batchv1.JobComplete,
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: transition,
+	}}}}
+
+	got := jobConditionTransitionTime(job, batchv1.JobComplete)
+	if assert.NotNil(t, got) {
+		assert.Equal(t, transition, *got)
+	}
+	assert.Nil(t, jobConditionTransitionTime(job, batchv1.JobFailed), "absent condition returns nil")
+
+	falseCond := &batchv1.Job{Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+		Type: batchv1.JobComplete, Status: corev1.ConditionFalse, LastTransitionTime: transition,
+	}}}}
+	assert.Nil(t, jobConditionTransitionTime(falseCond, batchv1.JobComplete), "false condition returns nil")
+}
+
+func TestLifecycleJobMainImage(t *testing.T) {
+	t.Run("nil job returns empty", func(t *testing.T) {
+		assert.Empty(t, lifecycleJobMainImage(nil))
+	})
+	t.Run("prefers the named superset container", func(t *testing.T) {
+		job := &batchv1.Job{Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "sidecar", Image: "sidecar:1"},
+				{Name: common.Container, Image: "apache/superset:2"},
+			},
+		}}}}
+		assert.Equal(t, "apache/superset:2", lifecycleJobMainImage(job))
+	})
+	t.Run("falls back to the first container", func(t *testing.T) {
+		job := &batchv1.Job{Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "other", Image: "first:1"}},
+		}}}}
+		assert.Equal(t, "first:1", lifecycleJobMainImage(job))
+	})
+	t.Run("empty containers returns empty", func(t *testing.T) {
+		assert.Empty(t, lifecycleJobMainImage(&batchv1.Job{}))
+	})
+}
+
+func TestTaskJobMatchesChecksum(t *testing.T) {
+	r := &SupersetReconciler{}
+	withChecksum := func(checksum string) *batchv1.Job {
+		return &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+			common.AnnotationConfigChecksum: checksum,
+		}}}
+	}
+
+	t.Run("matching annotation matches", func(t *testing.T) {
+		assert.True(t, r.taskJobMatchesChecksum(withChecksum("sha:1"), "sha:1"))
+	})
+	t.Run("mismatched annotation does not match", func(t *testing.T) {
+		assert.False(t, r.taskJobMatchesChecksum(withChecksum("sha:1"), "sha:2"))
+	})
+	t.Run("unannotated in-flight job is treated as matching", func(t *testing.T) {
+		assert.True(t, r.taskJobMatchesChecksum(&batchv1.Job{}, "sha:1"))
+	})
+	t.Run("unannotated completed job does not match", func(t *testing.T) {
+		job := &batchv1.Job{Status: batchv1.JobStatus{Succeeded: 1}}
+		assert.False(t, r.taskJobMatchesChecksum(job, "sha:1"))
 	})
 }

--- a/internal/controller/lifecycle_pipeline_test.go
+++ b/internal/controller/lifecycle_pipeline_test.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -183,4 +185,168 @@ func markJobSucceeded(t *testing.T, c client.Client, job *batchv1.Job) {
 	if err := c.Status().Update(context.Background(), job); err != nil {
 		t.Fatalf("marking %s job succeeded: %v", job.Name, err)
 	}
+}
+
+func TestClearUpgradeApprovalAnnotation(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+
+	t.Run("no annotations is a no-op", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(superset).Build()
+		r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+		assert.NoError(t, r.clearUpgradeApprovalAnnotation(ctx, superset))
+	})
+
+	t.Run("annotation present is removed via patch", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+				Annotations: map[string]string{
+					annotationApproveUpgrade: "token-123",
+					"keep":                   "me",
+				},
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(superset).Build()
+		r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+
+		require.NoError(t, r.clearUpgradeApprovalAnnotation(ctx, superset))
+
+		got := &supersetv1alpha1.Superset{}
+		require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "test", Namespace: "default"}, got))
+		_, present := got.Annotations[annotationApproveUpgrade]
+		assert.False(t, present, "approval annotation should be removed")
+		assert.Equal(t, "me", got.Annotations["keep"], "other annotations are preserved")
+	})
+
+	t.Run("different annotations present, no approval key is a no-op", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test", Namespace: "default",
+				Annotations: map[string]string{"other": "v"},
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(superset).Build()
+		r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+		assert.NoError(t, r.clearUpgradeApprovalAnnotation(ctx, superset))
+	})
+}
+
+func TestDeleteLifecycleTaskResources(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "uid-1"},
+		Status: supersetv1alpha1.SupersetStatus{
+			Lifecycle: &supersetv1alpha1.LifecycleStatus{
+				Migrate:                &supersetv1alpha1.TaskRefStatus{State: taskStateComplete},
+				LastCompletedChecksums: map[string]string{taskTypeMigrate: "sum"},
+			},
+		},
+	}
+	taskName := "test" + suffixMigrate
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      taskName,
+		Namespace: "default",
+		Labels:    map[string]string{labelInitTask: taskName, labelInitInstance: "test"},
+	}}
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test-migrate-config", Namespace: "default"}}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(superset, job, cm).Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+
+	require.NoError(t, r.deleteLifecycleTaskResources(ctx, superset, taskTypeMigrate, suffixMigrate))
+
+	// Status slot cleared.
+	assert.Nil(t, superset.Status.Lifecycle.Migrate)
+	_, present := superset.Status.Lifecycle.LastCompletedChecksums[taskTypeMigrate]
+	assert.False(t, present, "completed checksum entry should be deleted")
+}
+
+func TestFinalizeLifecycle(t *testing.T) {
+	t.Run("with components enters Restoring", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{
+			Spec: supersetv1alpha1.SupersetSpec{WebServer: &supersetv1alpha1.WebServerComponentSpec{}},
+			Status: supersetv1alpha1.SupersetStatus{Lifecycle: &supersetv1alpha1.LifecycleStatus{
+				Upgrade: &supersetv1alpha1.UpgradeContext{FromVersion: "1", ToVersion: "2"},
+			}},
+		}
+		r := &SupersetReconciler{Recorder: events.NewFakeRecorder(10)}
+		r.finalizeLifecycle(superset, "apache/superset:2")
+		assert.Equal(t, lifecyclePhaseRestoring, superset.Status.Lifecycle.Phase)
+		assert.Equal(t, "apache/superset:2", superset.Status.LastLifecycleImage)
+		assert.Nil(t, superset.Status.Lifecycle.Upgrade, "settle clears the upgrade context")
+		assert.True(t, hasConditionReason(superset.Status.Conditions, supersetv1alpha1.ConditionTypeLifecycleComplete, "LifecycleComplete"))
+	})
+
+	t.Run("without components enters Complete", func(t *testing.T) {
+		superset := &supersetv1alpha1.Superset{
+			Status: supersetv1alpha1.SupersetStatus{Lifecycle: &supersetv1alpha1.LifecycleStatus{}},
+		}
+		r := &SupersetReconciler{Recorder: events.NewFakeRecorder(10)}
+		r.finalizeLifecycle(superset, "apache/superset:2")
+		assert.Equal(t, lifecyclePhaseComplete, superset.Status.Lifecycle.Phase)
+	})
+}
+
+func TestCheckUpgradeGates(t *testing.T) {
+	ctx := context.Background()
+	r := &SupersetReconciler{Recorder: events.NewFakeRecorder(10)}
+
+	t.Run("no image change is not gated", func(t *testing.T) {
+		s := &supersetv1alpha1.Superset{Status: supersetv1alpha1.SupersetStatus{Lifecycle: &supersetv1alpha1.LifecycleStatus{}}}
+		_, gated := r.checkUpgradeGates(ctx, s, false, "apache/superset:1", "apache/superset:1")
+		assert.False(t, gated)
+	})
+
+	t.Run("first install (empty lastImage) is not gated", func(t *testing.T) {
+		s := &supersetv1alpha1.Superset{Status: supersetv1alpha1.SupersetStatus{Lifecycle: &supersetv1alpha1.LifecycleStatus{}}}
+		_, gated := r.checkUpgradeGates(ctx, s, true, "", "apache/superset:1")
+		assert.False(t, gated)
+	})
+
+	t.Run("downgrade blocks with terminal result", func(t *testing.T) {
+		s := &supersetv1alpha1.Superset{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			Status:     supersetv1alpha1.SupersetStatus{Lifecycle: &supersetv1alpha1.LifecycleStatus{}},
+		}
+		res, gated := r.checkUpgradeGates(ctx, s, true, "apache/superset:3.0.0", "apache/superset:2.0.0")
+		assert.True(t, gated)
+		assert.True(t, res.TerminalFailure)
+		assert.Equal(t, lifecyclePhaseBlocked, s.Status.Lifecycle.Phase)
+		assert.True(t, hasConditionReason(s.Status.Conditions, supersetv1alpha1.ConditionTypeLifecycleComplete, "DowngradeBlocked"))
+	})
+
+	t.Run("supervised upgrade awaits approval", func(t *testing.T) {
+		mode := upgradeModeSupervised
+		s := &supersetv1alpha1.Superset{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			Spec: supersetv1alpha1.SupersetSpec{
+				Lifecycle: &supersetv1alpha1.LifecycleSpec{UpgradeMode: &mode},
+			},
+			Status: supersetv1alpha1.SupersetStatus{Lifecycle: &supersetv1alpha1.LifecycleStatus{}},
+		}
+		res, gated := r.checkUpgradeGates(ctx, s, true, "apache/superset:2.0.0", "apache/superset:3.0.0")
+		assert.True(t, gated)
+		assert.False(t, res.TerminalFailure)
+		assert.Equal(t, lifecyclePhaseAwaitingApproval, s.Status.Lifecycle.Phase)
+		assert.Equal(t, phaseAwaitingApproval, s.Status.Phase)
+	})
+
+	t.Run("automatic upgrade proceeds past the gate", func(t *testing.T) {
+		s := &supersetv1alpha1.Superset{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			Status:     supersetv1alpha1.SupersetStatus{Lifecycle: &supersetv1alpha1.LifecycleStatus{}},
+		}
+		_, gated := r.checkUpgradeGates(ctx, s, true, "apache/superset:2.0.0", "apache/superset:3.0.0")
+		assert.False(t, gated)
+		// Upgrade context recorded for the in-flight upgrade.
+		require.NotNil(t, s.Status.Lifecycle.Upgrade)
+		assert.Equal(t, "2.0.0", s.Status.Lifecycle.Upgrade.FromVersion)
+		assert.Equal(t, "3.0.0", s.Status.Lifecycle.Upgrade.ToVersion)
+	})
 }

--- a/internal/controller/lifecycle_predicates_test.go
+++ b/internal/controller/lifecycle_predicates_test.go
@@ -169,3 +169,43 @@ func TestResolveLifecycleImage(t *testing.T) {
 		})
 	}
 }
+
+func TestTaskRequiresDrain(t *testing.T) {
+	r := &SupersetReconciler{}
+
+	t.Run("isTaskEnabled is false for unknown task type", func(t *testing.T) {
+		// The descriptor lookup misses, so the wrapper short-circuits to false.
+		assert.False(t, r.isTaskEnabled(&supersetv1alpha1.Superset{}, "Bogus"))
+	})
+
+	t.Run("unknown task type does not drain", func(t *testing.T) {
+		assert.False(t, r.taskRequiresDrain(&supersetv1alpha1.Superset{}, "Bogus"))
+	})
+
+	t.Run("defaults per task type", func(t *testing.T) {
+		// clone/migrate/rotate default to draining; init does not.
+		empty := &supersetv1alpha1.Superset{}
+		assert.True(t, r.taskRequiresDrain(empty, taskTypeClone))
+		assert.True(t, r.taskRequiresDrain(empty, taskTypeMigrate))
+		assert.True(t, r.taskRequiresDrain(empty, taskTypeRotate))
+		assert.False(t, r.taskRequiresDrain(empty, taskTypeInit))
+	})
+
+	t.Run("per-task RequiresDrain override wins", func(t *testing.T) {
+		// Override migrate (default true) to false.
+		noDrain := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{
+			Lifecycle: &supersetv1alpha1.LifecycleSpec{Migrate: &supersetv1alpha1.MigrateTaskSpec{
+				BaseTaskSpec: supersetv1alpha1.BaseTaskSpec{RequiresDrain: boolPtr(false)},
+			}},
+		}}
+		assert.False(t, r.taskRequiresDrain(noDrain, taskTypeMigrate))
+
+		// Override init (default false) to true.
+		drain := &supersetv1alpha1.Superset{Spec: supersetv1alpha1.SupersetSpec{
+			Lifecycle: &supersetv1alpha1.LifecycleSpec{Init: &supersetv1alpha1.InitTaskSpec{
+				BaseTaskSpec: supersetv1alpha1.BaseTaskSpec{RequiresDrain: boolPtr(true)},
+			}},
+		}}
+		assert.True(t, r.taskRequiresDrain(drain, taskTypeInit))
+	})
+}

--- a/internal/controller/maintenance_test.go
+++ b/internal/controller/maintenance_test.go
@@ -23,9 +23,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	supersetv1alpha1 "github.com/apache/superset-kubernetes-operator/api/v1alpha1"
 	"github.com/apache/superset-kubernetes-operator/internal/common"
@@ -419,4 +425,252 @@ func TestResolveMaintenanceImage_PartialOverride(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeploymentHasReplicas(t *testing.T) {
+	one := int32(1)
+	zero := int32(0)
+
+	t.Run("status replicas counts as present", func(t *testing.T) {
+		d := &appsv1.Deployment{Status: appsv1.DeploymentStatus{Replicas: 2}}
+		assert.True(t, deploymentHasReplicas(d))
+	})
+
+	t.Run("ready/available/updated/unavailable each count", func(t *testing.T) {
+		for _, d := range []*appsv1.Deployment{
+			{Status: appsv1.DeploymentStatus{ReadyReplicas: 1}},
+			{Status: appsv1.DeploymentStatus{AvailableReplicas: 1}},
+			{Status: appsv1.DeploymentStatus{UpdatedReplicas: 1}},
+			{Status: appsv1.DeploymentStatus{UnavailableReplicas: 1}},
+		} {
+			assert.True(t, deploymentHasReplicas(d))
+		}
+	})
+
+	t.Run("nil spec replicas with empty status counts as present", func(t *testing.T) {
+		// A Deployment with nil spec.Replicas defaults to 1 replica.
+		d := &appsv1.Deployment{}
+		assert.True(t, deploymentHasReplicas(d))
+	})
+
+	t.Run("explicit one replica counts as present", func(t *testing.T) {
+		d := &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Replicas: &one}}
+		assert.True(t, deploymentHasReplicas(d))
+	})
+
+	t.Run("scaled to zero with empty status is absent", func(t *testing.T) {
+		d := &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Replicas: &zero}}
+		assert.False(t, deploymentHasReplicas(d))
+	})
+}
+
+func TestComputeMaintenanceChecksum(t *testing.T) {
+	title := "Down"
+	otherTitle := "Up"
+	body := "<h1>x</h1>"
+
+	base := &supersetv1alpha1.MaintenancePageSpec{Title: &title}
+
+	t.Run("stable for identical specs", func(t *testing.T) {
+		assert.Equal(t, computeMaintenanceChecksum(base), computeMaintenanceChecksum(&supersetv1alpha1.MaintenancePageSpec{Title: &title}))
+	})
+
+	t.Run("changes when title changes", func(t *testing.T) {
+		assert.NotEqual(t, computeMaintenanceChecksum(base), computeMaintenanceChecksum(&supersetv1alpha1.MaintenancePageSpec{Title: &otherTitle}))
+	})
+
+	t.Run("changes when body is set", func(t *testing.T) {
+		assert.NotEqual(t, computeMaintenanceChecksum(base), computeMaintenanceChecksum(&supersetv1alpha1.MaintenancePageSpec{Title: &title, Body: &body}))
+	})
+
+	t.Run("includes image fields", func(t *testing.T) {
+		withImage := &supersetv1alpha1.MaintenancePageSpec{
+			Title: &title,
+			Image: &supersetv1alpha1.ContainerImageSpec{Repository: "nginx", Tag: "1.27"},
+		}
+		assert.NotEqual(t, computeMaintenanceChecksum(base), computeMaintenanceChecksum(withImage))
+	})
+
+	t.Run("empty spec yields a fixed-length hex digest", func(t *testing.T) {
+		c := computeMaintenanceChecksum(&supersetv1alpha1.MaintenancePageSpec{})
+		assert.Len(t, c, 16)
+	})
+}
+
+func TestWebServerDesiredReplicas_NoWebServer(t *testing.T) {
+	// With no webServer configured the accessor is nil, so desired replicas is 0.
+	s := &supersetv1alpha1.Superset{}
+	assert.Equal(t, int32(0), webServerDesiredReplicas(s))
+}
+
+func TestReconcileMaintenancePageUp(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+	title := "Down for maintenance"
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "uid-1"},
+		Spec: supersetv1alpha1.SupersetSpec{
+			WebServer: &supersetv1alpha1.WebServerComponentSpec{},
+			Lifecycle: &supersetv1alpha1.LifecycleSpec{
+				MaintenancePage: &supersetv1alpha1.MaintenancePageSpec{Title: &title},
+			},
+		},
+		Status: supersetv1alpha1.SupersetStatus{Lifecycle: &supersetv1alpha1.LifecycleStatus{}},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(superset).Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(20)}
+
+	// First pass: managed-mode ConfigMap + Deployment created, but not ready yet.
+	ready, err := r.reconcileMaintenancePageUp(ctx, superset)
+	assert.NoError(t, err)
+	assert.False(t, ready, "Deployment has no ready replicas yet")
+
+	// ConfigMap (managed mode) created.
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: maintenanceConfigMapName("test"), Namespace: "default"}, cm))
+	assert.Contains(t, cm.Data, "index.html")
+	assert.Contains(t, cm.Data, "nginx.conf")
+
+	// Deployment created and parent-owned.
+	deploy := &appsv1.Deployment{}
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: maintenanceDeploymentName("test"), Namespace: "default"}, deploy))
+	assert.True(t, isOwnedBy(deploy, superset))
+
+	// Mark the Deployment ready, then the page is up and MaintenanceActive flips.
+	deploy.Status.ReadyReplicas = 1
+	require.NoError(t, c.Status().Update(ctx, deploy))
+
+	ready, err = r.reconcileMaintenancePageUp(ctx, superset)
+	assert.NoError(t, err)
+	assert.True(t, ready)
+	assert.True(t, superset.Status.Lifecycle.MaintenanceActive)
+}
+
+func TestReconcileMaintenanceReturn_AlreadyInactive(t *testing.T) {
+	r := &SupersetReconciler{Recorder: events.NewFakeRecorder(10)}
+	superset := &supersetv1alpha1.Superset{Status: supersetv1alpha1.SupersetStatus{}}
+	cleared, err := r.reconcileMaintenanceReturn(context.Background(), superset)
+	assert.NoError(t, err)
+	assert.True(t, cleared, "no lifecycle status means already cleared")
+}
+
+func TestReconcileMaintenanceReturn_WebServerRemoved(t *testing.T) {
+	recorder := events.NewFakeRecorder(10)
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       supersetv1alpha1.SupersetSpec{}, // WebServer nil
+		Status: supersetv1alpha1.SupersetStatus{
+			Lifecycle: &supersetv1alpha1.LifecycleStatus{MaintenanceActive: true},
+		},
+	}
+	r := &SupersetReconciler{Recorder: recorder}
+	cleared, err := r.reconcileMaintenanceReturn(context.Background(), superset)
+	assert.NoError(t, err)
+	assert.True(t, cleared)
+	assert.False(t, superset.Status.Lifecycle.MaintenanceActive)
+	assertNextEventContains(t, recorder, "Normal MaintenanceEnded Maintenance page disabled because webServer was removed")
+}
+
+func TestReconcileMaintenanceReturn_WaitsForWebServerReady(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "uid-1"},
+		Spec: supersetv1alpha1.SupersetSpec{
+			WebServer: &supersetv1alpha1.WebServerComponentSpec{},
+		},
+		Status: supersetv1alpha1.SupersetStatus{
+			Lifecycle: &supersetv1alpha1.LifecycleStatus{MaintenanceActive: true},
+		},
+	}
+	webName := common.ResourceBaseName("test", common.ComponentWebServer)
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: webName, Namespace: "default"},
+		Status:     appsv1.DeploymentStatus{ReadyReplicas: 0},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(superset, deploy).WithStatusSubresource(deploy).Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+
+	// Web-server not ready: should not clear.
+	cleared, err := r.reconcileMaintenanceReturn(ctx, superset)
+	assert.NoError(t, err)
+	assert.False(t, cleared)
+	assert.True(t, superset.Status.Lifecycle.MaintenanceActive)
+
+	// Mark ready, then it clears.
+	deploy.Status.ReadyReplicas = 1
+	require.NoError(t, c.Status().Update(ctx, deploy))
+	cleared, err = r.reconcileMaintenanceReturn(ctx, superset)
+	assert.NoError(t, err)
+	assert.True(t, cleared)
+	assert.False(t, superset.Status.Lifecycle.MaintenanceActive)
+}
+
+func TestDeleteMaintenanceResources(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+	}
+	deploy := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: maintenanceDeploymentName("test"), Namespace: "default"}}
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: maintenanceConfigMapName("test"), Namespace: "default"}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(superset, deploy, cm).Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+
+	require.NoError(t, r.deleteMaintenanceResources(ctx, superset))
+
+	err := c.Get(ctx, client.ObjectKey{Name: maintenanceDeploymentName("test"), Namespace: "default"}, &appsv1.Deployment{})
+	assert.True(t, errors.IsNotFound(err))
+	err = c.Get(ctx, client.ObjectKey{Name: maintenanceConfigMapName("test"), Namespace: "default"}, &corev1.ConfigMap{})
+	assert.True(t, errors.IsNotFound(err))
+
+	// Deleting again (resources absent) is a clean no-op.
+	assert.NoError(t, r.deleteMaintenanceResources(ctx, superset))
+}
+
+func TestCleanupMaintenanceResources_ClearsActiveFlag(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Status:     supersetv1alpha1.SupersetStatus{Lifecycle: &supersetv1alpha1.LifecycleStatus{MaintenanceActive: true}},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(superset).Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+
+	require.NoError(t, r.cleanupMaintenanceResources(ctx, superset))
+	assert.False(t, superset.Status.Lifecycle.MaintenanceActive)
+}
+
+func TestReconcileMaintenancePageUp_CustomModeSkipsConfigMap(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "uid-1"},
+		Spec: supersetv1alpha1.SupersetSpec{
+			WebServer: &supersetv1alpha1.WebServerComponentSpec{},
+			Lifecycle: &supersetv1alpha1.LifecycleSpec{
+				MaintenancePage: &supersetv1alpha1.MaintenancePageSpec{
+					// Custom mode: user supplies an image, so no managed ConfigMap.
+					Image: &supersetv1alpha1.ContainerImageSpec{Repository: "my/maint", Tag: "v1"},
+				},
+			},
+		},
+		Status: supersetv1alpha1.SupersetStatus{Lifecycle: &supersetv1alpha1.LifecycleStatus{}},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(superset).Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(20)}
+
+	ready, err := r.reconcileMaintenancePageUp(ctx, superset)
+	assert.NoError(t, err)
+	assert.False(t, ready)
+
+	// No managed ConfigMap created in custom mode.
+	err = c.Get(ctx, client.ObjectKey{Name: maintenanceConfigMapName("test"), Namespace: "default"}, &corev1.ConfigMap{})
+	assert.True(t, errors.IsNotFound(err), "custom mode must not create a managed ConfigMap")
+
+	// Deployment still created.
+	deploy := &appsv1.Deployment{}
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: maintenanceDeploymentName("test"), Namespace: "default"}, deploy))
+	assert.Equal(t, "my/maint:v1", deploy.Spec.Template.Spec.Containers[0].Image)
 }

--- a/internal/controller/networking_test.go
+++ b/internal/controller/networking_test.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -763,5 +764,74 @@ func TestResolveServicePort(t *testing.T) {
 				t.Errorf("resolveServicePort() = %d, want %d", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestReconcileWebServerService_CreatesAndSwitchesSelector(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "uid-1"},
+		Spec: supersetv1alpha1.SupersetSpec{
+			WebServer: &supersetv1alpha1.WebServerComponentSpec{},
+		},
+		Status: supersetv1alpha1.SupersetStatus{Lifecycle: &supersetv1alpha1.LifecycleStatus{}},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(superset).Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+
+	svcName, _ := webServerServiceRef(superset)
+
+	// Normal mode: selector targets web-server.
+	if err := r.reconcileWebServerService(ctx, superset); err != nil {
+		t.Fatalf("reconcileWebServerService: %v", err)
+	}
+	svc := &corev1.Service{}
+	if err := c.Get(ctx, client.ObjectKey{Name: svcName, Namespace: "default"}, svc); err != nil {
+		t.Fatalf("get service: %v", err)
+	}
+	if svc.Spec.Selector[common.LabelKeyComponent] != string(common.ComponentWebServer) {
+		t.Errorf("expected web-server selector, got %v", svc.Spec.Selector)
+	}
+	if !isOwnedBy(svc, superset) {
+		t.Error("expected web-server Service to be owned by parent")
+	}
+
+	// Maintenance active: selector switches to maintenance-page.
+	superset.Status.Lifecycle.MaintenanceActive = true
+	if err := r.reconcileWebServerService(ctx, superset); err != nil {
+		t.Fatalf("reconcileWebServerService (maintenance): %v", err)
+	}
+	if err := c.Get(ctx, client.ObjectKey{Name: svcName, Namespace: "default"}, svc); err != nil {
+		t.Fatalf("get service: %v", err)
+	}
+	if svc.Spec.Selector[common.LabelKeyComponent] != string(common.ComponentMaintenancePage) {
+		t.Errorf("expected maintenance-page selector during maintenance, got %v", svc.Spec.Selector)
+	}
+}
+
+func TestReconcileWebServerService_DeletesWhenWebServerRemoved(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "uid-1"},
+		// WebServer nil -> Service should be deleted.
+	}
+	svcName, _ := webServerServiceRef(superset)
+	existing := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: "default"}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(superset, existing).Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+
+	if err := r.reconcileWebServerService(ctx, superset); err != nil {
+		t.Fatalf("reconcileWebServerService: %v", err)
+	}
+	err := c.Get(ctx, client.ObjectKey{Name: svcName, Namespace: "default"}, &corev1.Service{})
+	if !errors.IsNotFound(err) {
+		t.Errorf("expected web-server Service deleted, got %v", err)
+	}
+
+	// Idempotent when already absent.
+	if err := r.reconcileWebServerService(ctx, superset); err != nil {
+		t.Fatalf("reconcileWebServerService (absent): %v", err)
 	}
 }

--- a/internal/controller/schedule_test.go
+++ b/internal/controller/schedule_test.go
@@ -20,6 +20,7 @@ package controller
 
 import (
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/events"
@@ -118,4 +119,169 @@ func hasScheduleValidCondition(conditions []metav1.Condition) bool {
 		}
 	}
 	return false
+}
+
+// fixedNow returns a deterministic clock for schedule tests.
+func fixedNow(t time.Time) func() time.Time {
+	return func() time.Time { return t }
+}
+
+func TestNextScheduleRequeue(t *testing.T) {
+	// A daily 02:00 cron, evaluated at 03:00, next tick is the following day's
+	// 02:00 — i.e. 23h ahead. The requeue adds a one-second guard.
+	base := time.Date(2026, 6, 2, 3, 0, 0, 0, time.UTC)
+
+	t.Run("nil lifecycle yields zero", func(t *testing.T) {
+		r := &SupersetReconciler{Now: fixedNow(base)}
+		superset := &supersetv1alpha1.Superset{}
+		if d := r.nextScheduleRequeue(superset); d != 0 {
+			t.Fatalf("expected 0 for nil lifecycle, got %s", d)
+		}
+	})
+
+	t.Run("no active schedule yields zero", func(t *testing.T) {
+		r := &SupersetReconciler{Now: fixedNow(base)}
+		superset := &supersetv1alpha1.Superset{
+			Spec: supersetv1alpha1.SupersetSpec{Lifecycle: &supersetv1alpha1.LifecycleSpec{
+				Clone: &supersetv1alpha1.CloneTaskSpec{},
+			}},
+		}
+		if d := r.nextScheduleRequeue(superset); d != 0 {
+			t.Fatalf("expected 0 with no cron schedule, got %s", d)
+		}
+	})
+
+	t.Run("clone cron schedule produces a positive requeue", func(t *testing.T) {
+		r := &SupersetReconciler{Now: fixedNow(base)}
+		sched := "0 2 * * *"
+		superset := &supersetv1alpha1.Superset{
+			Spec: supersetv1alpha1.SupersetSpec{Lifecycle: &supersetv1alpha1.LifecycleSpec{
+				Clone: &supersetv1alpha1.CloneTaskSpec{
+					SchedulableBaseTaskSpec: supersetv1alpha1.SchedulableBaseTaskSpec{CronSchedule: &sched},
+				},
+			}},
+		}
+		d := r.nextScheduleRequeue(superset)
+		// next 02:00 is 23h after 03:00, plus one second guard.
+		want := 23*time.Hour + time.Second
+		if d != want {
+			t.Fatalf("expected requeue %s, got %s", want, d)
+		}
+	})
+
+	t.Run("disabled clone yields zero", func(t *testing.T) {
+		r := &SupersetReconciler{Now: fixedNow(base)}
+		sched := "0 2 * * *"
+		superset := &supersetv1alpha1.Superset{
+			Spec: supersetv1alpha1.SupersetSpec{Lifecycle: &supersetv1alpha1.LifecycleSpec{
+				Clone: &supersetv1alpha1.CloneTaskSpec{
+					SchedulableBaseTaskSpec: supersetv1alpha1.SchedulableBaseTaskSpec{
+						BaseTaskSpec: supersetv1alpha1.BaseTaskSpec{Disabled: boolPtr(true)},
+						CronSchedule: &sched,
+					},
+				},
+			}},
+		}
+		if d := r.nextScheduleRequeue(superset); d != 0 {
+			t.Fatalf("expected 0 for disabled clone, got %s", d)
+		}
+	})
+
+	t.Run("sub-second remaining clamps to one second", func(t *testing.T) {
+		// Evaluate at 01:59:59.9 so the next 02:00 tick is 0.1s away; the
+		// computed duration (next - now + 1s) would still exceed a second, so
+		// to exercise the clamp we instead evaluate just past a minute-resolution
+		// tick boundary. The clamp guards against a next-tick that is effectively
+		// "now": with a per-minute schedule evaluated exactly on the tick, the
+		// next tick is ~1 minute out. We assert the floor never drops below 1s.
+		now := time.Date(2026, 6, 2, 1, 59, 59, 0, time.UTC)
+		r := &SupersetReconciler{Now: fixedNow(now)}
+		sched := "* * * * *" // every minute
+		superset := &supersetv1alpha1.Superset{
+			Spec: supersetv1alpha1.SupersetSpec{Lifecycle: &supersetv1alpha1.LifecycleSpec{
+				Clone: &supersetv1alpha1.CloneTaskSpec{
+					SchedulableBaseTaskSpec: supersetv1alpha1.SchedulableBaseTaskSpec{CronSchedule: &sched},
+				},
+			}},
+		}
+		d := r.nextScheduleRequeue(superset)
+		if d < time.Second {
+			t.Fatalf("requeue must never be below 1s, got %s", d)
+		}
+	})
+}
+
+func TestProjectScheduleStatus(t *testing.T) {
+	base := time.Date(2026, 6, 2, 3, 0, 0, 0, time.UTC)
+
+	t.Run("nil lifecycle is a no-op", func(t *testing.T) {
+		r := &SupersetReconciler{Now: fixedNow(base)}
+		superset := &supersetv1alpha1.Superset{}
+		ref := &supersetv1alpha1.TaskRefStatus{}
+		r.projectScheduleStatus(superset, taskTypeClone, ref)
+		if ref.LastScheduledAt != nil || ref.NextScheduleAt != nil {
+			t.Fatalf("expected no projection for nil lifecycle, got %+v", ref)
+		}
+	})
+
+	t.Run("clone with no schedule is a no-op", func(t *testing.T) {
+		r := &SupersetReconciler{Now: fixedNow(base)}
+		superset := &supersetv1alpha1.Superset{
+			Spec: supersetv1alpha1.SupersetSpec{Lifecycle: &supersetv1alpha1.LifecycleSpec{
+				Clone: &supersetv1alpha1.CloneTaskSpec{},
+			}},
+		}
+		ref := &supersetv1alpha1.TaskRefStatus{}
+		r.projectScheduleStatus(superset, taskTypeClone, ref)
+		if ref.LastScheduledAt != nil || ref.NextScheduleAt != nil {
+			t.Fatalf("expected no projection without a cron schedule, got %+v", ref)
+		}
+	})
+
+	t.Run("non-clone task type is a no-op", func(t *testing.T) {
+		r := &SupersetReconciler{Now: fixedNow(base)}
+		sched := "0 2 * * *"
+		superset := &supersetv1alpha1.Superset{
+			Spec: supersetv1alpha1.SupersetSpec{Lifecycle: &supersetv1alpha1.LifecycleSpec{
+				Clone: &supersetv1alpha1.CloneTaskSpec{
+					SchedulableBaseTaskSpec: supersetv1alpha1.SchedulableBaseTaskSpec{CronSchedule: &sched},
+				},
+			}},
+		}
+		ref := &supersetv1alpha1.TaskRefStatus{}
+		r.projectScheduleStatus(superset, taskTypeMigrate, ref)
+		if ref.LastScheduledAt != nil || ref.NextScheduleAt != nil {
+			t.Fatalf("expected no projection for non-clone task, got %+v", ref)
+		}
+	})
+
+	t.Run("clone with cron projects last and next", func(t *testing.T) {
+		r := &SupersetReconciler{Now: fixedNow(base)}
+		sched := "0 2 * * *"
+		superset := &supersetv1alpha1.Superset{
+			Spec: supersetv1alpha1.SupersetSpec{Lifecycle: &supersetv1alpha1.LifecycleSpec{
+				Clone: &supersetv1alpha1.CloneTaskSpec{
+					SchedulableBaseTaskSpec: supersetv1alpha1.SchedulableBaseTaskSpec{CronSchedule: &sched},
+				},
+			}},
+		}
+		ref := &supersetv1alpha1.TaskRefStatus{}
+		r.projectScheduleStatus(superset, taskTypeClone, ref)
+
+		if ref.LastScheduledAt == nil {
+			t.Fatal("expected LastScheduledAt to be set")
+		}
+		// Last tick at or before 03:00 is today's 02:00.
+		wantLast := time.Date(2026, 6, 2, 2, 0, 0, 0, time.UTC)
+		if !ref.LastScheduledAt.Time.Equal(wantLast) {
+			t.Errorf("LastScheduledAt = %s, want %s", ref.LastScheduledAt.Time, wantLast)
+		}
+		if ref.NextScheduleAt == nil {
+			t.Fatal("expected NextScheduleAt to be set")
+		}
+		wantNext := time.Date(2026, 6, 3, 2, 0, 0, 0, time.UTC)
+		if !ref.NextScheduleAt.Time.Equal(wantNext) {
+			t.Errorf("NextScheduleAt = %s, want %s", ref.NextScheduleAt.Time, wantNext)
+		}
+	})
 }

--- a/internal/controller/websocket_config_test.go
+++ b/internal/controller/websocket_config_test.go
@@ -1,0 +1,142 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	"github.com/apache/superset-kubernetes-operator/internal/resolution"
+)
+
+func TestRenderWebsocketConfig(t *testing.T) {
+	t.Run("nil config renders empty object", func(t *testing.T) {
+		out, err := renderWebsocketConfig(nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "{}", out)
+	})
+
+	t.Run("empty raw renders empty object", func(t *testing.T) {
+		out, err := renderWebsocketConfig(&apiextensionsv1.JSON{Raw: []byte{}})
+		assert.NoError(t, err)
+		assert.Equal(t, "{}", out)
+	})
+
+	t.Run("valid JSON round-trips with indentation", func(t *testing.T) {
+		out, err := renderWebsocketConfig(&apiextensionsv1.JSON{Raw: []byte(`{"port":8080,"pingTimeout":300}`)})
+		assert.NoError(t, err)
+		// Pretty-printed with two-space indent.
+		assert.Contains(t, out, "\"port\": 8080")
+		assert.Contains(t, out, "\"pingTimeout\": 300")
+		assert.Contains(t, out, "\n  ")
+	})
+
+	t.Run("invalid JSON returns an error", func(t *testing.T) {
+		out, err := renderWebsocketConfig(&apiextensionsv1.JSON{Raw: []byte(`{not valid`)})
+		assert.Error(t, err)
+		assert.Empty(t, out)
+		assert.Contains(t, err.Error(), "parsing websocket config JSON")
+	})
+}
+
+func TestWebsocketConfigRefChecksumInput(t *testing.T) {
+	t.Run("nil ref yields empty string", func(t *testing.T) {
+		assert.Equal(t, "", websocketConfigRefChecksumInput(nil))
+	})
+
+	t.Run("optional nil formats as false", func(t *testing.T) {
+		ref := &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "ws-secret"},
+			Key:                  "config.json",
+		}
+		assert.Equal(t, "secret:ws-secret:config.json:false", websocketConfigRefChecksumInput(ref))
+	})
+
+	t.Run("optional true formats as true", func(t *testing.T) {
+		ref := &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "ws-secret"},
+			Key:                  "config.json",
+			Optional:             boolPtr(true),
+		}
+		assert.Equal(t, "secret:ws-secret:config.json:true", websocketConfigRefChecksumInput(ref))
+	})
+
+	t.Run("optional false formats as false", func(t *testing.T) {
+		ref := &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "ws-secret"},
+			Key:                  "config.json",
+			Optional:             boolPtr(false),
+		}
+		assert.Equal(t, "secret:ws-secret:config.json:false", websocketConfigRefChecksumInput(ref))
+	})
+}
+
+func TestInjectWebsocketConfigMap(t *testing.T) {
+	op := &resolution.OperatorInjected{}
+	injectWebsocketConfigMap(op, "my-superset-websocket-server")
+
+	if assert.Len(t, op.Volumes, 1) {
+		v := op.Volumes[0]
+		assert.Equal(t, websocketConfigVolume, v.Name)
+		if assert.NotNil(t, v.ConfigMap) {
+			assert.True(t, strings.Contains(v.ConfigMap.Name, "websocket-server"))
+			if assert.Len(t, v.ConfigMap.Items, 1) {
+				assert.Equal(t, websocketConfigKey, v.ConfigMap.Items[0].Key)
+				assert.Equal(t, websocketConfigKey, v.ConfigMap.Items[0].Path)
+			}
+		}
+	}
+	if assert.Len(t, op.VolumeMounts, 1) {
+		m := op.VolumeMounts[0]
+		assert.Equal(t, websocketConfigVolume, m.Name)
+		assert.Equal(t, websocketConfigMountPath, m.MountPath)
+		assert.Equal(t, websocketConfigKey, m.SubPath)
+		assert.True(t, m.ReadOnly)
+	}
+}
+
+func TestInjectWebsocketConfigSecret(t *testing.T) {
+	op := &resolution.OperatorInjected{}
+	configFrom := &corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{Name: "ws-secret"},
+		Key:                  "config",
+		Optional:             boolPtr(true),
+	}
+	injectWebsocketConfigSecret(op, configFrom)
+
+	if assert.Len(t, op.Volumes, 1) {
+		v := op.Volumes[0]
+		assert.Equal(t, websocketConfigVolume, v.Name)
+		if assert.NotNil(t, v.Secret) {
+			assert.Equal(t, "ws-secret", v.Secret.SecretName)
+			assert.Equal(t, boolPtr(true), v.Secret.Optional)
+			if assert.Len(t, v.Secret.Items, 1) {
+				assert.Equal(t, "config", v.Secret.Items[0].Key)
+				assert.Equal(t, websocketConfigKey, v.Secret.Items[0].Path)
+			}
+		}
+	}
+	if assert.Len(t, op.VolumeMounts, 1) {
+		assert.Equal(t, websocketConfigMountPath, op.VolumeMounts[0].MountPath)
+	}
+}


### PR DESCRIPTION
## Summary

Adds focused unit tests for previously under-covered functions in `internal/controller` (and one in `internal/config`), targeting genuine gaps identified from the merged coverage profile rather than padding. Most additions use the fake client; no envtest required. `internal/controller` rises from 85.0% to 89.2% on the untagged suite alone (higher once the envtest specs are included), with no source changes and no `codecov.yml` edits.

## Details

Notable gaps closed: `resetTaskStatusForRun` (0%→100%), `projectScheduleStatus` (41%→100%), `reconcileMaintenanceReturn` (33%→85%), `computeMaintenanceChecksum` (64%→93%); `applyExplicitOverrides`, `convertComponent`, `convertCloneComponent`, `warnEnvVarOverrides`, `preserveServiceAllocatedFields`, `mergeLabels`, `taskRequiresDrain`, `isTaskEnabled`, `defaultMigrateCommand` all to 100%.

New test files: `checksum_test.go`, `component_descriptors_test.go`, `component_reconciler_test.go`, `websocket_config_test.go`; the rest extend existing test files.

Remaining sub-85% functions are the deliberate residual: reconcile entrypoints covered by the envtest integration specs, and a few `client` error-return branches that need fault injection (out of scope).