### PR TITLE
feat(controller): add tiered debug logging and policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,8 +279,8 @@ build: manifests generate fmt vet ## Build manager binary.
 	go build -o bin/manager cmd/main.go
 
 .PHONY: run
-run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./cmd/main.go
+run: manifests generate fmt vet ## Run a controller from your host. Pass flags via ARGS, e.g. make run ARGS="--zap-log-level=2".
+	go run ./cmd/main.go $(ARGS)
 
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.

--- a/charts/superset-operator/templates/deployment.yaml
+++ b/charts/superset-operator/templates/deployment.yaml
@@ -53,6 +53,9 @@ spec:
           args:
             - --leader-elect={{ .Values.leaderElection.enabled }}
             - --health-probe-bind-address=:8081
+            {{- with .Values.logLevel }}
+            - --zap-log-level={{ . }}
+            {{- end }}
             {{- if .Values.metrics.enabled }}
             - --metrics-bind-address=:{{ .Values.metrics.service.port }}
             {{- if .Values.metrics.certSecretName }}

--- a/charts/superset-operator/values.schema.json
+++ b/charts/superset-operator/values.schema.json
@@ -40,6 +40,13 @@
         "enabled": { "type": "boolean" }
       }
     },
+    "logLevel": {
+      "description": "Operator log verbosity (--zap-log-level): empty = default (info). One of \"info\", \"debug\", \"error\", \"panic\", or an integer level (1 = debug/V1, 2 = V2 trace).",
+      "oneOf": [
+        { "type": "string", "enum": ["", "info", "debug", "error", "panic", "1", "2"] },
+        { "type": "integer", "enum": [1, 2] }
+      ]
+    },
     "metrics": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/superset-operator/values.yaml
+++ b/charts/superset-operator/values.yaml
@@ -21,6 +21,13 @@ serviceAccount:
 leaderElection:
   enabled: true
 
+# logLevel controls the operator's log verbosity (the manager's --zap-log-level
+# flag). Leave empty for the default ("info"). Set to "debug" (alias "1") to
+# include V(1) per-reconcile progress logs, or "2" for V(2) trace-level
+# internals. See the logging policy in the developer guidelines for what each
+# level emits.
+logLevel: ""
+
 metrics:
   enabled: true
   service:

--- a/docs/contributing/development-guidelines.md
+++ b/docs/contributing/development-guidelines.md
@@ -485,9 +485,9 @@ V(0).
 ### Enabling verbose logs when debugging
 
 ```sh
-go run ./cmd/main.go --zap-log-level=debug   # V(1)
-go run ./cmd/main.go --zap-log-level=2       # V(1)+V(2)
-# in-cluster: append --zap-log-level=debug to the manager container args
+make run ARGS="--zap-log-level=debug"   # V(1)
+make run ARGS="--zap-log-level=2"        # V(1)+V(2)
+# in-cluster (Helm): --set logLevel=debug (or 2) — see Installation › Debugging the operator
 ```
 
 ---

--- a/docs/contributing/development-guidelines.md
+++ b/docs/contributing/development-guidelines.md
@@ -429,6 +429,69 @@ See `internal/controller/monitoring.go` for the implementation.
 
 ---
 
+## Logging
+
+The operator logs through `logf.FromContext(ctx)` (controller-runtime's
+logr/zap). Verbosity is a single knob, `--zap-log-level`, configured in
+`cmd/main.go`:
+
+| Flag | Levels emitted | Audience |
+|------|----------------|----------|
+| `--zap-log-level=info` (default) | V(0) | Operators in production |
+| `--zap-log-level=debug` (alias `=1`) | V(0)+V(1) | Debugging a reconcile |
+| `--zap-log-level=2` | V(0)+V(1)+V(2) | Deep tracing internals |
+
+### Three tiers
+
+- **Info / V(0)** — `log.Info(msg, kv...)`. Low-frequency, meaningful state
+  *transitions* an operator wants at default verbosity (lifecycle task
+  created/completed/failed, downgrade blocked, awaiting approval, maintenance
+  cleared, a component actually changed). **Must not fire on every reconcile.**
+- **V(1) / debug** — `log.V(1).Info(msg, kv...)`. Per-reconcile progress and
+  decisions: reconcile entry, phase markers, checksum-skip decisions,
+  "waiting for X" requeues, schedule next-requeue time, CRD-absent skips, no-op
+  results.
+- **V(2) / trace** — `log.V(2).Info(msg, kv...)`. Fine-grained internals:
+  rendered config size/checksum, version-comparison result, per-resource
+  CreateOrUpdate op even when unchanged.
+
+### Error logging
+
+`log.Error(err, msg, kv...)` is reserved for **non-fatal errors that are
+swallowed** — not returned up the stack and not surfaced as a Kubernetes Event —
+so they are not silently lost. Do **not** `log.Error` an error you also return:
+controller-runtime already logs returned reconcile errors at the top of the
+loop, and the code records a Warning Event via `r.Recorder.Eventf`. Double
+logging just creates noise.
+
+### Cross-cutting rule
+
+Anything that fires on **every** reconcile regardless of state change is V(1) or
+deeper. V(0) is for genuine transitions only. When in doubt, ask "would this line
+appear in a steady-state cluster where nothing is changing?" — if yes, it is not
+V(0).
+
+### Conventions
+
+- Structured keys are **camelCase**: `name`, `namespace`, `component`, `task`,
+  `image`, `from`, `to`, `operation`, `reason`, `phase`. Reuse these; don't
+  invent synonyms.
+- Never log secret values or rendered config bodies. Log sizes, counts, or
+  checksums instead (e.g. `configBytes`, `envVars`, `checksum`).
+- Pure packages (`internal/resolution/`, `internal/config/`, `internal/common/`,
+  `internal/schedule/`) do **zero** logging by design — they have no
+  controller-runtime dependency and return errors only. Keep it that way.
+
+### Enabling verbose logs when debugging
+
+```sh
+go run ./cmd/main.go --zap-log-level=debug   # V(1)
+go run ./cmd/main.go --zap-log-level=2       # V(1)+V(2)
+# in-cluster: append --zap-log-level=debug to the manager container args
+```
+
+---
+
 ## Pull Requests
 
 ### Title format

--- a/docs/contributing/development-setup.md
+++ b/docs/contributing/development-setup.md
@@ -185,7 +185,7 @@ kind delete cluster --name superset
 | Command | Description |
 |---|---|
 | `make build` | Build manager binary. |
-| `make run` | Run a controller from your host. |
+| `make run` | Run a controller from your host. Pass flags via ARGS, e.g. make run ARGS="--zap-log-level=2". |
 | `make docker-build` | Build docker image with the manager. |
 | `make docker-push` | Push docker image with the manager. |
 | `make build-installer` | Generate a consolidated YAML with CRDs and deployment. |

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -262,6 +262,14 @@ EOF
 The operator will create the CeleryWorker and CeleryBeat Deployments and their
 ConfigMaps automatically.
 
+## Debugging the operator
+
+If a Superset isn't reconciling as expected, raise the operator's log verbosity
+by adding `--zap-log-level=debug` (or `=2` for trace-level internals) to the
+manager container args. See the
+[logging policy](../contributing/development-guidelines.md#logging) for what each
+level emits.
+
 ## Next steps
 
 - [Configuration](configuration.md) — full configuration reference

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -264,11 +264,28 @@ ConfigMaps automatically.
 
 ## Debugging the operator
 
-If a Superset isn't reconciling as expected, raise the operator's log verbosity
-by adding `--zap-log-level=debug` (or `=2` for trace-level internals) to the
-manager container args. See the
+If a Superset isn't reconciling as expected, raise the operator's log verbosity.
+The chart exposes a `logLevel` value mapped to the manager's `--zap-log-level`
+flag: `debug` (or `1`) adds V(1) per-reconcile progress logs, and `2` adds V(2)
+trace-level internals. See the
 [logging policy](../contributing/development-guidelines.md#logging) for what each
 level emits.
+
+Set it at install/upgrade time:
+
+```bash
+helm upgrade --install superset-operator <chart> \
+  --namespace superset-operator-system \
+  --set logLevel=debug
+```
+
+or in a values file:
+
+```yaml
+logLevel: debug   # "1" for V(1), "2" for V(2) trace
+```
+
+Revert to the default once you're done — V(2) is verbose.
 
 ## Next steps
 

--- a/internal/controller/component_descriptors.go
+++ b/internal/controller/component_descriptors.go
@@ -204,6 +204,8 @@ func (r *SupersetReconciler) reconcileComponent(
 		renderedConfig = supersetconfig.RenderConfig(desc.componentType, compConfigInput)
 		secretEnvVars = collectSecretEnvVars(&superset.Spec, superset.Name)
 		operatorInjected = buildOperatorInjected(renderedConfig, bootstrapScript, resourceBaseName, superset.Spec.ForceReload, secretEnvVars)
+		logf.FromContext(ctx).V(2).Info("Rendered component config",
+			"component", desc.componentType, "configBytes", len(renderedConfig), "envVars", len(secretEnvVars))
 
 		// Create/update the component ConfigMap.
 		if err := reconcileParentOwnedConfigMap(ctx, r.Client, r.Scheme, superset, renderedConfig, bootstrapScript, resourceBaseName, componentLabels(string(desc.componentType), superset.Name)); err != nil {
@@ -285,6 +287,7 @@ func (r *SupersetReconciler) reconcileComponent(
 	if desc.hasPythonConfig {
 		workloadChecksum = computeChecksum(configChecksum + renderedConfig + effectiveBootstrapScript(superset.Spec.BootstrapScript, accessor.bootstrapScript))
 	}
+	logf.FromContext(ctx).V(2).Info("Computed workload checksum", "component", desc.componentType, "checksum", workloadChecksum)
 
 	flatSpec := flatSpecFromResolution(flat, &superset.Spec.Image, accessor.image, saName)
 	if desc.adjustSpec != nil {

--- a/internal/controller/component_reconciler.go
+++ b/internal/controller/component_reconciler.go
@@ -131,6 +131,9 @@ func reconcileComponentDeployment(
 	if op != controllerutil.OperationResultNone {
 		logf.FromContext(ctx).Info("Reconciled component",
 			"component", componentName, "name", resourceBaseName, "operation", op)
+	} else {
+		logf.FromContext(ctx).V(2).Info("Component unchanged",
+			"component", componentName, "name", resourceBaseName, "operation", op)
 	}
 	return nil
 }

--- a/internal/controller/lifecycle.go
+++ b/internal/controller/lifecycle.go
@@ -429,6 +429,7 @@ func (r *SupersetReconciler) checkUpgradeGates(
 	newTag := tagFromImageRef(currentImage)
 	direction := CompareVersions(oldTag, newTag)
 	approvalToken := upgradeApprovalToken(lastImage, currentImage)
+	log.V(2).Info("Compared image versions", "from", oldTag, "to", newTag, "direction", direction)
 
 	if direction == DirectionDowngrade {
 		log.Info("Downgrade detected, blocking lifecycle", "from", oldTag, "to", newTag)

--- a/internal/controller/networkpolicy.go
+++ b/internal/controller/networkpolicy.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	supersetv1alpha1 "github.com/apache/superset-kubernetes-operator/api/v1alpha1"
 	"github.com/apache/superset-kubernetes-operator/internal/common"
@@ -114,7 +115,7 @@ func (r *SupersetReconciler) reconcileComponentNetworkPolicy(
 	labels := componentLabels(component, instanceName)
 	npSpec := superset.Spec.NetworkPolicy
 
-	_, err := createOrUpdateWithRetry(ctx, r.Client, np, func() error {
+	op, err := createOrUpdateWithRetry(ctx, r.Client, np, func() error {
 		if err := controllerutil.SetControllerReference(superset, np, r.Scheme); err != nil {
 			return err
 		}
@@ -172,7 +173,11 @@ func (r *SupersetReconciler) reconcileComponentNetworkPolicy(
 
 		return nil
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	logf.FromContext(ctx).V(2).Info("Reconciled NetworkPolicy", "name", npName, "component", component, "operation", op)
+	return nil
 }
 
 // npContainerPort resolves the container port for NetworkPolicy rules using the

--- a/internal/controller/scaling.go
+++ b/internal/controller/scaling.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	supersetv1alpha1 "github.com/apache/superset-kubernetes-operator/api/v1alpha1"
 )
@@ -43,6 +44,7 @@ func reconcileHPA(
 	namespace string,
 ) error {
 	if autoscaling == nil {
+		logf.FromContext(ctx).V(2).Info("Ensuring no HPA (autoscaling disabled)", "name", deploymentName)
 		return deleteByLabels(ctx, c, namespace, labels,
 			func() client.ObjectList { return &autoscalingv2.HorizontalPodAutoscalerList{} }, "")
 	}
@@ -54,7 +56,7 @@ func reconcileHPA(
 		},
 	}
 
-	_, err := createOrUpdateWithRetry(ctx, c, hpa, func() error {
+	op, err := createOrUpdateWithRetry(ctx, c, hpa, func() error {
 		if err := controllerutil.SetControllerReference(owner, hpa, scheme); err != nil {
 			return err
 		}
@@ -74,7 +76,11 @@ func reconcileHPA(
 
 		return nil
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	logf.FromContext(ctx).V(2).Info("Reconciled HPA", "name", deploymentName, "operation", op)
+	return nil
 }
 
 // reconcilePDB creates, updates, or deletes a PDB for the given component.
@@ -89,6 +95,7 @@ func reconcilePDB(
 	namespace string,
 ) error {
 	if pdbSpec == nil {
+		logf.FromContext(ctx).V(2).Info("Ensuring no PDB (disabled)", "name", name)
 		return deleteByLabels(ctx, c, namespace, labels,
 			func() client.ObjectList { return &policyv1.PodDisruptionBudgetList{} }, "")
 	}
@@ -100,7 +107,7 @@ func reconcilePDB(
 		},
 	}
 
-	_, err := createOrUpdateWithRetry(ctx, c, pdb, func() error {
+	op, err := createOrUpdateWithRetry(ctx, c, pdb, func() error {
 		if err := controllerutil.SetControllerReference(owner, pdb, scheme); err != nil {
 			return err
 		}
@@ -115,5 +122,9 @@ func reconcilePDB(
 
 		return nil
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	logf.FromContext(ctx).V(2).Info("Reconciled PDB", "name", name, "operation", op)
+	return nil
 }

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -282,7 +282,7 @@ func (r *SupersetReconciler) getComponentStatus(ctx context.Context, superset *s
 	if err := r.Get(ctx, client.ObjectKey{Namespace: superset.Namespace, Name: resourceBaseName}, deploy); err != nil {
 		if !apierrors.IsNotFound(err) {
 			log := logf.FromContext(ctx)
-			log.Info("failed to read component Deployment for status", "component", desc.componentType, "name", resourceBaseName, "error", err)
+			log.Error(err, "Failed to read component Deployment for status", "component", desc.componentType, "name", resourceBaseName)
 		}
 		resources = append(resources, componentResourceStatus("Deployment", resourceBaseName, false))
 		resources = append(resources, r.expectedComponentResources(ctx, superset, desc, accessor, cfg, resourceBaseName)...)

--- a/internal/controller/superset_controller.go
+++ b/internal/controller/superset_controller.go
@@ -117,6 +117,7 @@ func (r *SupersetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		gunicornSpecFrom(superset.Spec.WebServer),
 		celerySpecFrom(superset.Spec.CeleryWorker),
 	})
+	log.V(2).Info("Computed config checksum", "name", superset.Name, "checksum", configChecksum)
 
 	// Phase 2: Reconcile shared resources.
 	if err := r.reconcileServiceAccount(ctx, superset); err != nil {
@@ -136,6 +137,7 @@ func (r *SupersetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 	if !lifecycleRes.Complete {
 		// Update status before returning.
+		log.V(1).Info("Lifecycle incomplete, requeueing", "name", superset.Name, "terminalFailure", lifecycleRes.TerminalFailure)
 		r.updateLifecycleComponentStatus(ctx, superset, configChecksum)
 		if statusErr := patchStatusIfChanged(ctx, r.Client, superset, origSuperset, origSuperset.Status, superset.Status); statusErr != nil {
 			return ctrl.Result{}, fmt.Errorf("updating status during lifecycle: %w", statusErr)
@@ -198,6 +200,7 @@ func (r *SupersetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		_ = r.deleteMaintenanceResources(ctx, superset)
 	}
 	if !maintenanceCleared {
+		log.V(1).Info("Maintenance active, requeueing before component reconcile", "name", superset.Name)
 		r.updateLifecycleComponentStatus(ctx, superset, configChecksum)
 		if statusErr := patchStatusIfChanged(ctx, r.Client, superset, origSuperset, origSuperset.Status, superset.Status); statusErr != nil {
 			return ctrl.Result{}, fmt.Errorf("updating status during maintenance return: %w", statusErr)
@@ -229,6 +232,7 @@ func (r *SupersetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	// Phase 6: Schedule-based requeue for periodic lifecycle tasks.
 	if requeue := r.nextScheduleRequeue(superset); requeue > 0 {
+		log.V(1).Info("Scheduling next reconcile", "name", superset.Name, "after", requeue.String())
 		return ctrl.Result{RequeueAfter: requeue}, nil
 	}
 


### PR DESCRIPTION
## Summary

The operator's controller logging worked but was uneven: it used only Info (V0) and a handful of V(1) lines, with no V(2) trace level and no documented policy for which level a given message belongs at. When an operator needed to debug a stuck reconcile, there were no granular breadcrumbs to turn on — several reconcile paths (HPA/PDB scaling, NetworkPolicy, config rendering, version comparison, the main loop phases) logged nothing at all.

This PR defines a three-tier logging policy aligned with controller-runtime best practices, documents it in the developer guidelines, and implements it with a targeted set of high-value log statements. Operators can now raise verbosity with `--zap-log-level=debug` (V1) or `=2` (V2) to get progressively more detail without any noise at the default level. There are no API or behavior changes.

## Details

**Policy** (documented in `docs/contributing/development-guidelines.md`, with a brief user-facing pointer in `docs/user-guide/installation.md`):

- **Info / V(0)** — meaningful state *transitions* only; must not fire on every reconcile.
- **V(1) / debug** — per-reconcile progress and decisions (reconcile entry, phase markers, requeue scheduling, CRD-absent skips).
- **V(2) / trace** — fine-grained internals (config size/checksum, version comparison, per-resource CreateOrUpdate ops even when unchanged).
- **Error** — reserved for *swallowed* non-fatal errors only; never double-log an error that's also returned (controller-runtime logs it and an Event is recorded).
- Cross-cutting rules: every-reconcile lines are V(1)+; camelCase structured keys; never log secret values or rendered config bodies (log sizes/counts/checksums); pure packages stay log-free.

**Implementation** (`internal/controller/`):

- `status.go`: corrected the one level mismatch — a swallowed Deployment-read error moved from `Info` to `Error`.
- `superset_controller.go`: V(1) phase markers (lifecycle incomplete, maintenance active, schedule requeue) and a V(2) config checksum.
- `component_descriptors.go`: V(2) rendered-config breadcrumb (size/count only, never content) and workload checksum.
- `component_reconciler.go`: V(2) "Component unchanged" symmetric to the existing V(0) "Reconciled component".
- `scaling.go` / `networkpolicy.go`: V(2) HPA/PDB/NetworkPolicy reconcile ops.
- `lifecycle.go`: V(2) version-comparison result at the call site (pure `version.go` left untouched).

The pre-existing lifecycle transition logs (Info/V0) were intentionally kept as transitions, not regressed to V(1).