### PR TITLE
fix(controller): restore key reconcile logs, retry write conflicts

### DIFF
--- a/internal/controller/component_reconciler.go
+++ b/internal/controller/component_reconciler.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	supersetv1alpha1 "github.com/apache/superset-kubernetes-operator/api/v1alpha1"
 	"github.com/apache/superset-kubernetes-operator/internal/common"
@@ -112,7 +113,7 @@ func reconcileComponentDeployment(
 
 	labels := componentLabels(componentName, owner.GetName())
 
-	_, err := controllerutil.CreateOrUpdate(ctx, c, deploy, func() error {
+	op, err := createOrUpdateWithRetry(ctx, c, deploy, func() error {
 		if err := controllerutil.SetControllerReference(owner, deploy, scheme); err != nil {
 			return err
 		}
@@ -124,7 +125,14 @@ func reconcileComponentDeployment(
 		deploy.Spec = buildDeploymentSpec(spec, cfg, checksumAnnotations, labels)
 		return nil
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	if op != controllerutil.OperationResultNone {
+		logf.FromContext(ctx).Info("Reconciled component",
+			"component", componentName, "name", resourceBaseName, "operation", op)
+	}
+	return nil
 }
 
 // reconcileComponentService creates or updates a Service for the component.
@@ -148,7 +156,7 @@ func reconcileComponentService(
 
 	labels := componentLabels(componentName, owner.GetName())
 
-	_, err := controllerutil.CreateOrUpdate(ctx, c, svc, func() error {
+	_, err := createOrUpdateWithRetry(ctx, c, svc, func() error {
 		if err := controllerutil.SetControllerReference(owner, svc, scheme); err != nil {
 			return err
 		}

--- a/internal/controller/drain.go
+++ b/internal/controller/drain.go
@@ -181,7 +181,7 @@ func (r *SupersetReconciler) drainComponents(ctx context.Context, superset *supe
 				return false, fmt.Errorf("deleting Service for drain %s: %w", desc.componentType, err)
 			}
 		}
-		log.V(1).Info("Deleted component resources for drain", "component", desc.componentType)
+		log.Info("Deleted component resources for drain", "component", desc.componentType)
 	}
 
 	// Verify all component pods are terminated. Pods are the last resource in
@@ -206,7 +206,7 @@ func (r *SupersetReconciler) drainComponents(ctx context.Context, superset *supe
 		return false, nil
 	}
 
-	log.V(1).Info("All components drained")
+	log.Info("All components drained")
 	return true, nil
 }
 

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -19,9 +19,41 @@ limitations under the License.
 package controller
 
 import (
+	"context"
+
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
 	"github.com/apache/superset-kubernetes-operator/internal/common"
 	"github.com/apache/superset-kubernetes-operator/internal/resolution"
 )
+
+// createOrUpdateWithRetry wraps controllerutil.CreateOrUpdate with automatic
+// retry on optimistic-lock conflicts. Such conflicts are routine rather than
+// exceptional: another actor (e.g. the built-in Deployment controller writing
+// rollout status) can bump an object's resourceVersion between our Get and
+// Update, which the API server then rejects with a Conflict. Without a retry
+// this surfaces as a noisy error-level "the object has been modified" reconcile
+// failure that self-heals on the next requeue. Retrying re-Gets the latest
+// version and re-applies the mutation inline, so the conflict stays invisible.
+//
+// Use this in place of controllerutil.CreateOrUpdate for every parent-owned
+// resource so the benefit applies uniformly.
+func createOrUpdateWithRetry(
+	ctx context.Context,
+	c client.Client,
+	obj client.Object,
+	mutate controllerutil.MutateFn,
+) (controllerutil.OperationResult, error) {
+	var op controllerutil.OperationResult
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var innerErr error
+		op, innerErr = controllerutil.CreateOrUpdate(ctx, c, obj, mutate)
+		return innerErr
+	})
+	return op, err
+}
 
 // parentLabels returns the operator-managed labels for parent-owned resources
 // (ServiceAccount, Ingress, HTTPRoute, ServiceMonitor). These labels enable

--- a/internal/controller/helpers_retry_test.go
+++ b/internal/controller/helpers_retry_test.go
@@ -1,0 +1,170 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// configMapsGR is the GroupResource used to construct realistic Conflict errors
+// in these tests (ConfigMaps live in the core/"" group).
+var configMapsGR = schema.GroupResource{Group: "", Resource: "configmaps"}
+
+func newTestConfigMap(data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "cm", Namespace: "default"},
+		Data:       data,
+	}
+}
+
+// setData is a MutateFn that overwrites the ConfigMap's Data with the given map.
+func setData(cm *corev1.ConfigMap, data map[string]string) controllerutil.MutateFn {
+	return func() error {
+		cm.Data = data
+		return nil
+	}
+}
+
+func TestCreateOrUpdateWithRetry_Create(t *testing.T) {
+	ctx := context.Background()
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+
+	cm := newTestConfigMap(nil)
+	op, err := createOrUpdateWithRetry(ctx, c, cm, setData(cm, map[string]string{"k": "v"}))
+
+	require.NoError(t, err)
+	assert.Equal(t, controllerutil.OperationResultCreated, op)
+
+	got := &corev1.ConfigMap{}
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(cm), got))
+	assert.Equal(t, "v", got.Data["k"])
+}
+
+func TestCreateOrUpdateWithRetry_Update(t *testing.T) {
+	ctx := context.Background()
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).
+		WithObjects(newTestConfigMap(map[string]string{"k": "old"})).Build()
+
+	cm := newTestConfigMap(nil)
+	op, err := createOrUpdateWithRetry(ctx, c, cm, setData(cm, map[string]string{"k": "new"}))
+
+	require.NoError(t, err)
+	assert.Equal(t, controllerutil.OperationResultUpdated, op)
+
+	got := &corev1.ConfigMap{}
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(cm), got))
+	assert.Equal(t, "new", got.Data["k"])
+}
+
+func TestCreateOrUpdateWithRetry_NoOp(t *testing.T) {
+	ctx := context.Background()
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).
+		WithObjects(newTestConfigMap(map[string]string{"k": "v"})).Build()
+
+	cm := newTestConfigMap(nil)
+	op, err := createOrUpdateWithRetry(ctx, c, cm, setData(cm, map[string]string{"k": "v"}))
+
+	require.NoError(t, err)
+	assert.Equal(t, controllerutil.OperationResultNone, op)
+}
+
+func TestCreateOrUpdateWithRetry_RetriesConflictThenSucceeds(t *testing.T) {
+	ctx := context.Background()
+	updateCalls := 0
+	base := fake.NewClientBuilder().WithScheme(testScheme(t)).
+		WithObjects(newTestConfigMap(map[string]string{"k": "old"})).Build()
+	c := interceptor.NewClient(base, interceptor.Funcs{
+		Update: func(ctx context.Context, w client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			updateCalls++
+			if updateCalls == 1 {
+				// First write loses the optimistic-lock race.
+				return apierrors.NewConflict(configMapsGR, obj.GetName(), errors.New("resourceVersion changed"))
+			}
+			return w.Update(ctx, obj, opts...)
+		},
+	})
+
+	cm := newTestConfigMap(nil)
+	op, err := createOrUpdateWithRetry(ctx, c, cm, setData(cm, map[string]string{"k": "new"}))
+
+	require.NoError(t, err)
+	assert.Equal(t, controllerutil.OperationResultUpdated, op)
+	assert.Equal(t, 2, updateCalls, "should retry exactly once after the conflict")
+
+	got := &corev1.ConfigMap{}
+	require.NoError(t, base.Get(ctx, client.ObjectKeyFromObject(cm), got))
+	assert.Equal(t, "new", got.Data["k"], "the mutation must be reapplied on the successful retry")
+}
+
+func TestCreateOrUpdateWithRetry_DoesNotRetryNonConflictError(t *testing.T) {
+	ctx := context.Background()
+	updateCalls := 0
+	sentinel := apierrors.NewInternalError(errors.New("boom"))
+	base := fake.NewClientBuilder().WithScheme(testScheme(t)).
+		WithObjects(newTestConfigMap(map[string]string{"k": "old"})).Build()
+	c := interceptor.NewClient(base, interceptor.Funcs{
+		Update: func(ctx context.Context, w client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			updateCalls++
+			return sentinel
+		},
+	})
+
+	cm := newTestConfigMap(nil)
+	op, err := createOrUpdateWithRetry(ctx, c, cm, setData(cm, map[string]string{"k": "new"}))
+
+	require.Error(t, err)
+	assert.False(t, apierrors.IsConflict(err), "non-conflict error should be returned as-is")
+	assert.Equal(t, controllerutil.OperationResultNone, op)
+	assert.Equal(t, 1, updateCalls, "non-conflict errors must not be retried")
+}
+
+func TestCreateOrUpdateWithRetry_ReturnsConflictAfterExhaustingRetries(t *testing.T) {
+	ctx := context.Background()
+	updateCalls := 0
+	base := fake.NewClientBuilder().WithScheme(testScheme(t)).
+		WithObjects(newTestConfigMap(map[string]string{"k": "old"})).Build()
+	c := interceptor.NewClient(base, interceptor.Funcs{
+		Update: func(ctx context.Context, w client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			updateCalls++
+			return apierrors.NewConflict(configMapsGR, obj.GetName(), errors.New("persistent conflict"))
+		},
+	})
+
+	cm := newTestConfigMap(nil)
+	op, err := createOrUpdateWithRetry(ctx, c, cm, setData(cm, map[string]string{"k": "new"}))
+
+	require.Error(t, err)
+	assert.True(t, apierrors.IsConflict(err), "a persistent conflict must surface as a conflict error")
+	assert.Equal(t, controllerutil.OperationResultNone, op)
+	assert.Equal(t, retry.DefaultRetry.Steps, updateCalls, "should attempt exactly the configured number of retry steps")
+}

--- a/internal/controller/lifecycle.go
+++ b/internal/controller/lifecycle.go
@@ -242,6 +242,7 @@ func (r *SupersetReconciler) reconcileLifecycle(
 	}
 
 	// All tasks complete.
+	logf.FromContext(ctx).Info("Lifecycle tasks complete, reconciling components", "image", currentImage)
 	r.finalizeLifecycle(superset, currentImage)
 	return lifecycleComplete(), nil
 }

--- a/internal/controller/lifecycle_job.go
+++ b/internal/controller/lifecycle_job.go
@@ -142,6 +142,7 @@ func (r *SupersetReconciler) reconcileLifecycleTaskJob(
 			taskRef.CompletedChecksum = taskChecksum
 			setCondition(&taskRef.Conditions, supersetv1alpha1.ConditionTypeTaskComplete,
 				metav1.ConditionTrue, "TaskComplete", "Task completed successfully", superset.Generation)
+			log.Info("Lifecycle task completed", "task", taskType)
 			return lifecycleCheckpoint(), nil
 		}
 
@@ -165,6 +166,8 @@ func (r *SupersetReconciler) reconcileLifecycleTaskJob(
 					"%s task failed after %d attempts: %s", taskType, taskRef.Attempts, taskRef.Message)
 				setCondition(&taskRef.Conditions, supersetv1alpha1.ConditionTypeTaskComplete,
 					metav1.ConditionFalse, "TaskFailed", taskRef.Message, superset.Generation)
+				log.Info("Lifecycle task permanently failed", "task", taskType,
+					"attempts", taskRef.Attempts, "message", taskRef.Message)
 				return lifecycleTerminal(), nil
 			}
 

--- a/internal/controller/maintenance.go
+++ b/internal/controller/maintenance.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -224,7 +223,7 @@ func (r *SupersetReconciler) reconcileMaintenanceReturn(
 	superset.Status.Lifecycle.MaintenanceActive = false
 	r.Recorder.Eventf(superset, nil, corev1.EventTypeNormal, "MaintenanceEnded", "Lifecycle",
 		"Web-server is ready; routing web-server Service back to Superset")
-	log.V(1).Info("Web-server ready, clearing maintenance page")
+	log.Info("Web-server ready, clearing maintenance page")
 	return true, nil
 }
 
@@ -282,23 +281,21 @@ func (r *SupersetReconciler) reconcileMaintenanceDeployment(
 		{Name: naming.PortNameHTTP, ContainerPort: port, Protocol: corev1.ProtocolTCP},
 	}
 
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		deploy := &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      deployName,
-				Namespace: superset.Namespace,
-			},
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deployName,
+			Namespace: superset.Namespace,
+		},
+	}
+	_, err := createOrUpdateWithRetry(ctx, r.Client, deploy, func() error {
+		if err := controllerutil.SetControllerReference(superset, deploy, r.Scheme); err != nil {
+			return err
 		}
-		_, err := controllerutil.CreateOrUpdate(ctx, r.Client, deploy, func() error {
-			if err := controllerutil.SetControllerReference(superset, deploy, r.Scheme); err != nil {
-				return err
-			}
-			deploy.Spec = buildDeploymentSpec(&flat, cfg, podAnnotations, selectorLabels)
-			deploy.Labels = mergeLabels(nil, componentLabels(string(naming.ComponentMaintenancePage), superset.Name))
-			return nil
-		})
-		return err
+		deploy.Spec = buildDeploymentSpec(&flat, cfg, podAnnotations, selectorLabels)
+		deploy.Labels = mergeLabels(nil, componentLabels(string(naming.ComponentMaintenancePage), superset.Name))
+		return nil
 	})
+	return err
 }
 
 // reconcileMaintenanceConfigMap creates or updates the ConfigMap containing
@@ -311,26 +308,24 @@ func (r *SupersetReconciler) reconcileMaintenanceConfigMap(
 ) error {
 	cmName := maintenanceConfigMapName(superset.Name)
 
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		cm := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      cmName,
-				Namespace: superset.Namespace,
-			},
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmName,
+			Namespace: superset.Namespace,
+		},
+	}
+	_, err := createOrUpdateWithRetry(ctx, r.Client, cm, func() error {
+		if err := controllerutil.SetControllerReference(superset, cm, r.Scheme); err != nil {
+			return err
 		}
-		_, err := controllerutil.CreateOrUpdate(ctx, r.Client, cm, func() error {
-			if err := controllerutil.SetControllerReference(superset, cm, r.Scheme); err != nil {
-				return err
-			}
-			cm.Data = map[string]string{
-				"nginx.conf":   renderMaintenanceNginxMainConf(),
-				"default.conf": renderNginxConf(port),
-				"index.html":   renderMaintenanceHTML(spec),
-			}
-			return nil
-		})
-		return err
+		cm.Data = map[string]string{
+			"nginx.conf":   renderMaintenanceNginxMainConf(),
+			"default.conf": renderNginxConf(port),
+			"index.html":   renderMaintenanceHTML(spec),
+		}
+		return nil
 	})
+	return err
 }
 
 // buildMaintenanceFlatSpec constructs the FlatComponentSpec for the maintenance page.

--- a/internal/controller/monitoring.go
+++ b/internal/controller/monitoring.go
@@ -64,7 +64,7 @@ func (r *SupersetReconciler) reconcileServiceMonitor(ctx context.Context, supers
 	obj.SetName(superset.Name)
 	obj.SetNamespace(superset.Namespace)
 
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, obj, func() error {
+	_, err := createOrUpdateWithRetry(ctx, r.Client, obj, func() error {
 		if err := controllerutil.SetControllerReference(superset, obj, r.Scheme); err != nil {
 			return err
 		}

--- a/internal/controller/networking.go
+++ b/internal/controller/networking.go
@@ -121,7 +121,7 @@ func (r *SupersetReconciler) reconcileWebServerService(ctx context.Context, supe
 	containerPort := resolveWebServerPort(superset)
 	webServerLabels := componentLabels(string(common.ComponentWebServer), superset.Name)
 
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, svc, func() error {
+	_, err := createOrUpdateWithRetry(ctx, r.Client, svc, func() error {
 		// Clear existing owner references to handle upgrades from earlier
 		// versions where the Service may have been owned by another controller.
 		svc.OwnerReferences = nil
@@ -175,7 +175,7 @@ func (r *SupersetReconciler) reconcileHTTPRoute(ctx context.Context, superset *s
 		},
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, route, func() error {
+	_, err := createOrUpdateWithRetry(ctx, r.Client, route, func() error {
 		if err := controllerutil.SetControllerReference(superset, route, r.Scheme); err != nil {
 			return err
 		}
@@ -331,7 +331,7 @@ func (r *SupersetReconciler) reconcileIngress(ctx context.Context, superset *sup
 
 	webServerSvcName, webServerPort := webServerServiceRef(superset)
 
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, ingress, func() error {
+	_, err := createOrUpdateWithRetry(ctx, r.Client, ingress, func() error {
 		if err := controllerutil.SetControllerReference(superset, ingress, r.Scheme); err != nil {
 			return err
 		}

--- a/internal/controller/networkpolicy.go
+++ b/internal/controller/networkpolicy.go
@@ -114,7 +114,7 @@ func (r *SupersetReconciler) reconcileComponentNetworkPolicy(
 	labels := componentLabels(component, instanceName)
 	npSpec := superset.Spec.NetworkPolicy
 
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, np, func() error {
+	_, err := createOrUpdateWithRetry(ctx, r.Client, np, func() error {
 		if err := controllerutil.SetControllerReference(superset, np, r.Scheme); err != nil {
 			return err
 		}

--- a/internal/controller/scaling.go
+++ b/internal/controller/scaling.go
@@ -54,7 +54,7 @@ func reconcileHPA(
 		},
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, c, hpa, func() error {
+	_, err := createOrUpdateWithRetry(ctx, c, hpa, func() error {
 		if err := controllerutil.SetControllerReference(owner, hpa, scheme); err != nil {
 			return err
 		}
@@ -100,7 +100,7 @@ func reconcilePDB(
 		},
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, c, pdb, func() error {
+	_, err := createOrUpdateWithRetry(ctx, c, pdb, func() error {
 		if err := controllerutil.SetControllerReference(owner, pdb, scheme); err != nil {
 			return err
 		}

--- a/internal/controller/superset_controller.go
+++ b/internal/controller/superset_controller.go
@@ -271,7 +271,7 @@ func (r *SupersetReconciler) reconcileServiceAccount(ctx context.Context, supers
 		}
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, sa, func() error {
+	_, err := createOrUpdateWithRetry(ctx, r.Client, sa, func() error {
 		if err := controllerutil.SetControllerReference(superset, sa, r.Scheme); err != nil {
 			return err
 		}
@@ -454,7 +454,7 @@ func reconcileParentOwnedConfigMap(
 		},
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, c, cm, func() error {
+	_, err := createOrUpdateWithRetry(ctx, c, cm, func() error {
 		if err := controllerutil.SetControllerReference(parent, cm, scheme); err != nil {
 			return err
 		}

--- a/internal/controller/websocket_config.go
+++ b/internal/controller/websocket_config.go
@@ -82,7 +82,7 @@ func reconcileParentOwnedWebsocketConfigMap(
 		},
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, c, cm, func() error {
+	_, err := createOrUpdateWithRetry(ctx, c, cm, func() error {
 		if err := controllerutil.SetControllerReference(parent, cm, scheme); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

Adds edge-triggered INFO logging for component and lifecycle state transitions, and routes all parent-owned writes through a shared conflict-retry helper.

## Details

### Logging
- `reconcileComponentDeployment` logs "Reconciled component" from the `CreateOrUpdate` `OperationResult` (fires only on Created/Updated, silent on no-op).
- Added "Lifecycle task completed", "Lifecycle task permanently failed", and "Lifecycle tasks complete, reconciling components".
- Promoted to INFO: "Deleted component resources for drain", "All components drained", "Web-server ready, clearing maintenance page".
- Per-reconcile lines ("Reconciling Superset", "CRD not installed" skips, steady-state task re-logs) remain at `V(1)`.

### Conflict retry
- New `createOrUpdateWithRetry` helper wraps `controllerutil.CreateOrUpdate` in `retry.RetryOnConflict`.
- All 14 parent-owned write sites route through it (components, HPA/PDB, Service/Ingress/HTTPRoute, NetworkPolicy, ServiceMonitor, ServiceAccount, ConfigMaps, websocket config, maintenance Deployment/ConfigMap). The two maintenance writers' hand-rolled `RetryOnConflict` blocks are consolidated into the helper.
- Helper has full unit coverage: create, update, no-op, retry-on-conflict, non-conflict error (no retry), and conflict exhausting the retry budget.