### PR TITLE
fix(controller): reduce lifecycle status log noise

### DIFF
--- a/internal/controller/drain.go
+++ b/internal/controller/drain.go
@@ -181,7 +181,7 @@ func (r *SupersetReconciler) drainComponents(ctx context.Context, superset *supe
 				return false, fmt.Errorf("deleting Service for drain %s: %w", desc.componentType, err)
 			}
 		}
-		log.Info("Deleted component resources for drain", "component", desc.componentType)
+		log.V(1).Info("Deleted component resources for drain", "component", desc.componentType)
 	}
 
 	// Verify all component pods are terminated. Pods are the last resource in
@@ -202,11 +202,11 @@ func (r *SupersetReconciler) drainComponents(ctx context.Context, superset *supe
 		}
 	}
 	if componentPods > 0 {
-		log.Info("Waiting for component pods to terminate", "remaining", componentPods)
+		log.V(1).Info("Waiting for component pods to terminate", "remaining", componentPods)
 		return false, nil
 	}
 
-	log.Info("All components drained")
+	log.V(1).Info("All components drained")
 	return true, nil
 }
 

--- a/internal/controller/lifecycle.go
+++ b/internal/controller/lifecycle.go
@@ -555,7 +555,7 @@ func (r *SupersetReconciler) reconcileLifecycleTask(
 
 	if taskRef.State == taskStateComplete && taskRef.CompletedChecksum == taskChecksum {
 		rememberCompletedTaskChecksum(superset, taskType, taskChecksum)
-		log.Info("Task complete (checksum match, skipping)", "task", taskType)
+		log.V(1).Info("Task complete (checksum match, skipping)", "task", taskType)
 		return lifecycleComplete(), nil
 	}
 
@@ -571,7 +571,7 @@ func (r *SupersetReconciler) reconcileLifecycleTask(
 			return lifecycleResult{}, fmt.Errorf("checking pod spec for failed task %s: %w", taskName, err)
 		}
 		if !podSpecChanged {
-			log.Info("Task permanently failed", "task", taskType)
+			log.V(1).Info("Task permanently failed", "task", taskType)
 			setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeLifecycleComplete,
 				metav1.ConditionFalse, "TaskFailed", fmt.Sprintf("%s: %s", taskType, taskRef.Message), superset.Generation)
 			return lifecycleTerminal(), nil

--- a/internal/controller/maintenance.go
+++ b/internal/controller/maintenance.go
@@ -157,7 +157,7 @@ func (r *SupersetReconciler) reconcileMaintenancePageUp(
 		return false, fmt.Errorf("getting maintenance Deployment: %w", err)
 	}
 	if deploy.Status.ReadyReplicas < 1 {
-		log.Info("Waiting for maintenance page pod to become ready")
+		log.V(1).Info("Waiting for maintenance page pod to become ready")
 		return false, nil
 	}
 
@@ -193,14 +193,14 @@ func (r *SupersetReconciler) reconcileMaintenanceReturn(
 		r.Recorder.Eventf(superset, nil, corev1.EventTypeNormal, "MaintenanceEnded", "Lifecycle",
 			"Maintenance page disabled because webServer was removed")
 		superset.Status.Lifecycle.MaintenanceActive = false
-		log.Info("WebServer removed while maintenance active, clearing maintenance")
+		log.V(1).Info("WebServer removed while maintenance active, clearing maintenance")
 		return true, nil
 	}
 	if webServerDesiredReplicas(superset) == 0 {
 		r.Recorder.Eventf(superset, nil, corev1.EventTypeNormal, "MaintenanceEnded", "Lifecycle",
 			"Maintenance page disabled because webServer has zero desired replicas")
 		superset.Status.Lifecycle.MaintenanceActive = false
-		log.Info("WebServer scaled to zero while maintenance active, clearing maintenance")
+		log.V(1).Info("WebServer scaled to zero while maintenance active, clearing maintenance")
 		return true, nil
 	}
 
@@ -209,13 +209,13 @@ func (r *SupersetReconciler) reconcileMaintenanceReturn(
 	deploy := &appsv1.Deployment{}
 	if err := r.Get(ctx, client.ObjectKey{Namespace: superset.Namespace, Name: webDeployName}, deploy); err != nil {
 		if errors.IsNotFound(err) {
-			log.Info("Waiting for web-server Deployment to be created before clearing maintenance")
+			log.V(1).Info("Waiting for web-server Deployment to be created before clearing maintenance")
 			return false, nil
 		}
 		return false, fmt.Errorf("getting web-server Deployment: %w", err)
 	}
 	if deploy.Status.ReadyReplicas < 1 {
-		log.Info("Waiting for web-server pods to become ready before clearing maintenance")
+		log.V(1).Info("Waiting for web-server pods to become ready before clearing maintenance")
 		return false, nil
 	}
 
@@ -224,7 +224,7 @@ func (r *SupersetReconciler) reconcileMaintenanceReturn(
 	superset.Status.Lifecycle.MaintenanceActive = false
 	r.Recorder.Eventf(superset, nil, corev1.EventTypeNormal, "MaintenanceEnded", "Lifecycle",
 		"Web-server is ready; routing web-server Service back to Superset")
-	log.Info("Web-server ready, clearing maintenance page")
+	log.V(1).Info("Web-server ready, clearing maintenance page")
 	return true, nil
 }
 

--- a/internal/controller/monitoring.go
+++ b/internal/controller/monitoring.go
@@ -100,8 +100,8 @@ func (r *SupersetReconciler) reconcileServiceMonitor(ctx context.Context, supers
 	})
 
 	if meta.IsNoMatchError(err) {
-		// ServiceMonitor CRD not installed -- log and skip.
-		logf.FromContext(ctx).Info("ServiceMonitor CRD not installed, skipping monitoring setup")
+		// ServiceMonitor CRD not installed -- skip optional monitoring setup.
+		logf.FromContext(ctx).V(1).Info("ServiceMonitor CRD not installed, skipping monitoring setup")
 		return nil
 	}
 

--- a/internal/controller/networking.go
+++ b/internal/controller/networking.go
@@ -200,7 +200,7 @@ func (r *SupersetReconciler) reconcileHTTPRoute(ctx context.Context, superset *s
 		return nil
 	})
 	if meta.IsNoMatchError(err) {
-		logf.FromContext(ctx).Info("Gateway API CRDs not installed, skipping HTTPRoute reconciliation")
+		logf.FromContext(ctx).V(1).Info("Gateway API CRDs not installed, skipping HTTPRoute reconciliation")
 		return nil
 	}
 	return err

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -279,8 +280,10 @@ func (r *SupersetReconciler) getComponentStatus(ctx context.Context, superset *s
 
 	deploy := &appsv1.Deployment{}
 	if err := r.Get(ctx, client.ObjectKey{Namespace: superset.Namespace, Name: resourceBaseName}, deploy); err != nil {
-		log := logf.FromContext(ctx)
-		log.Info("component Deployment not found for status", "component", desc.componentType, "name", resourceBaseName, "error", err)
+		if !apierrors.IsNotFound(err) {
+			log := logf.FromContext(ctx)
+			log.Info("failed to read component Deployment for status", "component", desc.componentType, "name", resourceBaseName, "error", err)
+		}
 		resources = append(resources, componentResourceStatus("Deployment", resourceBaseName, false))
 		resources = append(resources, r.expectedComponentResources(ctx, superset, desc, accessor, cfg, resourceBaseName)...)
 		return &supersetv1alpha1.ComponentRefStatus{

--- a/internal/controller/superset_controller.go
+++ b/internal/controller/superset_controller.go
@@ -85,7 +85,7 @@ func (r *SupersetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	// Handle suspend.
 	if superset.Spec.Suspend != nil && *superset.Spec.Suspend {
-		log.Info("Reconciliation suspended", "name", superset.Name)
+		log.V(1).Info("Reconciliation suspended", "name", superset.Name)
 		setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeSuspended,
 			metav1.ConditionTrue, "Suspended", "Reconciliation is suspended", superset.Generation)
 		superset.Status.Phase = phaseSuspended
@@ -97,7 +97,7 @@ func (r *SupersetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	setCondition(&superset.Status.Conditions, supersetv1alpha1.ConditionTypeSuspended,
 		metav1.ConditionFalse, "NotSuspended", "Reconciliation is not suspended", superset.Generation)
 
-	log.Info("Reconciling Superset", "name", superset.Name)
+	log.V(1).Info("Reconciling Superset", "name", superset.Name)
 
 	// Phase 1: Compute shared config checksum (per-component checksums are
 	// derived from this combined with each component's rendered config).


### PR DESCRIPTION
## Summary

Reduce repetitive controller logs emitted during expected lifecycle and status polling states.

When lifecycle tasks gate component reconciliation, component Deployments may legitimately be absent. The controller already reports that through Superset status, so logging every expected `NotFound` at info level adds noise without improving diagnosability.

## Details

- Suppress expected component Deployment `NotFound` logs during status refresh.
- Move routine reconcile, optional CRD skip, drain wait, maintenance wait, and repeated lifecycle terminal/skip messages to verbose logging.
- Keep lifecycle transition and recovery logs visible at info level.