### PR TITLE
test: add Go-native fuzzing for pure functions

### DIFF
--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Scheduled deep fuzzing. Fuzz targets (*_fuzz_test.go) also replay their seed
+# corpus during the regular test job on every PR; this workflow runs them for a
+# longer bounded duration to explore new inputs. A crash fails the job and
+# prints the testdata/fuzz reproducer, which we commit as a regression seed.
+name: Fuzz
+
+on:
+  schedule:
+    - cron: "17 6 * * 3" # Wednesday 06:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: Fuzz
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Run fuzz targets
+        run: make fuzz FUZZTIME=5m
+
+      - name: Upload crash reproducers
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: fuzz-crashers
+          path: "**/testdata/fuzz/**"
+          if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ The operator uses a **single public CRD architecture** where the parent `Superse
 - **CRD validation**: All validation uses CEL (`x-kubernetes-validations`) on CRD types — no admission webhooks. Rules cover: environment mode restrictions, secret mutual exclusivity, metastore/valkey validation, networking constraints, monitoring constraints. Defaults (repository, pullPolicy, environment) use kubebuilder default markers.
 - **Metrics**: Operator exposes controller-runtime default metrics (reconcile counts, durations, leader election) on HTTPS :8443 with Kubernetes auth/authz. No custom metrics — controller-runtime defaults are sufficient. Superset instance monitoring via optional `spec.monitoring.serviceMonitor` (creates a Prometheus ServiceMonitor targeting the web-server component using unstructured objects; gracefully skips if CRD is absent).
 - **Config mount path**: `/app/pythonpath` for superset_config.py.
+- **Fuzzing**: Go-native `go test -fuzz` targets in `*_fuzz_test.go` on pure string/codegen/merge functions (`CompareVersions`, `pyQuote`/`RenderConfig`, `MergeMaps`). `make fuzz` runs them bounded; seeds replay under `make test-unit`; scheduled `fuzz.yaml` runs them longer. Robustness, not a security boundary (CR input is trusted). See `docs/contributing/development-guidelines.md`.
 - **All Go files must have the Apache 2.0 copyright header** (see `hack/boilerplate.go.txt`)
 
 ## Naming Conventions

--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,20 @@ test-unit: manifests generate fmt vet ## Run unit tests (no envtest or cluster r
 test-integration: manifests generate fmt vet setup-envtest ## Run integration tests (requires envtest).
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -tags integration -coverprofile cover.out
 
+# Fuzz targets live in *_fuzz_test.go beside the code they exercise. `go test
+# -fuzz` runs a single target per invocation, so we loop over them. FUZZTIME
+# bounds each target (override for longer scheduled runs, e.g. FUZZTIME=5m).
+# Seed corpora and any committed testdata/fuzz crashers also replay during the
+# normal `make test-unit` run.
+.PHONY: fuzz
+fuzz: ## Run all fuzz targets for a bounded duration (FUZZTIME per target, default 30s).
+	@FUZZTIME=$${FUZZTIME:-30s}; \
+	set -e; \
+	go test ./internal/controller/ -run '^$$' -fuzz '^FuzzCompareVersions$$' -fuzztime $$FUZZTIME; \
+	go test ./internal/config/     -run '^$$' -fuzz '^FuzzPyQuote$$'         -fuzztime $$FUZZTIME; \
+	go test ./internal/config/     -run '^$$' -fuzz '^FuzzRenderConfig$$'    -fuzztime $$FUZZTIME; \
+	go test ./internal/resolution/ -run '^$$' -fuzz '^FuzzMergeMaps$$'       -fuzztime $$FUZZTIME
+
 # E2E tests live under test/e2e/ and assume Kind is pre-installed; the manager
 # image is built and side-loaded into the cluster. CertManager is installed by
 # default; skip with CERT_MANAGER_INSTALL_SKIP=true.

--- a/docs/contributing/development-guidelines.md
+++ b/docs/contributing/development-guidelines.md
@@ -209,6 +209,41 @@ func TestMergeEnvVars_ConflictResolution(t *testing.T) {
 }
 ```
 
+### Fuzzing
+
+We fuzz a small set of pure functions with Go's built-in fuzzing
+(`go test -fuzz`).
+
+Fuzz targets live in `*_fuzz_test.go` files beside the code they exercise, in
+the same package and with no build tag (so they compile under the default
+`go test`). Run all of them, bounded, with:
+
+```sh
+make fuzz              # 30s per target
+make fuzz FUZZTIME=2m  # longer local run
+```
+
+Each target seeds a corpus with `f.Add(...)` cases and asserts an invariant
+beyond "does not panic" — e.g. `CompareVersions` is antisymmetric, `RenderConfig`
+is deterministic, `pyQuote` round-trips, `MergeMaps` is a last-writer-wins union.
+The seed corpus (plus any committed `testdata/fuzz/...` reproducers) replays as
+ordinary subtests during `make test-unit`, so regressions are caught on every PR;
+the scheduled `fuzz.yaml` workflow runs the targets for longer to explore new
+inputs.
+
+**When to add a target:** a pure, deterministic function that parses strings,
+generates code/config, or merges collections from CR-author-controlled input.
+Skip trivial scalar or preset math already covered by table tests.
+
+**Scope — robustness, not a security boundary.** As noted under
+[Security and the threat model](#security-and-the-threat-model), `Superset` CR
+input comes from a *trusted* namespace admin. Fuzzing here guards against panics
+and non-determinism on awkward-but-valid input; it is not defending a trust
+boundary. Frame findings accordingly.
+
+**On a finding:** `go test` writes a reproducer to `testdata/fuzz/<target>/<id>`.
+Commit it as a permanent regression seed, then fix the bug.
+
 ---
 
 ## License Headers

--- a/docs/contributing/development-setup.md
+++ b/docs/contributing/development-setup.md
@@ -171,6 +171,7 @@ kind delete cluster --name superset
 | `make test` | Run all tests (unit + integration + e2e). |
 | `make test-unit` | Run unit tests (no envtest or cluster required). |
 | `make test-integration` | Run integration tests (requires envtest). |
+| `make fuzz` | Run all fuzz targets for a bounded duration (FUZZTIME per target, default 30s). |
 | `make setup-test-e2e` | Set up a Kind cluster for e2e tests if it does not exist |
 | `make test-e2e` | Run the e2e tests. Expected an isolated environment using Kind. |
 | `make cleanup-test-e2e` | Tear down the Kind cluster used for e2e tests |

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -106,7 +106,6 @@ and Staging) and Development:
 
 Development mode is intentionally less secure. It exists for local development
 with Kind or Minikube where secret management infrastructure is not available.
-This is not a vulnerability — it is a documented design decision.
 
 ### Secret Handling
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -420,9 +420,8 @@ spec:
 
 The top-level value applies to web server, Celery worker, Celery Beat, Celery
 Flower, MCP server, and lifecycle `migrate`, `rotate`, and `init` task Jobs.
-The websocket server is a Node.js component and does not use this script. Clone
-tasks also do not use it because they run a database-tool image rather than the
-Superset image.
+The websocket server (Node.js) and clone tasks (which run a database-tool image)
+do not use this script.
 
 Components and lifecycle tasks can override the top-level script. Set the
 override to an empty string to disable inheritance:

--- a/internal/config/renderer_fuzz_test.go
+++ b/internal/config/renderer_fuzz_test.go
@@ -1,0 +1,118 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package config
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// FuzzPyQuote checks that pyQuote produces a safe Python double-quoted string
+// body for any input. Config values such as cache key prefixes flow through it
+// into generated superset_config.py, so the escaped result must never break out
+// of its quoting context. See docs/contributing/development-guidelines.md (Fuzzing).
+func FuzzPyQuote(f *testing.F) {
+	for _, s := range []string{
+		"",
+		"simple",
+		`has "double" quotes`,
+		`has \ backslash`,
+		"has\nnewline\ttab",
+		"null\x00byte",
+		"unicode: café 日本語 🚀",
+		"'single'",
+	} {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		got := pyQuote(s)
+
+		// The body must stay on a single line: a raw newline or carriage return
+		// would split the generated assignment and produce invalid Python.
+		if strings.ContainsAny(got, "\n\r") {
+			t.Fatalf("pyQuote(%q) = %q contains a raw newline/CR", s, got)
+		}
+
+		// Wrapping the body back in double quotes must round-trip to the original
+		// string, proving it is a well-formed escaped string body (no unescaped
+		// delimiter, valid escape sequences).
+		unquoted, err := strconv.Unquote(`"` + got + `"`)
+		if err != nil {
+			t.Fatalf("pyQuote(%q) = %q is not a valid quoted body: %v", s, got, err)
+		}
+		if unquoted != s {
+			t.Fatalf("pyQuote round-trip mismatch: got %q, want %q", unquoted, s)
+		}
+	})
+}
+
+// renderConfigComponents are the component types RenderConfig knows how to
+// render config for. WebsocketServer is included to cover its empty-string path.
+var renderConfigComponents = []ComponentType{
+	ComponentWebServer,
+	ComponentCeleryWorker,
+	ComponentCeleryBeat,
+	ComponentCeleryFlower,
+	ComponentWebsocketServer,
+	ComponentMcpServer,
+	ComponentInit,
+}
+
+// FuzzRenderConfig exercises RenderConfig across every component type with
+// arbitrary user-controlled string fields. It asserts that rendering never
+// panics and is deterministic (identical input yields byte-identical output).
+func FuzzRenderConfig(f *testing.F) {
+	f.Add("FEATURE_FLAGS = {}", "WEBSERVER_THREADS = 16", "PostgreSQL", "psycopg2", "ALERT_REPORTS", true, "superset_", uint8(2), true, int32(8088))
+	f.Add("", "", "MySQL", "", "", false, "", uint8(0), false, int32(0))
+	f.Add(`x = "quoted \n value"`, "", "MySQL", "mysqldb", "DASHBOARD_RBAC", false, `pre"fix`, uint8(1), true, int32(-1))
+
+	f.Fuzz(func(t *testing.T,
+		config, componentConfig, dbType, dbDriver, flagKey string,
+		flagVal bool, keyPrefix string, modeSel uint8, withValkey bool, port int32,
+	) {
+		input := &ConfigInput{
+			MetastoreMode:   MetastoreMode(int(modeSel) % 3),
+			DBType:          dbType,
+			DBDriver:        dbDriver,
+			Config:          config,
+			ComponentConfig: componentConfig,
+			WebServerPort:   port,
+		}
+		if flagKey != "" {
+			input.FeatureFlags = map[string]bool{flagKey: flagVal}
+		}
+		if withValkey {
+			input.Valkey = &ValkeyInput{
+				Cache:          ValkeyCacheInput{KeyPrefix: keyPrefix},
+				DataCache:      ValkeyCacheInput{KeyPrefix: keyPrefix},
+				ResultsBackend: ValkeyResultsInput{KeyPrefix: keyPrefix},
+			}
+		}
+
+		for _, ct := range renderConfigComponents {
+			first := RenderConfig(ct, input)
+			if second := RenderConfig(ct, input); first != second {
+				t.Fatalf("RenderConfig(%q) is non-deterministic:\nfirst:\n%s\nsecond:\n%s", ct, first, second)
+			}
+		}
+	})
+}

--- a/internal/controller/version_fuzz_test.go
+++ b/internal/controller/version_fuzz_test.go
@@ -1,0 +1,78 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package controller
+
+import "testing"
+
+// FuzzCompareVersions exercises CompareVersions with arbitrary image tags. The
+// tags come from the (trusted) Superset CR spec, so this is a robustness check:
+// the semver parsing must never panic and the result must obey the ordering
+// contract. See docs/contributing/development-guidelines.md (Fuzzing).
+func FuzzCompareVersions(f *testing.F) {
+	seeds := [][2]string{
+		{"4.0.0", "4.0.1"},
+		{"4.1.0", "4.0.0"},
+		{"4.0.0", "4.0.0"},
+		{"v4.0.0", "4.0.0"},
+		{"4.0.0-rc1", "4.0.0"},
+		{"latest", "4.0.0"},
+		{"sha-abc123", "sha-def456"},
+		{"", "x"},
+		{"", ""},
+	}
+	for _, s := range seeds {
+		f.Add(s[0], s[1])
+	}
+
+	isValid := func(d VersionDirection) bool {
+		switch d {
+		case DirectionUpgrade, DirectionDowngrade, DirectionRebuild, DirectionUnknown:
+			return true
+		default:
+			return false
+		}
+	}
+
+	f.Fuzz(func(t *testing.T, oldTag, newTag string) {
+		got := CompareVersions(oldTag, newTag)
+		if !isValid(got) {
+			t.Fatalf("CompareVersions(%q, %q) = %q, not a defined VersionDirection", oldTag, newTag, got)
+		}
+
+		// Comparing a tag to itself is always a rebuild.
+		if self := CompareVersions(oldTag, oldTag); self != DirectionRebuild {
+			t.Fatalf("CompareVersions(%q, %q) = %q, want Rebuild", oldTag, oldTag, self)
+		}
+
+		// Swapping the arguments must invert the direction: an upgrade one way is
+		// a downgrade the other, while Rebuild and Unknown are symmetric.
+		reverse := CompareVersions(newTag, oldTag)
+		want := map[VersionDirection]VersionDirection{
+			DirectionUpgrade:   DirectionDowngrade,
+			DirectionDowngrade: DirectionUpgrade,
+			DirectionRebuild:   DirectionRebuild,
+			DirectionUnknown:   DirectionUnknown,
+		}[got]
+		if reverse != want {
+			t.Fatalf("CompareVersions(%q, %q) = %q but CompareVersions(%q, %q) = %q, want %q",
+				oldTag, newTag, got, newTag, oldTag, reverse, want)
+		}
+	})
+}

--- a/internal/resolution/merge_fuzz_test.go
+++ b/internal/resolution/merge_fuzz_test.go
@@ -1,0 +1,71 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package resolution
+
+import (
+	"maps"
+	"reflect"
+	"testing"
+)
+
+// FuzzMergeMaps checks that MergeMaps produces the union of its inputs with
+// last-writer-wins precedence for any label/annotation keys and values, and
+// that it is idempotent. See docs/contributing/development-guidelines.md (Fuzzing).
+func FuzzMergeMaps(f *testing.F) {
+	f.Add("a", "1", "b", "2", "c", "3", "9")
+	f.Add("", "", "", "", "", "", "")
+	f.Add("k", "first", "k", "second", "k", "third", "fourth")
+
+	f.Fuzz(func(t *testing.T, k1, v1, k2, v2, k3, v3, v4 string) {
+		// Construct overlapping maps so precedence (later map wins) is exercised.
+		inputs := []map[string]string{
+			{k1: v1},
+			{k2: v2, k3: v3},
+			{k1: v4},
+		}
+
+		// Reference union with last-writer-wins, mirroring MergeMaps' contract.
+		want := map[string]string{}
+		for _, m := range inputs {
+			maps.Copy(want, m)
+		}
+
+		got := MergeMaps(inputs...)
+
+		if len(want) == 0 {
+			if got != nil {
+				t.Fatalf("MergeMaps of empty maps = %v, want nil", got)
+			}
+			return
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("MergeMaps = %v, want %v", got, want)
+		}
+
+		// Idempotent: merging the same inputs again yields an equal map, and
+		// re-merging the result is a no-op copy.
+		if again := MergeMaps(inputs...); !reflect.DeepEqual(again, got) {
+			t.Fatalf("MergeMaps not idempotent: %v vs %v", again, got)
+		}
+		if reMerged := MergeMaps(got); !reflect.DeepEqual(reMerged, got) {
+			t.Fatalf("MergeMaps(MergeMaps(x)) = %v, want %v", reMerged, got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds Go-native fuzzing (`go test -fuzz`) for the operator's pure, input-driven functions. The `Superset` CR is authored by a trusted namespace admin, so this is robustness insurance rather than a security control: it guards the spots that do real string parsing, code generation, and merging against panics and non-determinism on awkward-but-valid input. It is also recognized by the OpenSSF Scorecard fuzzing check. Native Go fuzzing covers these needs without the onboarding cost of a hosted service.

Four targets cover where that risk actually lives:

- `FuzzCompareVersions` — semver parsing of image tags (asserts the ordering contract: reflexive rebuild, antisymmetric direction, always a defined result).
- `FuzzPyQuote` / `FuzzRenderConfig` — Python config generation from arbitrary config strings (asserts safe quoting/round-trip and deterministic rendering across every component type).
- `FuzzMergeMaps` — label/annotation merging (asserts last-writer-wins union and idempotence).

Each target's seed corpus replays as ordinary subtests during `make test-unit`, so regressions are caught on every PR.

## Details

- Fuzz targets live in `*_fuzz_test.go` beside the code they exercise, same package, no build tag.
- `make fuzz` runs all targets bounded by `FUZZTIME` (default 30s; override for longer runs).
- A scheduled `.github/workflows/fuzz.yaml` (weekly + `workflow_dispatch`) runs the targets for longer to explore new inputs and uploads any crash reproducer as an artifact. On a finding, the `testdata/fuzz/<target>/<id>` file is committed as a permanent regression seed.
- Documents how/when to fuzz in `docs/contributing/development-guidelines.md` (new `### Fuzzing` section) with a brief pointer in `AGENTS.md`.
- Drive-by docs cleanup: removed a couple of distracting meta-commentary asides in `security.md` and `configuration.md`.