### PR TITLE
fix: save all artifacts in vote-email curl command

### DIFF
--- a/scripts/release-email.sh
+++ b/scripts/release-email.sh
@@ -102,7 +102,7 @@ PGP keys used for signing are listed in:
 To verify the candidate (Go 1.26+, Helm, and Apache Rat must be installed
 locally; make will fetch additional Go modules and tools on first use):
 
-  curl -O ${DIST_DEV_BASE}/kubernetes-operator-${VERSION}-rc${RC}/${PROJECT}-${VERSION}-rc${RC}-source.tar.gz{,.asc,.sha512}
+  curl --remote-name-all ${DIST_DEV_BASE}/kubernetes-operator-${VERSION}-rc${RC}/${PROJECT}-${VERSION}-rc${RC}-source.tar.gz{,.asc,.sha512}
   curl -O ${DIST_RELEASE_BASE}/KEYS
   gpg --import KEYS
   gpg --verify ${PROJECT}-${VERSION}-rc${RC}-source.tar.gz{.asc,}


### PR DESCRIPTION
## Summary

The `[VOTE]` email template emitted by `scripts/release-email.sh` instructs voters to download and verify the release candidate with:

```bash
curl -O .../source.tar.gz{,.asc,.sha512}
```

The shell expands the braces into three URLs, but `curl -O` applies remote-name behavior to only the first URL. So curl saves the tarball and streams the .asc and .sha512 responses to stdout — they print to the terminal but never land on disk. The next step, `gpg --verify ...{.asc,}`, then fails for every voter because the signature file doesn't exist. This was hit while preparing the 0.1.0-rc1 vote on macOS.

This swaps `curl -O` for `curl --remote-name-all`, which uses the remote filename for all URLs, so the tarball, signature, and checksum are all written to disk.

## Details

- Only the multi-URL line is changed; the adjacent `curl -O .../KEYS` is a single URL and is left as-is.
- `--remote-name-all` has been in curl since 7.19.0 (2008), so it's safe on macOS (curl 8.x) and Linux.
- The `cp ...{,.asc,.sha512}` invocations in `docs/contributing/releasing.md` are unaffected — cp handles multiple brace-expanded arguments correctly.