### PR TITLE
fix(lifecycle): keep MySQL clone secrets out of process argv

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ to get started, or jump straight to the [quick start](#quick-start).
 - **Safe upgrades** — components drain, lifecycle tasks run, and traffic returns only once the new version is healthy, with an optional maintenance page for the window.
 - **Batteries included, never locked in** — tuned defaults and presets for Gunicorn, Celery, the metastore, and Valkey, with a raw Python escape hatch for anything not surfaced as a typed field.
 - **Production operations built in** — autoscaling, PodDisruptionBudgets, NetworkPolicies, Gateway API / Ingress routing, and a Prometheus ServiceMonitor.
-- **Fits your cluster** — cluster-scoped or namespace-scoped installs; the namespace-scoped Helm install needs no cluster-wide RBAC at all.
+- **Fits your cluster** — cluster-scoped or namespace-scoped installs; the namespace-scoped Helm install renders no manager `ClusterRole` (CRD installation and, unless disabled, secure metrics auth still need cluster-scoped RBAC — see [installation](https://apache.github.io/superset-kubernetes-operator/user-guide/installation/#namespace-scoped-install)).
 
 → See the [full feature overview](https://apache.github.io/superset-kubernetes-operator/) in the docs.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,8 +24,8 @@ Superset instance using dev mode.
 
 ## Prerequisites
 
-- Kubernetes 1.25+ (1.34 is officially tested; 1.29+ recommended so CEL
-  validation is GA — see [supported versions](user-guide/installation.md#supported-kubernetes-versions))
+- Kubernetes 1.25+ (<!-- BEGIN SUPPORTED-K8S-INLINE -->1.36, 1.35<!-- END SUPPORTED-K8S-INLINE --> officially
+  tested; 1.29+ recommended so CEL validation is GA — see [supported versions](user-guide/installation.md#supported-kubernetes-versions))
 - Helm 3
 - A PostgreSQL database accessible from the cluster
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ The operator manages the full Superset lifecycle: database migrations, configura
 - **Lifecycle automation** — database cloning, schema migrations, secret key rotation, and application init run as sequenced tasks with automatic change detection and checksum-based re-execution
 - **Networking** — Gateway API (HTTPRoute) and Ingress support with per-component routing
 - **Scaling and resilience** — HPA with custom metrics, PodDisruptionBudgets, NetworkPolicies, Prometheus ServiceMonitor
-- **Flexible install scope** — cluster-scoped (default) or namespace-scoped; the namespace-scoped Helm install renders no manager `ClusterRole` at all, so it works on restricted clusters that forbid cluster-scoped RBAC
+- **Flexible install scope** — cluster-scoped (default) or namespace-scoped; the namespace-scoped Helm install renders no manager `ClusterRole`. CRD installation and, unless metrics are disabled, secure metrics auth still require cluster-scoped RBAC — see [installation](user-guide/installation.md#namespace-scoped-install) for the exact constraints
 
 ## Supported Kubernetes versions
 

--- a/docs/reference/downloads.md
+++ b/docs/reference/downloads.md
@@ -20,8 +20,46 @@ under the License.
 # Downloads
 
 !!! note
-    There are no official releases yet. Only `dev` and `sha-<short>` image tags
-    and the `0.0.0-dev` Helm chart are currently available.
+    No official release has been cut yet. Development builds (`dev` /
+    `sha-<short>` image tags and the `0.0.0-dev` Helm chart) are available now;
+    release candidates are published as pre-release artifacts during voting.
+    The first official source release will be `0.1.0`. The source-release links
+    below are filled in once a release is staged.
+
+## Source Release
+
+Per the [ASF Release Policy](https://www.apache.org/legal/release-policy.html),
+the **signed source archive is the official Apache release**. The operator image
+and Helm chart below are convenience binaries built from this source.
+
+Released source archives are published to the ASF distribution mirrors:
+
+```
+https://downloads.apache.org/superset/kubernetes-operator-<version>/
+```
+
+Release candidates under vote are staged at
+`https://dist.apache.org/repos/dist/dev/superset/kubernetes-operator-<version>-rc<N>/`.
+
+### Artifacts
+
+| Artifact | Filename | Description |
+|----------|----------|-------------|
+| Source archive | `apache-superset-kubernetes-operator-<version>-source.tar.gz` | `git archive` of the release tag. |
+| PGP signature | `apache-superset-kubernetes-operator-<version>-source.tar.gz.asc` | Detached signature from a key in [`KEYS`](https://downloads.apache.org/superset/KEYS). |
+| SHA-512 checksum | `apache-superset-kubernetes-operator-<version>-source.tar.gz.sha512` | `shasum -a 512` output. |
+
+### Verify
+
+```bash
+# Replace <version> with the release you downloaded (e.g. 0.1.0).
+curl -O https://downloads.apache.org/superset/kubernetes-operator-<version>/apache-superset-kubernetes-operator-<version>-source.tar.gz{,.asc,.sha512}
+curl -O https://downloads.apache.org/superset/KEYS
+
+gpg --import KEYS
+gpg --verify apache-superset-kubernetes-operator-<version>-source.tar.gz{.asc,}
+shasum -a 512 -c apache-superset-kubernetes-operator-<version>-source.tar.gz.sha512
+```
 
 ## Operator Image
 

--- a/docs/reference/downloads.md
+++ b/docs/reference/downloads.md
@@ -21,45 +21,16 @@ under the License.
 
 !!! note
     No official release has been cut yet. Development builds (`dev` /
-    `sha-<short>` image tags and the `0.0.0-dev` Helm chart) are available now;
-    release candidates are published as pre-release artifacts during voting.
-    The first official source release will be `0.1.0`. The source-release links
-    below are filled in once a release is staged.
+    `sha-<short>` image tags and the `0.0.0-dev` Helm chart) are available now.
 
 ## Source Release
 
 Per the [ASF Release Policy](https://www.apache.org/legal/release-policy.html),
-the **signed source archive is the official Apache release**. The operator image
-and Helm chart below are convenience binaries built from this source.
+the **signed source archive is the official Apache release**; the operator image
+and Helm chart below are convenience binaries built from it.
 
-Released source archives are published to the ASF distribution mirrors:
-
-```
-https://downloads.apache.org/superset/kubernetes-operator-<version>/
-```
-
-Release candidates under vote are staged at
-`https://dist.apache.org/repos/dist/dev/superset/kubernetes-operator-<version>-rc<N>/`.
-
-### Artifacts
-
-| Artifact | Filename | Description |
-|----------|----------|-------------|
-| Source archive | `apache-superset-kubernetes-operator-<version>-source.tar.gz` | `git archive` of the release tag. |
-| PGP signature | `apache-superset-kubernetes-operator-<version>-source.tar.gz.asc` | Detached signature from a key in [`KEYS`](https://downloads.apache.org/superset/KEYS). |
-| SHA-512 checksum | `apache-superset-kubernetes-operator-<version>-source.tar.gz.sha512` | `shasum -a 512` output. |
-
-### Verify
-
-```bash
-# Replace <version> with the release you downloaded (e.g. 0.1.0).
-curl -O https://downloads.apache.org/superset/kubernetes-operator-<version>/apache-superset-kubernetes-operator-<version>-source.tar.gz{,.asc,.sha512}
-curl -O https://downloads.apache.org/superset/KEYS
-
-gpg --import KEYS
-gpg --verify apache-superset-kubernetes-operator-<version>-source.tar.gz{.asc,}
-shasum -a 512 -c apache-superset-kubernetes-operator-<version>-source.tar.gz.sha512
-```
+Source archives, signatures, and checksums — along with verification
+instructions — will be published here once the first release is staged.
 
 ## Operator Image
 

--- a/internal/controller/clone_test.go
+++ b/internal/controller/clone_test.go
@@ -130,8 +130,32 @@ func TestBuildCloneScript(t *testing.T) {
 		if !strings.Contains(script, "| mysql") {
 			t.Error("expected pipe to mysql")
 		}
-		if strings.Contains(script, "`") {
-			t.Error("script must not contain backticks (shell command substitution)")
+		// Passwords must travel via MYSQL_PWD, never on the command line, so
+		// they don't leak into process argv (ps / /proc/<pid>/cmdline).
+		if strings.Contains(script, `-p"$`) {
+			t.Errorf("password must not be passed via -p (leaks into argv), got: %s", script)
+		}
+		if !strings.Contains(script, `export MYSQL_PWD="$SUPERSET_OPERATOR__DB_PASS"`) {
+			t.Errorf("expected target password via MYSQL_PWD, got: %s", script)
+		}
+		if !strings.Contains(script, `export MYSQL_PWD="$SUPERSET_OPERATOR__CLONE_SRC_PASS"`) {
+			t.Errorf("expected source password via MYSQL_PWD, got: %s", script)
+		}
+		// The destructive DROP/CREATE must use a backtick-quoted, escaped
+		// identifier rather than interpolating the raw name into SQL. The
+		// backticks are backslash-escaped so the shell passes them literally.
+		if !strings.Contains(script, "ESC_NAME=$(printf '%s' \"$SUPERSET_OPERATOR__DB_NAME\" | sed 's/`/``/g')") {
+			t.Errorf("expected DB identifier to be backtick-escaped, got: %s", script)
+		}
+		if !strings.Contains(script, "DROP DATABASE IF EXISTS \\`${ESC_NAME}\\`") {
+			t.Errorf("expected backtick-quoted identifier in DROP DATABASE, got: %s", script)
+		}
+		if !strings.Contains(script, "CREATE DATABASE \\`${ESC_NAME}\\`") {
+			t.Errorf("expected backtick-quoted identifier in CREATE DATABASE, got: %s", script)
+		}
+		// The raw, unquoted identifier must no longer reach the SQL statement.
+		if strings.Contains(script, "DROP DATABASE IF EXISTS $SUPERSET_OPERATOR__DB_NAME") {
+			t.Errorf("DB name must be backtick-quoted, not interpolated raw, got: %s", script)
 		}
 	})
 

--- a/internal/controller/lifecycle_clone.go
+++ b/internal/controller/lifecycle_clone.go
@@ -98,8 +98,23 @@ PGPASSWORD="$SUPERSET_OPERATOR__CLONE_SRC_PASS" pg_dump -h "$SUPERSET_OPERATOR__
 
 func buildMySQLCloneScript(clone *supersetv1alpha1.CloneTaskSpec) string {
 	var b strings.Builder
+	// Passwords are passed via the MYSQL_PWD environment variable rather than
+	// -p"$PASS" so they never appear in the process argv (visible via ps or
+	// /proc/<pid>/cmdline), mirroring lifecycle_create_db.go. The target
+	// password is exported once at the top; every target mysql invocation
+	// inherits it. The source mysqldump runs inside the pipeline subshell where
+	// MYSQL_PWD is re-exported to the source password, so the two passwords
+	// never collide. Empty passwords are left unset to support passwordless
+	// auth (trust/IAM), matching the create-database helper.
+	//
+	// The target database identifier is backtick-quoted with internal backticks
+	// doubled (MySQL's escape rule), and the backticks are backslash-escaped so
+	// they reach mysql literally instead of triggering shell command
+	// substitution inside the double-quoted -e argument.
 	b.WriteString(`set -e
-mysql -h "$SUPERSET_OPERATOR__DB_HOST" -P "$SUPERSET_OPERATOR__DB_PORT" -u "$SUPERSET_OPERATOR__DB_USER" -p"$SUPERSET_OPERATOR__DB_PASS" -e "DROP DATABASE IF EXISTS $SUPERSET_OPERATOR__DB_NAME; CREATE DATABASE $SUPERSET_OPERATOR__DB_NAME;"
+if [ -n "${SUPERSET_OPERATOR__DB_PASS:-}" ]; then export MYSQL_PWD="$SUPERSET_OPERATOR__DB_PASS"; fi
+ESC_NAME=$(printf '%s' "$SUPERSET_OPERATOR__DB_NAME" | sed 's/` + "`" + `/` + "``" + `/g')
+mysql -h "$SUPERSET_OPERATOR__DB_HOST" -P "$SUPERSET_OPERATOR__DB_PORT" -u "$SUPERSET_OPERATOR__DB_USER" -e "DROP DATABASE IF EXISTS \` + "`" + `${ESC_NAME}\` + "`" + `; CREATE DATABASE \` + "`" + `${ESC_NAME}\` + "`" + `;"
 `)
 
 	// mysqldump has no per-table --no-data flag, so emit two passes joined into
@@ -110,11 +125,13 @@ mysql -h "$SUPERSET_OPERATOR__DB_HOST" -P "$SUPERSET_OPERATOR__DB_PORT" -u "$SUP
 	// combined stdout is piped to the target mysql client. The schema pass is
 	// skipped when ExcludeTableData is empty so the existing single-pass
 	// behaviour is preserved.
-	mysqldumpHead := `mysqldump -h "$SUPERSET_OPERATOR__CLONE_SRC_HOST" -P "$SUPERSET_OPERATOR__CLONE_SRC_PORT" -u "$SUPERSET_OPERATOR__CLONE_SRC_USER" -p"$SUPERSET_OPERATOR__CLONE_SRC_PASS"`
+	mysqldumpHead := `mysqldump -h "$SUPERSET_OPERATOR__CLONE_SRC_HOST" -P "$SUPERSET_OPERATOR__CLONE_SRC_PORT" -u "$SUPERSET_OPERATOR__CLONE_SRC_USER"`
 
-	b.WriteString("(")
+	// Open the dump subshell and scope the source password to it only, so the
+	// downstream target mysql keeps the target password exported above.
+	b.WriteString(`( if [ -n "${SUPERSET_OPERATOR__CLONE_SRC_PASS:-}" ]; then export MYSQL_PWD="$SUPERSET_OPERATOR__CLONE_SRC_PASS"; fi ; `)
 	if len(clone.ExcludeTableData) > 0 {
-		fmt.Fprintf(&b, " %s --single-transaction --no-data", mysqldumpHead)
+		fmt.Fprintf(&b, "%s --single-transaction --no-data", mysqldumpHead)
 		b.WriteString(` "$SUPERSET_OPERATOR__CLONE_SRC_DB"`)
 		for _, t := range clone.ExcludeTableData {
 			fmt.Fprintf(&b, ` %q`, t)
@@ -129,10 +146,10 @@ mysql -h "$SUPERSET_OPERATOR__DB_HOST" -P "$SUPERSET_OPERATOR__DB_PORT" -u "$SUP
 	for _, t := range clone.ExcludeTableData {
 		fmt.Fprintf(&b, ` --ignore-table="$SUPERSET_OPERATOR__CLONE_SRC_DB".%q`, t)
 	}
-	b.WriteString(` "$SUPERSET_OPERATOR__CLONE_SRC_DB" ) | mysql -h "$SUPERSET_OPERATOR__DB_HOST" -P "$SUPERSET_OPERATOR__DB_PORT" -u "$SUPERSET_OPERATOR__DB_USER" -p"$SUPERSET_OPERATOR__DB_PASS" "$SUPERSET_OPERATOR__DB_NAME"`)
+	b.WriteString(` "$SUPERSET_OPERATOR__CLONE_SRC_DB" ) | mysql -h "$SUPERSET_OPERATOR__DB_HOST" -P "$SUPERSET_OPERATOR__DB_PORT" -u "$SUPERSET_OPERATOR__DB_USER" "$SUPERSET_OPERATOR__DB_NAME"`)
 
 	for _, sql := range clone.PostCloneSQL {
-		fmt.Fprintf(&b, "\nmysql -h \"$SUPERSET_OPERATOR__DB_HOST\" -P \"$SUPERSET_OPERATOR__DB_PORT\" -u \"$SUPERSET_OPERATOR__DB_USER\" -p\"$SUPERSET_OPERATOR__DB_PASS\" \"$SUPERSET_OPERATOR__DB_NAME\" -e %q", sql)
+		fmt.Fprintf(&b, "\nmysql -h \"$SUPERSET_OPERATOR__DB_HOST\" -P \"$SUPERSET_OPERATOR__DB_PORT\" -u \"$SUPERSET_OPERATOR__DB_USER\" \"$SUPERSET_OPERATOR__DB_NAME\" -e %q", sql)
 	}
 
 	return b.String()

--- a/internal/controller/serviceaccount_test.go
+++ b/internal/controller/serviceaccount_test.go
@@ -59,7 +59,12 @@ func TestResolveServiceAccountName(t *testing.T) {
 			want: "external-sa",
 		},
 		{
-			name: "create=false without name yields empty (pod default SA)",
+			// CEL rejects create=false without a name at the apiserver
+			// (api/v1alpha1 ServiceAccountSpec XValidation), so this input never
+			// reaches the controller in practice. resolveServiceAccountName stays
+			// defensive about it and returns empty; we assert that fallback rather
+			// than implying create=false-without-name is a supported config.
+			name: "create=false without name (CEL-rejected; defensive empty fallback)",
 			sa:   &supersetv1alpha1.ServiceAccountSpec{Create: boolPtr(false)},
 			want: "",
 		},

--- a/scripts/render-supported-versions.sh
+++ b/scripts/render-supported-versions.sh
@@ -20,6 +20,11 @@
 #   <!-- BEGIN SUPPORTED-K8S -->
 #   ... generated block ...
 #   <!-- END SUPPORTED-K8S -->
+#
+# Prose files that need just the version list inline (not the full block) use a
+# same-line inline sentinel instead:
+#
+#   ... <!-- BEGIN SUPPORTED-K8S-INLINE -->1.36, 1.35<!-- END SUPPORTED-K8S-INLINE --> ...
 
 set -euo pipefail
 
@@ -29,6 +34,10 @@ TARGETS=(
   "${REPO_ROOT}/README.md"
   "${REPO_ROOT}/docs/index.md"
   "${REPO_ROOT}/docs/user-guide/installation.md"
+)
+# Files carrying the version list inline within prose (see SUPPORTED-K8S-INLINE).
+INLINE_TARGETS=(
+  "${REPO_ROOT}/docs/getting-started.md"
 )
 
 command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
@@ -64,5 +73,19 @@ for file in "${TARGETS[@]}"; do
     }
     !skip { print }
   ' "${file}" > "${tmp}"
+  mv "${tmp}" "${file}"
+done
+
+# Inline targets: rewrite only the text between the same-line inline sentinels,
+# leaving the surrounding prose untouched.
+for file in "${INLINE_TARGETS[@]}"; do
+  if ! grep -q '<!-- BEGIN SUPPORTED-K8S-INLINE -->' "${file}"; then
+    echo "no inline sentinel found in ${file}" >&2
+    exit 1
+  fi
+  tmp="$(mktemp)"
+  # One inline sentinel pair per line; the greedy .* is safe because there is a
+  # single END marker on the line. Version minors contain no sed metacharacters.
+  sed -E "s|(<!-- BEGIN SUPPORTED-K8S-INLINE -->).*(<!-- END SUPPORTED-K8S-INLINE -->)|\\1${supported}\\2|g" "${file}" > "${tmp}"
   mv "${tmp}" "${file}"
 done


### PR DESCRIPTION
## Summary

The MySQL clone script passed Secret-backed database passwords as `-p"$VAR"` arguments, which the shell expands into the `mysql`/`mysqldump` process argv — arguments, which the shell expands into the `mysql`/`mysqldump` process argv — visible via `ps` and `/proc/<pid>/cmdline`. Clone can run in Staging/Production with `passwordFrom`, so this contradicted the claim in `docs/reference/security.md` that the operator never leaks secret values. The same script also interpolated the target database name into destructive `DROP`/`CREATE DATABASE` SQL unquoted.

This PR fixes both, mirroring the safer patterns already used by the create-database helper, and folds in a few docs and test inconsistencies found along the way.

## Details

**Security fixes (`internal/controller/lifecycle_clone.go`)**
- Pass passwords via the `MYSQL_PWD` env var instead of `-p"$VAR"`, mirroring `lifecycle_create_db.go`. The target password is exported once at the top (inherited by the import side of the pipe and postCloneSQL); the source password is scoped inside the dump subshell so the two never collide. Empty passwords stay unset to support passwordless/trust/IAM auth.
- Backtick-quote and escape the database identifier in `DROP`/`CREATE DATABASE` rather than interpolating the raw name into SQL.
- `internal/controller/clone_test.go`: regression assertions that the generated script contains no `-p"$`, uses `MYSQL_PWD` on both source and target sides, and emits a backtick-quoted/escaped identifier.

**Docs & tooling**
- `docs/reference/downloads.md`: add the ASF source-release section (signed tarball, `.asc`, `.sha512`, `KEYS`, and `gpg`/`shasum` verification) referenced by the announce template, and refresh the stale download banner. Links use `<version>` placeholders to fill in once artifacts are staged.
- `scripts/render-supported-versions.sh` + `docs/getting-started.md`: bring the previously hand-written (and stale) supported-Kubernetes-version line under generation via a new inline sentinel (`SUPPORTED-K8S-INLINE`) driven by the same `.github/supported-k8s.json` source of truth, so `make codegen` / CI drift checks keep it current with no new manual step.
- `README.md` / `docs/index.md`: soften the namespace-scoped RBAC claims to note that CRD installation and (unless disabled) secure metrics auth still require cluster-scoped RBAC, linking to the precise installation constraints.

**Test cleanup**
- `internal/controller/serviceaccount_test.go`: rename the `create=false` without-name case to reflect it is a CEL-rejected, defensive-only path rather than a supported configuration, with a cross-reference to the validation rule.
