### PR TITLE
docs: document extension deployment options

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -341,6 +341,70 @@ Both fields are **concatenated**, not mutually exclusive. In this example, the c
 
 See [Config Rendering Pipeline](../architecture/overview.md#config-rendering-pipeline) for the full rendering order and an example of the generated output.
 
+## Extensions
+
+Superset loads extension bundles (`.supx` files) from the directory configured
+by `EXTENSIONS_PATH` in `superset_config.py`. The operator does not currently
+provide a typed extension field. Use one of two deployment patterns.
+
+### Bake Extensions Into The Image
+
+Build a Superset image that already contains the extension bundles, then point
+`EXTENSIONS_PATH` at that directory:
+
+```yaml
+spec:
+  image:
+    repository: example.com/superset-with-extensions
+    tag: "6.1.0-extensions-v1"
+  config: |
+    EXTENSIONS_PATH = "/app/extensions"
+```
+
+This is the most repeatable path when extension contents should version with
+the Superset image.
+
+### Mount Extensions With PodTemplate
+
+Mount the extension directory with native Kubernetes volume fields, then point
+`EXTENSIONS_PATH` at the mount path:
+
+```yaml
+spec:
+  config: |
+    EXTENSIONS_PATH = "/app/extensions"
+
+  podTemplate:
+    volumes:
+      - name: superset-extensions
+        persistentVolumeClaim:
+          claimName: superset-extensions
+    container:
+      volumeMounts:
+        - name: superset-extensions
+          mountPath: /app/extensions
+          readOnly: true
+```
+
+Top-level `spec.podTemplate` is inherited by every operator-managed Superset
+workload Pod, so the extension volume is mounted consistently across the
+deployment and lifecycle workloads.
+
+Because `.supx` files are binary zip archives, use a storage source suited for
+binary artifacts.
+
+When you know mounted extension contents have changed, update
+`spec.forceReload` to roll the component pods:
+
+```yaml
+spec:
+  forceReload: "extensions-v2"
+```
+
+See Superset's
+[extension deployment documentation](https://superset.apache.org/developer-docs/extensions/deployment/)
+for up-to-date guidance on deploying extensions.
+
 ## Bootstrap Script
 
 `bootstrapScript` is an escape hatch for the default Python component and
@@ -1037,6 +1101,8 @@ useful for **secret rotation**: when you update a Kubernetes Secret's data, pods
 don't automatically restart because the operator references secrets via
 `valueFrom.secretKeyRef` (resolved at pod creation time). Changing `forceReload`
 forces new pods that pick up the updated secret values.
+
+Use the same mechanism when you know mounted extension contents have changed.
 
 ## Suspend Reconciliation
 

--- a/internal/controller/deployment_builder_test.go
+++ b/internal/controller/deployment_builder_test.go
@@ -167,6 +167,16 @@ func TestBuildDeploymentSpec(t *testing.T) {
 				PullPolicy: corev1.PullIfNotPresent,
 			},
 			PodTemplate: &supersetv1alpha1.PodTemplate{
+				Volumes: []corev1.Volume{
+					{
+						Name: "superset-extensions",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "superset-extensions",
+							},
+						},
+					},
+				},
 				Resources: &corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("2"),
@@ -175,6 +185,11 @@ func TestBuildDeploymentSpec(t *testing.T) {
 					Limits: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("4"),
 						corev1.ResourceMemory: resource.MustParse("8Gi"),
+					},
+				},
+				Container: &supersetv1alpha1.ContainerTemplate{
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "superset-extensions", MountPath: "/app/extensions", ReadOnly: true},
 					},
 				},
 			},
@@ -196,6 +211,26 @@ func TestBuildDeploymentSpec(t *testing.T) {
 		}
 		if podResources.Limits.Memory().String() != "8Gi" {
 			t.Errorf("expected pod memory limit 8Gi, got %s", podResources.Limits.Memory())
+		}
+
+		if len(result.Template.Spec.Volumes) != 1 {
+			t.Fatalf("expected one pod volume, got %d", len(result.Template.Spec.Volumes))
+		}
+		volume := result.Template.Spec.Volumes[0]
+		if volume.Name != "superset-extensions" {
+			t.Fatalf("expected superset-extensions volume, got %q", volume.Name)
+		}
+		if volume.PersistentVolumeClaim == nil || volume.PersistentVolumeClaim.ClaimName != "superset-extensions" {
+			t.Fatalf("expected PVC-backed extension volume, got %+v", volume.VolumeSource)
+		}
+
+		container := result.Template.Spec.Containers[0]
+		if len(container.VolumeMounts) != 1 {
+			t.Fatalf("expected one volume mount on superset container, got %d", len(container.VolumeMounts))
+		}
+		mount := container.VolumeMounts[0]
+		if mount.Name != "superset-extensions" || mount.MountPath != "/app/extensions" || !mount.ReadOnly {
+			t.Fatalf("unexpected extension volume mount: %+v", mount)
 		}
 	})
 


### PR DESCRIPTION
## Summary

Document how to deploy Superset extensions with the operator today. The guide now describes the two supported patterns: baking extension bundles into the Superset image, or mounting them with Kubernetes-native `podTemplate` volume fields and setting the extension path through `spec.config`.

It also clarifies that top-level `spec.podTemplate` is inherited by operator-managed Superset workload Pods, and documents `spec.forceReload` as the escape hatch for recycling pods when mounted extension contents change.

## Details

- Adds an Extensions section to the configuration guide.
- Shows examples for image-baked and mounted extension bundles.
- Adds a small regression assertion that podTemplate volumes and volumeMounts reach the Superset container.