### PR TITLE
chore: refine release tooling

### DIFF
--- a/docs/contributing/development-guidelines.md
+++ b/docs/contributing/development-guidelines.md
@@ -463,7 +463,7 @@ The PR template (`PULL_REQUEST_TEMPLATE.md`) pre-fills these sections.
 ### Changelog entry
 
 Add a bullet under `## [Unreleased]` in
-[`CHANGELOG.md`](https://github.com/apache/superset-kubernetes-operator/blob/main/CHANGELOG.md)
+[`docs/reference/releases.md`](../reference/releases.md)
 for noteworthy changes — new features,
 new CRD fields, behavior changes, breaking changes, deprecations, and
 critical bug fixes. Skip the entry for routine work that a user wouldn't

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -73,15 +73,18 @@ it. Review and merge these PRs promptly to stay current on security patches.
 
 ## Versioning
 
-The project follows [Semantic Versioning](https://semver.org/). Two versions are tracked:
+The project follows [Semantic Versioning](https://semver.org/). The operator
+and Helm chart versions are coupled for release artifacts:
 
 | Version | Location | Purpose |
 |---------|----------|---------|
 | **Operator version** | `VERSION` in `Makefile` | Operator image tag. Single source of truth. |
-| **Chart version** | `version` in `charts/superset-operator/Chart.yaml` | Helm chart version. Can diverge for chart-only fixes. |
+| **Chart version** | `version` in `charts/superset-operator/Chart.yaml` | Helm chart package version. |
+| **Chart app version** | `appVersion` in `charts/superset-operator/Chart.yaml` | Default operator image tag used by the chart. |
 
-The Chart.yaml `appVersion` is injected from the Makefile `VERSION` at package time
-(`make helm` passes `--app-version`), so it does not need to be updated manually.
+Release preparation sets all three to the same base release version, for example
+`0.1.0`. The tag-triggered release workflow packages RC convenience artifacts
+with the RC suffix, for example `0.1.0-rc1`.
 
 While the project is pre-1.0, all versions use `0.x.y` to signal instability per semver.
 
@@ -116,8 +119,8 @@ Before creating the first RC for a minor release, run or verify:
 
 ## Reviewing the Changelog
 
-Contributors add bullets to `## [Unreleased]` in `CHANGELOG.md` as PRs land
-(see the
+Contributors add bullets to `## [Unreleased]` in
+[`docs/reference/releases.md`](../reference/releases.md) as PRs land (see the
 [changelog convention](development-guidelines.md#changelog-entry)). Before
 tagging the RC, the release manager does one review pass to make sure the
 section accurately reflects the release:
@@ -133,37 +136,43 @@ section accurately reflects the release:
 4. Group bullets under the standard Keep a Changelog subheadings — `Added`,
    `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security` — dropping any
    that end up empty.
-5. Rename the section header from `## [Unreleased]` to
-   `## [<version>] — <YYYY-MM-DD>` and add a fresh empty `## [Unreleased]`
-   above it. Update the comparison links at the bottom of the file.
+5. Rename the section header from `## [Unreleased]` to `## [<version>]` and add
+   a fresh empty `## [Unreleased]` above it. Add the final release date after
+   the vote passes and the release has been promoted. Update the comparison
+   links at the bottom of the file.
 
-Two flows depending on whether the release branch already exists:
+Two flows depending on whether the minor release branch already exists:
 
-- **First RC of a minor release.** The `release/<version>` branch does not
-  exist yet, and `release-rc.sh` will create it from `main`. Land the
-  reviewed `CHANGELOG.md` on `main` first (a normal PR), then run
-  `release-rc.sh` so the new branch and RC tag pick it up.
-- **Subsequent RCs (`rc2`, `rc3`, …).** The `release/<version>` branch
-  already exists. Commit the `CHANGELOG.md` polish on that branch directly,
+- **First RC of a minor release.** The `<major>.<minor>` branch does not exist
+  yet. Create it from `main`, commit the reviewed changelog and any
+  release-only polish there, then run `release-rc.sh` so the RC tag picks it up.
+- **Subsequent RCs (`rc2`, `rc3`, …).** The `<major>.<minor>` branch already
+  exists. Commit changelog polish on that branch directly,
   then run `release-rc.sh` to bump the RC number.
 
 ## Creating a Release Candidate
 
 The `scripts/release-rc.sh` script automates the full RC preparation: creates
-the release branch (first RC only), bumps the operator and Helm chart
-versions, regenerates manifests, runs the lint/license/test/docs/helm-lint
-checks, commits, and tags.
+the minor release branch (first RC only), bumps the operator version and Helm
+chart `version`/`appVersion` metadata to the target release version, regenerates
+manifests, runs the lint/license/test/docs/helm-lint checks, commits, and tags.
+The tag-triggered release workflow packages and publishes the RC image and Helm
+chart with the RC version suffix. The script also verifies that
+`docs/reference/releases.md` contains a heading for the target release version.
 
 ```sh
-# First RC for 0.2.0 — creates release/0.2.0 branch and v0.2.0-rc1 tag.
-# Chart version defaults to the operator version unless overridden.
-scripts/release-rc.sh 0.2.0
+# First RC for 0.2.0 — create the 0.2 branch first, then tag v0.2.0-rc1.
+git checkout main
+git pull
+git checkout -b 0.2
+# Commit docs/reference/releases.md and any release-only polish here.
+scripts/release-rc.sh 0.2.0 --expect-rc 1
 
-# Pin the Helm chart to a different version (rare; only for chart-only fixes).
-scripts/release-rc.sh 0.2.0 --chart-version 0.2.1
+# Build and verify signed source artifacts before pushing anything.
+scripts/release-source.sh
 
-# Push branch + tag to trigger the release workflow
-git push origin release/0.2.0 v0.2.0-rc1
+# Push branch + tag to trigger the release workflow after source verification.
+git push origin 0.2 v0.2.0-rc1
 ```
 
 Running the script again from the same release branch increments the RC
@@ -181,9 +190,9 @@ A release candidate therefore needs three artifacts staged on
 
 | Artifact | Filename pattern | Notes |
 |---|---|---|
-| Source archive | `apache-superset-kubernetes-operator-<version>-source.tar.gz` | A `git archive` of the RC tag, prefixed with the project directory. |
-| Detached PGP signature | `apache-superset-kubernetes-operator-<version>-source.tar.gz.asc` | Generated with a key in [`KEYS`](https://dist.apache.org/repos/dist/release/superset/KEYS). |
-| SHA-512 checksum | `apache-superset-kubernetes-operator-<version>-source.tar.gz.sha512` | `shasum -a 512` output, with a bare filename so verifiers can run `shasum -c` after a plain download. |
+| Source archive | `apache-superset-kubernetes-operator-<version>-rc<n>-source.tar.gz` | A `git archive` of the RC tag, prefixed with the project directory. |
+| Detached PGP signature | `apache-superset-kubernetes-operator-<version>-rc<n>-source.tar.gz.asc` | Generated with a key in [`KEYS`](https://dist.apache.org/repos/dist/release/superset/KEYS). |
+| SHA-512 checksum | `apache-superset-kubernetes-operator-<version>-rc<n>-source.tar.gz.sha512` | `shasum -a 512` output, with a bare filename so verifiers can run `shasum -c` after a plain download. |
 
 ### Pre-requisites for the release manager
 
@@ -204,15 +213,17 @@ A release candidate therefore needs three artifacts staged on
 ### Producing the source tarball
 
 `scripts/release-source.sh` wraps `git archive`, `gpg`, and `shasum` and
-self-verifies before exiting:
+self-verifies before exiting. It infers the local RC tag from `HEAD`, writes to
+`dist/<version>-rc<n>/`, and signs with the newest usable local secret key that
+has an `@apache.org` UID:
 
 ```sh
-scripts/release-source.sh 0.2.0 --rc 1
-# → dist/apache-superset-kubernetes-operator-0.2.0-rc1-source.tar.gz{,.asc,.sha512}
+scripts/release-source.sh
+# → dist/0.2.0-rc1/apache-superset-kubernetes-operator-0.2.0-rc1-source.tar.gz{,.asc,.sha512}
 ```
 
-Pass `--gpg-key <id>` to pick a non-default signing key, and `--out-dir
-<path>` to write the artifacts somewhere other than `./dist/`.
+Pass `--gpg-key <id>` to pick a specific signing key, and `--out-dir <path>` to
+write the artifacts somewhere other than `dist/<version>-rc<n>/`.
 
 > **Why a script, not raw `git archive` + `gpg` + `shasum`.** The script
 > avoids a small set of subtle errors that are easy to make manually:
@@ -230,7 +241,7 @@ Pass `--gpg-key <id>` to pick a non-default signing key, and `--out-dir
 ```sh
 cd ~/asf/dev-superset
 mkdir kubernetes-operator-${VERSION}-rc${RC}
-cp /path/to/dist/apache-superset-kubernetes-operator-${VERSION}-rc${RC}-source.tar.gz{,.asc,.sha512} \
+cp /path/to/dist/${VERSION}-rc${RC}/apache-superset-kubernetes-operator-${VERSION}-rc${RC}-source.tar.gz{,.asc,.sha512} \
    kubernetes-operator-${VERSION}-rc${RC}/
 svn add kubernetes-operator-${VERSION}-rc${RC}
 svn commit -m "Stage Superset Kubernetes Operator ${VERSION}-rc${RC}"
@@ -241,63 +252,33 @@ After the commit lands, the artifacts appear at
 
 ### Vote email template
 
-Send the vote thread to `dev@superset.apache.org` with `[VOTE]` in the
-subject. The thread must stay open for **at least 72 hours** and pass with at
-least three `+1` votes from PMC members and no `-1` votes (per
-[ASF voting rules](https://www.apache.org/foundation/voting.html#ReleaseVotes)).
+Generate a vote email draft from the RC tag on `HEAD`, review it, then send the
+thread to `dev@superset.apache.org` with `[VOTE]` in the subject:
 
-```text
-Subject: [VOTE] Release Apache Superset Kubernetes Operator <version>-rc<n>
-
-Hello,
-
-This is a vote to release Apache Superset Kubernetes Operator <version> based
-on candidate rc<n>.
-
-The release candidate artifacts are staged at:
-  https://dist.apache.org/repos/dist/dev/superset/kubernetes-operator-<version>-rc<n>/
-
-The git tag is:
-  https://github.com/apache/superset-kubernetes-operator/releases/tag/v<version>-rc<n>
-
-PGP keys used for signing are listed in:
-  https://dist.apache.org/repos/dist/release/superset/KEYS
-
-To verify the candidate (Go 1.26+, Helm, and Apache Rat must be installed
-locally; `make` will fetch additional Go modules and tools on first use):
-
-  curl -O https://dist.apache.org/repos/dist/dev/superset/kubernetes-operator-<version>-rc<n>/apache-superset-kubernetes-operator-<version>-rc<n>-source.tar.gz{,.asc,.sha512}
-  curl -O https://dist.apache.org/repos/dist/release/superset/KEYS
-  gpg --import KEYS
-  gpg --verify apache-superset-kubernetes-operator-<version>-rc<n>-source.tar.gz{.asc,}
-  shasum -a 512 -c apache-superset-kubernetes-operator-<version>-rc<n>-source.tar.gz.sha512
-  tar -xzf apache-superset-kubernetes-operator-<version>-rc<n>-source.tar.gz
-  cd apache-superset-kubernetes-operator-<version>/
-  make test-unit helm-lint check-license
-
-Notable changes are documented in:
-  https://github.com/apache/superset-kubernetes-operator/blob/v<version>-rc<n>/CHANGELOG.md
-
-The vote will be open for at least 72 hours.
-
-[ ] +1 release this package
-[ ]  0 no opinion
-[ ] -1 do not release this package because ...
-
-Thanks,
-<release manager>
+```sh
+scripts/release-email.sh vote > dist/0.2.0-rc1/VOTE.txt
 ```
 
+The vote thread must stay open for **at least 72 hours** and pass with at least
+three `+1` votes from PMC members and no `-1` votes (per
+[ASF voting rules](https://www.apache.org/foundation/voting.html#ReleaseVotes)).
+
 After the vote thread closes, post a `[RESULT][VOTE]` summary to the same list
-with the tally and the binding/non-binding breakdown.
+with the tally and the binding/non-binding breakdown:
+
+```sh
+scripts/release-email.sh result > dist/0.2.0-rc1/RESULT.txt
+```
 
 ## Finalizing a Release
 
-After the ASF vote passes, the `scripts/release-finalize.sh` script tags the final
-release on the release branch:
+After the ASF vote passes, the `scripts/release-finalize.sh` script tags the
+final release on the same commit as the voted RC. Do not commit changelog date
+updates or other polish before finalizing; those changes were not part of the
+voted source release.
 
 ```sh
-# From the release/0.2.0 branch
+# From the 0.2 branch
 scripts/release-finalize.sh 0.2.0
 
 # Push the tag to trigger the release workflow
@@ -306,19 +287,22 @@ git push origin v0.2.0
 
 The release workflow pushes the `0.2.0` and `latest` images to GHCR.
 
+After the final tag is pushed, add the final release date to
+`docs/reference/releases.md` in a normal follow-up commit and merge or
+cherry-pick that release metadata back to `main`.
+
 After the binary release workflow finishes, promote the source artifacts.
-`release-source.sh --finalize` reuses the staged RC tarball bytes (so the
-detached signature stays valid) and regenerates the SHA-512 file under the
-final filename:
+`release-source.sh` sees the final tag on `HEAD`, requires a matching RC tag on
+the same commit, reuses the staged RC tarball bytes (so the detached signature
+stays valid), and regenerates the SHA-512 file under the final filename:
 
 ```sh
-scripts/release-source.sh 0.2.0 --finalize \
-  --rc-dir ~/asf/dev-superset/kubernetes-operator-0.2.0-rc${RC}
-# → dist/apache-superset-kubernetes-operator-0.2.0-source.tar.gz{,.asc,.sha512}
+scripts/release-source.sh
+# → dist/0.2.0/apache-superset-kubernetes-operator-0.2.0-source.tar.gz{,.asc,.sha512}
 
 cd ~/asf/release-superset
 mkdir kubernetes-operator-0.2.0
-cp /path/to/dist/apache-superset-kubernetes-operator-0.2.0-source.tar.gz{,.asc,.sha512} \
+cp /path/to/dist/0.2.0/apache-superset-kubernetes-operator-0.2.0-source.tar.gz{,.asc,.sha512} \
    kubernetes-operator-0.2.0/
 svn add kubernetes-operator-0.2.0
 svn commit -m "Release Apache Superset Kubernetes Operator 0.2.0"
@@ -329,6 +313,10 @@ svn rm kubernetes-operator-0.2.0-rc*
 svn commit -m "Clean up Superset Kubernetes Operator 0.2.0 release candidates"
 ```
 
-The release announcement should go to `announce@apache.org` and
-`dev@superset.apache.org` after the artifacts have propagated to the ASF
-mirror network (typically within 24 hours).
+Generate the release announcement after the artifacts have propagated to the ASF
+mirror network (typically within 24 hours), review it, then send it to
+`announce@apache.org` and `dev@superset.apache.org`:
+
+```sh
+scripts/release-email.sh announce > dist/0.2.0/ANNOUNCE.txt
+```

--- a/docs/reference/releases.md
+++ b/docs/reference/releases.md
@@ -17,7 +17,18 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Changelog
+# Releases
 
-The project changelog is maintained in
-[docs/reference/releases.md](docs/reference/releases.md).
+This page tracks notable changes in Apache Superset Kubernetes Operator
+releases.
+
+## [Unreleased]
+
+## [0.1.0]
+
+### Added
+
+- Initial release.
+
+[Unreleased]: https://github.com/apache/superset-kubernetes-operator/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/apache/superset-kubernetes-operator/releases/tag/v0.1.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
   - Reference:
     - API Reference: reference/api-reference.md
     - Downloads: reference/downloads.md
+    - Releases: reference/releases.md
     - Security: reference/security.md
   - Contributing:
     - Development Setup: contributing/development-setup.md

--- a/scripts/release-email.sh
+++ b/scripts/release-email.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Generate release email drafts. The script prints templates only; it does not
+# send mail.
+
+set -euo pipefail
+
+die() { echo "error: $*" >&2; exit 1; }
+
+usage() {
+  cat <<EOF
+Usage:
+  $0 vote
+  $0 result
+  $0 announce
+
+Run from the release commit. The script infers v<version>-rc<n> and/or
+v<version> tags from HEAD.
+EOF
+}
+
+MODE="${1:-}"
+[[ -n "$MODE" ]] || { usage >&2; die "mode is required"; }
+shift || true
+[[ $# -eq 0 ]] || die "unexpected arguments: $*"
+
+PROJECT="apache-superset-kubernetes-operator"
+DISPLAY_NAME="Apache Superset Kubernetes Operator"
+DIST_DEV_BASE="https://dist.apache.org/repos/dist/dev/superset"
+DIST_RELEASE_BASE="https://dist.apache.org/repos/dist/release/superset"
+GITHUB_BASE="https://github.com/apache/superset-kubernetes-operator"
+DOWNLOADS_BASE="https://superset.apache.org/downloads/"
+
+version_re() {
+  printf "%s" "$1" | sed 's/[.]/\\./g'
+}
+
+latest_rc_tag_on_head() {
+  git tag --points-at HEAD \
+    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-rc[1-9][0-9]*$' \
+    | awk -F-rc '{ print $2 ":" $0 }' \
+    | sort -t: -k1,1n \
+    | tail -1 \
+    | cut -d: -f2- \
+    || true
+}
+
+final_tag_on_head() {
+  git tag --points-at HEAD \
+    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+    | tail -1 \
+    || true
+}
+
+require_rc() {
+  RC_TAG="$(latest_rc_tag_on_head)"
+  [[ -n "$RC_TAG" ]] || die "no v<version>-rc<n> tag found on HEAD"
+  VERSION="${RC_TAG#v}"
+  VERSION="${VERSION%-rc*}"
+  RC="${RC_TAG##*-rc}"
+}
+
+require_final() {
+  FINAL_TAG="$(final_tag_on_head)"
+  [[ -n "$FINAL_TAG" ]] || die "no v<version> final tag found on HEAD"
+  VERSION="${FINAL_TAG#v}"
+}
+
+case "$MODE" in
+  vote)
+    require_rc
+    cat <<EOF
+Subject: [VOTE] Release ${DISPLAY_NAME} ${VERSION}-rc${RC}
+
+Hello,
+
+This is a vote to release ${DISPLAY_NAME} ${VERSION} based on candidate rc${RC}.
+
+The release candidate artifacts are staged at:
+  ${DIST_DEV_BASE}/kubernetes-operator-${VERSION}-rc${RC}/
+
+The git tag is:
+  ${GITHUB_BASE}/releases/tag/v${VERSION}-rc${RC}
+
+PGP keys used for signing are listed in:
+  ${DIST_RELEASE_BASE}/KEYS
+
+To verify the candidate (Go 1.26+, Helm, and Apache Rat must be installed
+locally; make will fetch additional Go modules and tools on first use):
+
+  curl -O ${DIST_DEV_BASE}/kubernetes-operator-${VERSION}-rc${RC}/${PROJECT}-${VERSION}-rc${RC}-source.tar.gz{,.asc,.sha512}
+  curl -O ${DIST_RELEASE_BASE}/KEYS
+  gpg --import KEYS
+  gpg --verify ${PROJECT}-${VERSION}-rc${RC}-source.tar.gz{.asc,}
+  shasum -a 512 -c ${PROJECT}-${VERSION}-rc${RC}-source.tar.gz.sha512
+  tar -xzf ${PROJECT}-${VERSION}-rc${RC}-source.tar.gz
+  cd ${PROJECT}-${VERSION}/
+  make test-unit helm-lint check-license
+
+Notable changes are documented in:
+  ${GITHUB_BASE}/blob/v${VERSION}-rc${RC}/docs/reference/releases.md
+
+The vote will be open for at least 72 hours.
+
+[ ] +1 release this package
+[ ]  0 no opinion
+[ ] -1 do not release this package because ...
+
+Thanks,
+<release manager>
+EOF
+    ;;
+
+  result)
+    require_rc
+    cat <<EOF
+Subject: [RESULT][VOTE] Release ${DISPLAY_NAME} ${VERSION}-rc${RC}
+
+Hello,
+
+The vote to release ${DISPLAY_NAME} ${VERSION} based on candidate rc${RC}
+has passed.
+
+The vote tally is:
+
+Binding +1:
+- <name>
+- <name>
+- <name>
+
+Non-binding +1:
+- <name>
+
+0:
+- <name>
+
+-1:
+- <name and reason, or "None">
+
+The release will now be finalized.
+
+Thanks,
+<release manager>
+EOF
+    ;;
+
+  announce)
+    require_final
+    cat <<EOF
+Subject: [ANNOUNCE] Apache Superset Kubernetes Operator ${VERSION} released
+
+The Apache Superset team is pleased to announce the release of
+${DISPLAY_NAME} ${VERSION}.
+
+The signed source release is available at:
+  ${DIST_RELEASE_BASE}/kubernetes-operator-${VERSION}/
+
+Downloads and verification instructions are available at:
+  ${DOWNLOADS_BASE}
+
+Release notes are available at:
+  ${GITHUB_BASE}/blob/v${VERSION}/docs/reference/releases.md
+
+Thanks to everyone who contributed to this release.
+
+The Apache Superset team
+EOF
+    ;;
+
+  -h|--help)
+    usage
+    ;;
+
+  *)
+    usage >&2
+    die "unknown mode: ${MODE}"
+    ;;
+esac

--- a/scripts/release-finalize.sh
+++ b/scripts/release-finalize.sh
@@ -21,7 +21,7 @@
 #   scripts/release-finalize.sh <version>
 #
 # Example:
-#   scripts/release-finalize.sh 0.2.0    # creates tag v0.2.0
+#   scripts/release-finalize.sh 0.2.0    # from 0.2 branch, creates tag v0.2.0
 
 set -euo pipefail
 
@@ -40,7 +40,7 @@ VERSION="${1:-}"
 [[ -f Makefile ]] || die "must be run from the repository root"
 
 TAG="v${VERSION}"
-BRANCH="release/${VERSION}"
+BRANCH="${VERSION%.*}"
 
 # --- preflight checks ---
 if [[ -n "$(git status --porcelain)" ]]; then
@@ -55,6 +55,11 @@ fi
 LAST_RC=$(git tag -l "v${VERSION}-rc*" | sort -V | tail -1 || true)
 if [[ -z "$LAST_RC" ]]; then
   die "no RC tags found for v${VERSION} — run scripts/release-rc.sh first"
+fi
+LAST_RC_COMMIT=$(git rev-list -n 1 "${LAST_RC}")
+HEAD_COMMIT=$(git rev-parse HEAD)
+if [[ "$HEAD_COMMIT" != "$LAST_RC_COMMIT" ]]; then
+  die "HEAD is ${HEAD_COMMIT}, but ${LAST_RC} points to ${LAST_RC_COMMIT}; do not tag unvoted changes as the final release"
 fi
 
 if git rev-parse "${TAG}" >/dev/null 2>&1; then

--- a/scripts/release-rc.sh
+++ b/scripts/release-rc.sh
@@ -18,12 +18,12 @@
 # regenerate manifests, run checks, commit, and tag.
 #
 # Usage:
-#   scripts/release-rc.sh <version> [--chart-version <chart-version>]
+#   scripts/release-rc.sh <version> [--expect-rc <n>]
 #
 # Examples:
-#   scripts/release-rc.sh 0.2.0               # first RC → v0.2.0-rc1
+#   scripts/release-rc.sh 0.2.0               # first RC on 0.2 → v0.2.0-rc1
 #   scripts/release-rc.sh 0.2.0               # again   → v0.2.0-rc2
-#   scripts/release-rc.sh 0.3.0 --chart-version 0.2.0
+#   scripts/release-rc.sh 0.2.0 --expect-rc 1
 
 set -euo pipefail
 
@@ -47,12 +47,12 @@ fi
 
 # --- parse args ---
 VERSION=""
-CHART_VERSION=""
+EXPECT_RC=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --chart-version) CHART_VERSION="$2"; shift 2 ;;
+    --expect-rc) EXPECT_RC="$2"; shift 2 ;;
     -h|--help)
-      echo "Usage: $0 <version> [--chart-version <chart-version>]"
+      echo "Usage: $0 <version> [--expect-rc <n>]"
       exit 0
       ;;
     -*)  die "unknown flag: $1" ;;
@@ -60,21 +60,25 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ -n "$VERSION" ]] || die "usage: $0 <version> [--chart-version <chart-version>]"
+[[ -n "$VERSION" ]] || die "usage: $0 <version> [--expect-rc <n>]"
 [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "version must be semver (e.g., 0.2.0), got: $VERSION"
-if [[ -n "$CHART_VERSION" ]]; then
-  [[ "$CHART_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "chart version must be semver, got: $CHART_VERSION"
+if [[ -n "$EXPECT_RC" ]]; then
+  [[ "$EXPECT_RC" =~ ^[1-9][0-9]*$ ]] || die "--expect-rc must be a positive integer, got: $EXPECT_RC"
 fi
 
 # --- preflight checks ---
 command -v helm >/dev/null 2>&1 || die "helm is required but not installed"
 [[ -f Makefile ]] || die "must be run from the repository root"
+CHANGELOG_FILE="docs/reference/releases.md"
+[[ -f "$CHANGELOG_FILE" ]] || die "release notes file is missing: ${CHANGELOG_FILE}"
+grep -Eq "^##[[:space:]]+\\[${VERSION//./\\.}\\]([[:space:]]|$)" "$CHANGELOG_FILE" \
+  || die "${CHANGELOG_FILE} must contain a release heading for ${VERSION} (expected: ## [${VERSION}])"
 
 if [[ -n "$(git status --porcelain)" ]]; then
   die "working tree is not clean — commit or stash changes first"
 fi
 
-BRANCH="release/${VERSION}"
+BRANCH="${VERSION%.*}"
 CURRENT_BRANCH=$(git branch --show-current)
 
 # --- create or switch to release branch ---
@@ -98,6 +102,9 @@ else
   RC_N=1
 fi
 TAG="v${VERSION}-rc${RC_N}"
+if [[ -n "$EXPECT_RC" && "$RC_N" -ne "$EXPECT_RC" ]]; then
+  die "next RC would be rc${RC_N}, but --expect-rc ${EXPECT_RC} was provided"
+fi
 info "Preparing ${TAG}"
 
 # --- bump operator version in Makefile ---
@@ -109,16 +116,20 @@ else
   info "Makefile VERSION already set to ${VERSION}"
 fi
 
-# --- bump chart version ---
-# Default to the operator version when not explicitly overridden, so the source
-# release archive does not capture a stale "0.0.0-dev" Chart.yaml.
-: "${CHART_VERSION:=${VERSION}}"
+# --- bump chart version metadata ---
 CURRENT_CHART_VERSION=$(grep -E '^version:' charts/superset-operator/Chart.yaml | head -1 | awk '{print $2}')
-if [[ "$CURRENT_CHART_VERSION" != "$CHART_VERSION" ]]; then
-  info "Updating Chart.yaml version: ${CURRENT_CHART_VERSION} → ${CHART_VERSION}"
-  sed_inplace "s/^version: .*/version: ${CHART_VERSION}/" charts/superset-operator/Chart.yaml
+if [[ "$CURRENT_CHART_VERSION" != "$VERSION" ]]; then
+  info "Updating Chart.yaml version: ${CURRENT_CHART_VERSION} → ${VERSION}"
+  sed_inplace "s/^version: .*/version: ${VERSION}/" charts/superset-operator/Chart.yaml
 else
-  info "Chart.yaml version already set to ${CHART_VERSION}"
+  info "Chart.yaml version already set to ${VERSION}"
+fi
+CURRENT_CHART_APP_VERSION=$(grep -E '^appVersion:' charts/superset-operator/Chart.yaml | head -1 | awk '{print $2}' | tr -d '"')
+if [[ "$CURRENT_CHART_APP_VERSION" != "$VERSION" ]]; then
+  info "Updating Chart.yaml appVersion: ${CURRENT_CHART_APP_VERSION} → ${VERSION}"
+  sed_inplace "s/^appVersion: .*/appVersion: \"${VERSION}\"/" charts/superset-operator/Chart.yaml
+else
+  info "Chart.yaml appVersion already set to ${VERSION}"
 fi
 
 # --- regenerate generated artifacts ---
@@ -140,10 +151,6 @@ make helm-lint
 
 info "Building docs"
 make docs-build
-
-# --- package Helm chart ---
-info "Packaging Helm chart"
-make helm
 
 # --- commit ---
 CHANGED_FILES=$(git diff --name-only)
@@ -170,6 +177,7 @@ echo -e "${BOLD}Release candidate ${TAG} is ready.${RESET}"
 echo ""
 echo "Next steps:"
 echo "  1. Review the commit:  git log --oneline -3"
-echo "  2. Push branch + tag:  git push origin ${BRANCH} ${TAG}"
+echo "  2. Build and verify source artifacts:  scripts/release-source.sh"
+echo "  3. Push branch + tag only after artifact verification:  git push origin ${BRANCH} ${TAG}"
 echo ""
 echo "The release workflow will build and push the ${VERSION}-rc${RC_N} image to GHCR."

--- a/scripts/release-source.sh
+++ b/scripts/release-source.sh
@@ -18,23 +18,24 @@
 # SHA-512 checksum) for an operator release candidate or final release.
 #
 # Usage:
-#   scripts/release-source.sh <version> --rc <n>     # produce RC artifacts
-#   scripts/release-source.sh <version> --finalize \
-#       --rc-dir <dir>                                # promote RC → final
+#   scripts/release-source.sh                         # infer tag from HEAD
+#   scripts/release-source.sh <version> --rc <n>      # produce a specific RC
+#   scripts/release-source.sh --finalize              # promote voted RC → final
 #
 # In RC mode the script:
 #   1. Archives the v<version>-rc<n> git tag into
 #      apache-superset-kubernetes-operator-<version>-rc<n>-source.tar.gz
-#   2. Detached-signs it with the user's default GPG key (override with
-#      --gpg-key <id>)
+#   2. Detached-signs it with the newest usable local apache.org secret key
+#      (override with --gpg-key <id>)
 #   3. Writes a SHA-512 checksum file with a *bare* filename so verifiers can
 #      run `shasum -a 512 -c <file>.sha512` after a plain download.
 #
-# In --finalize mode the script:
-#   1. Re-derives the final filenames from the RC-staged artifacts in
-#      <rc-dir>: copies the tarball + .asc (detached signatures verify file
-#      contents, not the filename, so the same signature stays valid) and
-#      regenerates the .sha512 file (since shasum embeds the filename).
+# In finalize mode the script:
+#   1. Requires HEAD to have both v<version> and v<version>-rc<n> tags.
+#   2. Re-derives the final filenames from the RC artifacts: copies the tarball
+#      + .asc (detached signatures verify file contents, not the filename, so
+#      the same signature stays valid) and regenerates the .sha512 file (since
+#      shasum embeds the filename).
 #   2. Verifies the result before exiting.
 #
 # Run from the repository root.
@@ -54,17 +55,22 @@ warn() { echo -e "${YELLOW}warning:${RESET} $*"; }
 usage() {
   cat <<EOF
 Usage:
-  $0 <version> --rc <n> [--gpg-key <id>] [--out-dir <dir>]
-  $0 <version> --finalize --rc-dir <dir> [--gpg-key <id>] [--out-dir <dir>]
+  $0 [<version>] [--rc <n>] [--gpg-key <id>] [--out-dir <dir>]
+  $0 [<version>] --finalize [--rc-dir <dir>] [--gpg-key <id>] [--out-dir <dir>]
 
 Options:
-  --rc <n>          Build artifacts for v<version>-rc<n>.
+  <version>         Release version. Defaults to the release tag on HEAD.
+  --rc <n>          Build artifacts for v<version>-rc<n>. Defaults to the
+                    latest local v<version>-rc<n> tag on HEAD.
   --finalize        Promote RC artifacts in --rc-dir to final filenames.
-  --rc-dir <dir>    Directory containing the staged RC artifacts.
+                    Defaults when HEAD has a final v<version> tag.
+  --rc-dir <dir>    Directory containing the staged RC artifacts. Defaults to
+                    ./dist/<version>-rc<n> when a matching RC tag is on HEAD.
   --gpg-key <id>    GPG key id/fingerprint for the .asc signature.
-                    Required for --finalize when re-signing is needed; in RC
-                    mode the GPG default is used when this is omitted.
-  --out-dir <dir>   Output directory (default: ./dist).
+                    Defaults to the newest usable local secret key with an
+                    apache.org UID.
+  --out-dir <dir>   Output directory. Defaults to ./dist/<version>-rc<n> in
+                    RC mode and ./dist/<version> in finalize mode.
 EOF
 }
 
@@ -73,7 +79,7 @@ RC=""
 MODE=""
 RC_DIR=""
 GPG_KEY=""
-OUT_DIR="dist"
+OUT_DIR=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -88,16 +94,124 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ -n "$VERSION" ]] || { usage >&2; die "version is required"; }
-[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "version must be semver (e.g., 0.2.0), got: $VERSION"
-[[ -n "$MODE" ]] || { usage >&2; die "either --rc <n> or --finalize is required"; }
-
 command -v gpg     >/dev/null 2>&1 || die "gpg is required"
-command -v shasum  >/dev/null 2>&1 || die "shasum is required"
 command -v git     >/dev/null 2>&1 || die "git is required"
 
-mkdir -p "$OUT_DIR"
 PROJECT="apache-superset-kubernetes-operator"
+
+detect_apache_signing_key() {
+  local now
+  now=$(date +%s)
+  gpg --list-secret-keys --with-colons --fingerprint 2>/dev/null | awk -F: -v now="$now" '
+    /^sec:/ {
+      fpr = ""
+      created = $6
+      expires = $7
+      usable = ($2 != "e" && $2 != "r" && (expires == "" || expires > now) && $12 ~ /[sS]/)
+    }
+    /^fpr:/ && fpr == "" { fpr = $10 }
+    /^uid:/ && usable && $10 ~ /<[^>]+@apache[.]org>/ && fpr != "" {
+      print created ":" fpr
+      fpr = ""
+    }
+  ' | sort -t: -k1,1n | tail -1 | cut -d: -f2
+}
+
+signing_key() {
+  if [[ -n "$GPG_KEY" ]]; then
+    printf "%s\n" "$GPG_KEY"
+  else
+    detect_apache_signing_key
+  fi
+}
+
+command -v shasum  >/dev/null 2>&1 || die "shasum is required"
+
+version_re() {
+  printf "%s" "$1" | sed 's/[.]/\\./g'
+}
+
+latest_rc_tag_on_head() {
+  local version="$1"
+  local pattern
+
+  if [[ -n "$version" ]]; then
+    pattern="^v$(version_re "$version")-rc[1-9][0-9]*$"
+  else
+    pattern='^v[0-9]+\.[0-9]+\.[0-9]+-rc[1-9][0-9]*$'
+  fi
+
+  git tag --points-at HEAD \
+    | grep -E "$pattern" \
+    | awk -F-rc '{ print $2 ":" $0 }' \
+    | sort -t: -k1,1n \
+    | tail -1 \
+    | cut -d: -f2- \
+    || true
+}
+
+final_tag_on_head() {
+  local version="$1"
+  local pattern
+
+  if [[ -n "$version" ]]; then
+    pattern="^v$(version_re "$version")$"
+  else
+    pattern='^v[0-9]+\.[0-9]+\.[0-9]+$'
+  fi
+
+  git tag --points-at HEAD | grep -E "$pattern" | tail -1 || true
+}
+
+infer_release_identity() {
+  local final_tag rc_tag
+
+  final_tag="$(final_tag_on_head "$VERSION")"
+  rc_tag="$(latest_rc_tag_on_head "$VERSION")"
+
+  if [[ -z "$MODE" ]]; then
+    if [[ -n "$final_tag" ]]; then
+      MODE="finalize"
+    else
+      MODE="rc"
+    fi
+  fi
+
+  case "$MODE" in
+    rc)
+      if [[ -z "$rc_tag" ]]; then
+        die "no RC tag found on HEAD; create one with scripts/release-rc.sh first"
+      fi
+      if [[ -z "$VERSION" ]]; then
+        VERSION="${rc_tag#v}"
+        VERSION="${VERSION%-rc*}"
+      fi
+      if [[ -z "$RC" ]]; then
+        RC="${rc_tag##*-rc}"
+      fi
+      ;;
+
+    finalize)
+      if [[ -z "$final_tag" ]]; then
+        die "no final release tag found on HEAD; create one with scripts/release-finalize.sh first"
+      fi
+      if [[ -z "$rc_tag" ]]; then
+        die "no matching RC tag found on HEAD; final artifacts must promote the voted RC bytes"
+      fi
+      if [[ -z "$VERSION" ]]; then
+        VERSION="${final_tag#v}"
+      fi
+      if [[ -z "$RC" && -n "$rc_tag" ]]; then
+        RC="${rc_tag##*-rc}"
+      fi
+      ;;
+  esac
+}
+
+infer_release_identity
+
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "version must be semver (e.g., 0.2.0), got: $VERSION"
+[[ "$MODE" == "rc" || "$MODE" == "finalize" ]] || die "unknown mode: ${MODE}"
 
 # Compute the SHA-512 with a bare filename inside the file (no path) so
 # downstream `shasum -a 512 -c <file>.sha512` works after a plain download.
@@ -119,15 +233,18 @@ verify_artifacts() {
 
 case "$MODE" in
   rc)
-    [[ -n "$RC" ]] || die "--rc requires a number"
-    [[ "$RC" =~ ^[0-9]+$ ]] || die "rc must be a positive integer"
+    [[ "$RC" =~ ^[1-9][0-9]*$ ]] || die "rc must be a positive integer"
 
     TAG="v${VERSION}-rc${RC}"
     BASE="${PROJECT}-${VERSION}-rc${RC}-source.tar.gz"
+    : "${OUT_DIR:=dist/${VERSION}-rc${RC}}"
+    mkdir -p "$OUT_DIR"
     OUT="${OUT_DIR}/${BASE}"
 
     git rev-parse --verify "${TAG}^{tag}" >/dev/null 2>&1 \
       || die "git tag ${TAG} does not exist; create it with scripts/release-rc.sh first"
+    [[ "$(git rev-parse "${TAG}^{commit}")" == "$(git rev-parse HEAD)" ]] \
+      || die "git tag ${TAG} does not point to HEAD"
 
     info "Archiving ${TAG} → ${OUT}"
     git archive --format=tar.gz \
@@ -135,12 +252,11 @@ case "$MODE" in
       -o "${OUT}" "${TAG}"
 
     info "Signing ${BASE}"
-    if [[ -n "$GPG_KEY" ]]; then
-      gpg --armor --local-user "$GPG_KEY" \
-          --output "${OUT}.asc" --detach-sig "${OUT}"
-    else
-      gpg --armor --output "${OUT}.asc" --detach-sig "${OUT}"
-    fi
+    SIGNING_KEY="$(signing_key)"
+    [[ -n "$SIGNING_KEY" ]] || die "no usable local apache.org secret signing key found; rerun with --gpg-key <fingerprint>"
+    info "Using GPG key ${SIGNING_KEY}"
+    gpg --armor --local-user "$SIGNING_KEY" \
+        --output "${OUT}.asc" --detach-sig "${OUT}"
 
     info "Computing SHA-512"
     write_sha512 "${OUT}"
@@ -155,8 +271,15 @@ case "$MODE" in
     ;;
 
   finalize)
-    [[ -n "$RC_DIR" ]] || die "--finalize requires --rc-dir"
+    if [[ -z "$RC_DIR" ]]; then
+      [[ "$RC" =~ ^[1-9][0-9]*$ ]] \
+        || die "cannot infer --rc-dir because no matching RC tag was found on HEAD"
+      RC_DIR="dist/${VERSION}-rc${RC}"
+      info "Using inferred RC artifact directory ${RC_DIR}"
+    fi
     [[ -d "$RC_DIR" ]] || die "rc directory does not exist: ${RC_DIR}"
+    : "${OUT_DIR:=dist/${VERSION}}"
+    mkdir -p "$OUT_DIR"
 
     # Locate the RC tarball and derive the final filename from the version arg.
     RC_TARBALL=$(find "$RC_DIR" -maxdepth 1 -type f \


### PR DESCRIPTION
## Summary

Refines the release tooling and documentation for the first Apache Superset Kubernetes Operator source release.

## Details

This updates the release flow around maintenance branches, RC/final tags, source artifact generation, and release communication drafts. It also moves release notes into the docs site, keeps the root changelog as a pointer, and adds validation so release prep fails if the target version is missing from the documented release notes.

The tooling now supports RC preparation, source artifact signing, final release promotion from voted RC artifacts, and generation of vote/result/announcement email drafts.