### PR TITLE
docs: correct sample path, secret-restriction list, and image tag docs

### DIFF
--- a/config/samples/superset_v1alpha1_superset_prod.yaml
+++ b/config/samples/superset_v1alpha1_superset_prod.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Production-mode sample. Secrets are referenced via *From fields.
-# See docs/installation.md for full setup instructions.
+# See docs/user-guide/installation.md for full setup instructions.
 #
 # Prerequisites:
 #   kubectl create secret generic superset-secret \

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -92,14 +92,14 @@ While the project is pre-1.0, all versions use `0.x.y` to signal instability per
 
 The release workflow (`.github/workflows/release.yml`) builds multi-platform
 images and pushes them to GHCR. It runs automatically on pushes to `main`
-(producing `dev` and `sha-<short>` tags) and on version tags (producing semver
+(producing `dev` and `sha-<commit>` tags) and on version tags (producing semver
 tags). It can also be triggered manually via `workflow_dispatch`.
 
 **Image tagging:**
 
 | Trigger | Image tag | Example |
 |---|---|---|
-| Push to `main` | `dev` + `sha-<short-sha>` | `dev`, `sha-abc1234` |
+| Push to `main` | `dev` + `sha-<commit>` | `dev`, `sha-1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b` |
 | RC tag | Semver without `v` prefix | `0.1.0-rc1` |
 | Release tag | Semver without `v` prefix + `latest` | `0.1.0`, `latest` |
 

--- a/docs/reference/downloads.md
+++ b/docs/reference/downloads.md
@@ -20,8 +20,11 @@ under the License.
 # Downloads
 
 !!! note
-    No official release has been cut yet. Development builds (`dev` /
-    `sha-<short>` image tags and the `0.0.0-dev` Helm chart) are available now.
+    No final release has been cut yet. Development builds (`dev` /
+    `sha-<commit>` image tags and the `0.0.0-dev` Helm chart) are always available,
+    and release candidates (`<version>-rc<N>` tags) may be published for testing
+    ahead of a vote. Signed final artifacts are published once a release passes
+    the ASF vote.
 
 ## Source Release
 
@@ -52,7 +55,7 @@ docker pull ghcr.io/apache/superset-kubernetes-operator:dev
 | Tag | Example | Description |
 |-----|---------|-------------|
 | `dev` | `dev` | Floating tag tracking the latest commit on `main`. Rebuilt on every merge. |
-| `sha-<short>` | `sha-abc1234` | Immutable tag for a specific commit. |
+| `sha-<commit>` | `sha-1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b` | Immutable tag for a specific commit (full Git SHA). |
 | `<version>` | `0.1.0` | Semver release. Published when a version tag is pushed. |
 | `<version>-rc<N>` | `0.1.0-rc1` | Release candidate. |
 | `latest` | `latest` | Points to the highest stable (non-prerelease) release. |

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -28,9 +28,9 @@ For lifecycle (migrations, upgrades), see [Lifecycle](lifecycle.md).
 The `environment` field controls validation strictness (enforced by
 [CEL](https://kubernetes.io/docs/reference/using-api/cel/) rules in the CRD schema):
 
-- **`Production`** (default) — inline `secretKey`, `metastore.uri`, `metastore.password`, and `valkey.password` are rejected by CRD validation. Use `secretKeyFrom`, `metastore.uriFrom`, `metastore.passwordFrom`, or `valkey.passwordFrom` to reference Kubernetes Secrets.
-- **`Staging`** — same secret restrictions as Production, but allows `lifecycle.clone` for database cloning from an external source.
-- **`Development`** — allows plain-text `secretKey`, `metastore.uri`, `metastore.password`, and `valkey.password` directly in the CR for quick local development. Also permits `lifecycle.clone`, `lifecycle.init.adminUser`, and `lifecycle.init.loadExamples`.
+- **`Production`** (default) — inline `secretKey`, `previousSecretKey`, `metastore.uri`, `metastore.password`, `valkey.password`, and `websocketServer.config` are rejected by CRD validation. Use the corresponding `*From` fields (`secretKeyFrom`, `previousSecretKeyFrom`, `metastore.uriFrom`, `metastore.passwordFrom`, `valkey.passwordFrom`, `websocketServer.configFrom`) to reference Kubernetes Secrets.
+- **`Staging`** — same secret restrictions as Production, but allows `lifecycle.clone` for database cloning from an external source. `lifecycle.clone.source.password` must still be supplied via `passwordFrom`.
+- **`Development`** — allows plain-text `secretKey`, `previousSecretKey`, `metastore.uri`, `metastore.password`, `valkey.password`, `websocketServer.config`, and `lifecycle.clone.source.password` directly in the CR for quick local development. Also permits `lifecycle.clone`, `lifecycle.init.adminUser`, and `lifecycle.init.loadExamples`.
 
 ### Dev Mode Example
 


### PR DESCRIPTION
## Summary

Documentation and sample fixes:

- `config/samples/superset_v1alpha1_superset_prod.yaml` — update the setup-guide reference from `docs/installation.md` to `docs/user-guide/installation.md`.
- `docs/user-guide/configuration.md` — expand the per-environment inline-secret restriction summary to include `previousSecretKey`, `websocketServer.config`, and `lifecycle.clone.source.password` (with their `*From` alternatives), matching the CEL rules in `api/v1alpha1/superset_types.go`.
- `docs/reference/downloads.md` — reword the pre-release note to distinguish dev builds, release candidates (`<version>-rc<N>`), and voted-on final artifacts.
- `docs/reference/downloads.md`, `docs/contributing/releasing.md` — change the `sha-<short>` image-tag references to the full-SHA form (`sha-<commit>`) to match `release.yml` (`type=sha,format=long`).