### PR TITLE
build: pin golang builder to a patch version for release-age soak

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@
 # limitations under the License.
 
 # Build the manager binary
-# To update the digest: docker pull golang:1.26 && docker inspect --format='{{index .RepoDigests 0}}' golang:1.26
-FROM --platform=$BUILDPLATFORM golang:1.26@sha256:2d6c80227255c3112a4d08e67ba98e58efd3846daf15d9d7d4c389565d881b1a AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.3@sha256:2d6c80227255c3112a4d08e67ba98e58efd3846daf15d9d7d4c389565d881b1a AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -391,18 +391,29 @@ Pod that drifts from this baseline.
 
 The release pipeline produces signed multi-architecture artifacts:
 
-- **Base image:** [`gcr.io/distroless/static:nonroot`](https://github.com/GoogleContainerTools/distroless)
-  — no shell, no package manager, no unnecessary binaries. The Dockerfile
-  pins the digest and Renovate keeps it current.
+- **Base images:** the build stage uses a fully-qualified Go patch tag and the
+  runtime stage uses
+  [`gcr.io/distroless/static:nonroot`](https://github.com/GoogleContainerTools/distroless)
+  — no shell, no package manager, no unnecessary binaries. The Dockerfile pins both
+  by digest and Renovate keeps them current (digest refreshes are applied without the
+  version soak — see the dependency policy below).
 - **Architectures:** `linux/amd64` and `linux/arm64` are built and signed
   identically.
 - **Image signatures:** The release workflow signs the manager image and the
   packaged Helm chart with [Cosign](https://github.com/sigstore/cosign) using
   GitHub Actions OIDC (keyless). Verify with
   `cosign verify ghcr.io/apache/superset-kubernetes-operator@<digest>`.
-- **Dependency policy:** Go modules and GitHub Actions are kept current via
-  [Renovate](https://docs.renovatebot.com/) with a 7-day minimum age and
-  pinned action versions.
+- **Dependency policy:** Go modules, GitHub Actions, and container base images are
+  kept current via [Renovate](https://docs.renovatebot.com/) with pinned versions and
+  a 7-day minimum age before a *version* update is proposed. This soak does **not**
+  apply to *digest* updates: when a floating tag is re-pushed to a new digest for the
+  same version (a base-OS rebuild, or a patch published under a rolling tag), Renovate
+  proposes the digest bump immediately, because `minimumReleaseAge` gates versions, not
+  digests. The Go builder is pinned to a fully-qualified patch version so Go upgrades
+  are soaked version updates; the distroless runtime base has no semantic-version tag,
+  so its digest refreshes are inherently un-soaked. This residual exposure is accepted
+  and bounded by the minimal distroless base and by keyless Cosign signing of the
+  image this project itself publishes.
 - **Future work:** SBOM and SLSA build provenance generation are tracked as
   enhancements for later releases.
 


### PR DESCRIPTION
## Summary

Renovate PR #110 bumped the `golang:1.26` builder to a digest published only 16 hours ago, despite our `minimumReleaseAge: "7 days"` policy. The cause is that `minimumReleaseAge` gates *version* updates, not *digest* updates — the floating `golang:1.26` tag had simply been re-pushed to point at the freshly released 1.26.4, so Renovate proposed the digest bump immediately with no soak.

This pins the builder to a fully-qualified patch version (`golang:1.26.3`, the image we already run). Future Go upgrades now arrive as version updates subject to the 7-day soak — e.g. Renovate will re-propose 1.26.4 and hold it for a week rather than adopting it the day it ships.

## Details

- `Dockerfile`: `golang:1.26` → `golang:1.26.3` (same digest, now explicit).
- `docs/reference/security.md`: corrected the Supply Chain section, which previously implied a blanket 7-day age. It now scopes the soak to version updates and documents that digest refreshes of a floating tag (base-OS rebuilds, and the un-versionable `distroless/static:nonroot` runtime base) are applied without soak — an accepted, bounded residual risk.