### PR TITLE
refactor(resolution): collapse duplicated merge/render helpers

### DIFF
--- a/internal/config/celery.go
+++ b/internal/config/celery.go
@@ -67,30 +67,14 @@ func ResolveCelery(spec *v1alpha1.CeleryWorkerProcessSpec) ResolvedCelery {
 		return r
 	}
 
-	if spec.Concurrency != nil {
-		r.Concurrency = *spec.Concurrency
-	}
-	if spec.Pool != nil {
-		r.Pool = *spec.Pool
-	}
-	if spec.Optimization != nil {
-		r.Optimization = *spec.Optimization
-	}
-	if spec.MaxTasksPerChild != nil {
-		r.MaxTasksPerChild = *spec.MaxTasksPerChild
-	}
-	if spec.MaxMemoryPerChild != nil {
-		r.MaxMemoryPerChild = *spec.MaxMemoryPerChild
-	}
-	if spec.PrefetchMultiplier != nil {
-		r.PrefetchMultiplier = *spec.PrefetchMultiplier
-	}
-	if spec.SoftTimeLimit != nil {
-		r.SoftTimeLimit = *spec.SoftTimeLimit
-	}
-	if spec.TimeLimit != nil {
-		r.TimeLimit = *spec.TimeLimit
-	}
+	setIf(&r.Concurrency, spec.Concurrency)
+	setIf(&r.Pool, spec.Pool)
+	setIf(&r.Optimization, spec.Optimization)
+	setIf(&r.MaxTasksPerChild, spec.MaxTasksPerChild)
+	setIf(&r.MaxMemoryPerChild, spec.MaxMemoryPerChild)
+	setIf(&r.PrefetchMultiplier, spec.PrefetchMultiplier)
+	setIf(&r.SoftTimeLimit, spec.SoftTimeLimit)
+	setIf(&r.TimeLimit, spec.TimeLimit)
 
 	return r
 }
@@ -116,20 +100,18 @@ func (c *ResolvedCelery) Command() []string {
 		"-O", c.Optimization,
 		"-c", fmt.Sprintf("%d", c.Concurrency),
 	}
-	if c.MaxTasksPerChild > 0 {
-		cmd = append(cmd, fmt.Sprintf("--max-tasks-per-child=%d", c.MaxTasksPerChild))
-	}
-	if c.MaxMemoryPerChild > 0 {
-		cmd = append(cmd, fmt.Sprintf("--max-memory-per-child=%d", c.MaxMemoryPerChild))
-	}
-	if c.PrefetchMultiplier > 0 {
-		cmd = append(cmd, fmt.Sprintf("--prefetch-multiplier=%d", c.PrefetchMultiplier))
-	}
-	if c.SoftTimeLimit > 0 {
-		cmd = append(cmd, fmt.Sprintf("--soft-time-limit=%d", c.SoftTimeLimit))
-	}
-	if c.TimeLimit > 0 {
-		cmd = append(cmd, fmt.Sprintf("--time-limit=%d", c.TimeLimit))
+	cmd = appendIntFlag(cmd, "--max-tasks-per-child=%d", c.MaxTasksPerChild)
+	cmd = appendIntFlag(cmd, "--max-memory-per-child=%d", c.MaxMemoryPerChild)
+	cmd = appendIntFlag(cmd, "--prefetch-multiplier=%d", c.PrefetchMultiplier)
+	cmd = appendIntFlag(cmd, "--soft-time-limit=%d", c.SoftTimeLimit)
+	cmd = appendIntFlag(cmd, "--time-limit=%d", c.TimeLimit)
+	return cmd
+}
+
+// appendIntFlag appends a formatted flag to cmd only when val is positive.
+func appendIntFlag(cmd []string, format string, val int32) []string {
+	if val > 0 {
+		cmd = append(cmd, fmt.Sprintf(format, val))
 	}
 	return cmd
 }

--- a/internal/config/engine_options.go
+++ b/internal/config/engine_options.go
@@ -129,19 +129,9 @@ func applyExplicitOverrides(result *EngineOptionsInput, spec *v1alpha1.SQLAlchem
 	if spec == nil {
 		return
 	}
-	if spec.PoolSize != nil {
-		result.PoolSize = *spec.PoolSize
-	}
-	if spec.MaxOverflow != nil {
-		result.MaxOverflow = *spec.MaxOverflow
-	}
-	if spec.PoolRecycle != nil {
-		result.PoolRecycle = *spec.PoolRecycle
-	}
-	if spec.PoolPrePing != nil {
-		result.PoolPrePing = *spec.PoolPrePing
-	}
-	if spec.PoolTimeout != nil {
-		result.PoolTimeout = *spec.PoolTimeout
-	}
+	setIf(&result.PoolSize, spec.PoolSize)
+	setIf(&result.MaxOverflow, spec.MaxOverflow)
+	setIf(&result.PoolRecycle, spec.PoolRecycle)
+	setIf(&result.PoolPrePing, spec.PoolPrePing)
+	setIf(&result.PoolTimeout, spec.PoolTimeout)
 }

--- a/internal/config/gunicorn.go
+++ b/internal/config/gunicorn.go
@@ -92,36 +92,16 @@ func ResolveGunicorn(spec *v1alpha1.GunicornSpec) ResolvedGunicorn {
 		return r
 	}
 
-	if spec.Workers != nil {
-		r.Workers = *spec.Workers
-	}
-	if spec.Threads != nil {
-		r.Threads = *spec.Threads
-	}
-	if spec.WorkerClass != nil {
-		r.WorkerClass = *spec.WorkerClass
-	}
-	if spec.Timeout != nil {
-		r.Timeout = *spec.Timeout
-	}
-	if spec.KeepAlive != nil {
-		r.KeepAlive = *spec.KeepAlive
-	}
-	if spec.MaxRequests != nil {
-		r.MaxRequests = *spec.MaxRequests
-	}
-	if spec.MaxRequestsJitter != nil {
-		r.MaxRequestsJitter = *spec.MaxRequestsJitter
-	}
-	if spec.LimitRequestLine != nil {
-		r.LimitRequestLine = *spec.LimitRequestLine
-	}
-	if spec.LimitRequestFieldSize != nil {
-		r.LimitRequestFieldSize = *spec.LimitRequestFieldSize
-	}
-	if spec.LogLevel != nil {
-		r.LogLevel = *spec.LogLevel
-	}
+	setIf(&r.Workers, spec.Workers)
+	setIf(&r.Threads, spec.Threads)
+	setIf(&r.WorkerClass, spec.WorkerClass)
+	setIf(&r.Timeout, spec.Timeout)
+	setIf(&r.KeepAlive, spec.KeepAlive)
+	setIf(&r.MaxRequests, spec.MaxRequests)
+	setIf(&r.MaxRequestsJitter, spec.MaxRequestsJitter)
+	setIf(&r.LimitRequestLine, spec.LimitRequestLine)
+	setIf(&r.LimitRequestFieldSize, spec.LimitRequestFieldSize)
+	setIf(&r.LogLevel, spec.LogLevel)
 
 	return r
 }

--- a/internal/config/renderer.go
+++ b/internal/config/renderer.go
@@ -212,26 +212,26 @@ func RenderConfig(componentType ComponentType, input *ConfigInput) string {
 	}
 
 	// [4] Base config (spec.config)
-	if input.Config != "" {
-		b.WriteString("# Base config (spec.config)\n")
-		b.WriteString(input.Config)
-		if !strings.HasSuffix(input.Config, "\n") {
-			b.WriteString("\n")
-		}
-		b.WriteString("\n")
-	}
+	writeConfigSection(&b, "Base config (spec.config)", input.Config)
 
 	// [5] Component config
-	if input.ComponentConfig != "" {
-		b.WriteString("# Component config\n")
-		b.WriteString(input.ComponentConfig)
-		if !strings.HasSuffix(input.ComponentConfig, "\n") {
-			b.WriteString("\n")
-		}
-		b.WriteString("\n")
-	}
+	writeConfigSection(&b, "Component config", input.ComponentConfig)
 
 	return b.String()
+}
+
+// writeConfigSection appends a labeled block of raw Python config, ensuring it
+// ends with a blank line. It is a no-op when content is empty.
+func writeConfigSection(b *strings.Builder, label, content string) {
+	if content == "" {
+		return
+	}
+	b.WriteString("# " + label + "\n")
+	b.WriteString(content)
+	if !strings.HasSuffix(content, "\n") {
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
 }
 
 // renderValkey writes the Valkey cache/broker/results Python configuration.
@@ -338,20 +338,22 @@ func renderEngineOptions(b *strings.Builder, opts *EngineOptionsInput) {
 	b.WriteString("SQLALCHEMY_ENGINE_OPTIONS = {\n")
 	if opts.UseNullPool {
 		b.WriteString("    \"poolclass\": NullPool,\n")
-	} else {
-		fmt.Fprintf(b, "    \"pool_size\": %d,\n", opts.PoolSize)
-		fmt.Fprintf(b, "    \"max_overflow\": %d,\n", opts.MaxOverflow)
-		if opts.PoolRecycle > 0 {
-			fmt.Fprintf(b, "    \"pool_recycle\": %d,\n", opts.PoolRecycle)
-		}
-		if opts.PoolPrePing {
-			b.WriteString("    \"pool_pre_ping\": True,\n")
-		} else {
-			b.WriteString("    \"pool_pre_ping\": False,\n")
-		}
-		if opts.PoolTimeout > 0 {
-			fmt.Fprintf(b, "    \"pool_timeout\": %d,\n", opts.PoolTimeout)
-		}
+		b.WriteString("}\n\n")
+		return
+	}
+
+	fmt.Fprintf(b, "    \"pool_size\": %d,\n", opts.PoolSize)
+	fmt.Fprintf(b, "    \"max_overflow\": %d,\n", opts.MaxOverflow)
+	if opts.PoolRecycle > 0 {
+		fmt.Fprintf(b, "    \"pool_recycle\": %d,\n", opts.PoolRecycle)
+	}
+	prePing := "False"
+	if opts.PoolPrePing {
+		prePing = "True"
+	}
+	fmt.Fprintf(b, "    \"pool_pre_ping\": %s,\n", prePing)
+	if opts.PoolTimeout > 0 {
+		fmt.Fprintf(b, "    \"pool_timeout\": %d,\n", opts.PoolTimeout)
 	}
 	b.WriteString("}\n\n")
 }

--- a/internal/config/util.go
+++ b/internal/config/util.go
@@ -1,0 +1,28 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+// setIf assigns *src to *dst when src is non-nil. It collapses the repeated
+// "if spec.X != nil { r.X = *spec.X }" override pattern used when folding an
+// optional spec onto a resolved-defaults struct.
+func setIf[T any](dst, src *T) {
+	if src != nil {
+		*dst = *src
+	}
+}

--- a/internal/resolution/merge.go
+++ b/internal/resolution/merge.go
@@ -19,6 +19,8 @@ limitations under the License.
 package resolution
 
 import (
+	"maps"
+
 	corev1 "k8s.io/api/core/v1"
 
 	supersetv1alpha1 "github.com/apache/superset-kubernetes-operator/api/v1alpha1"
@@ -26,9 +28,9 @@ import (
 
 // MergeMaps merges multiple string maps. Later maps take precedence on key conflict.
 // Returns nil if the result is empty.
-func MergeMaps(maps ...map[string]string) map[string]string {
+func MergeMaps(inputs ...map[string]string) map[string]string {
 	size := 0
-	for _, m := range maps {
+	for _, m := range inputs {
 		size += len(m)
 	}
 	if size == 0 {
@@ -36,13 +38,27 @@ func MergeMaps(maps ...map[string]string) map[string]string {
 	}
 
 	result := make(map[string]string, size)
-	for _, m := range maps {
-		for k, v := range m {
-			result[k] = v
-		}
+	for _, m := range inputs {
+		maps.Copy(result, m)
 	}
-	if len(result) == 0 {
-		return nil
+	return result
+}
+
+// mergeByKey merges multiple slices, deduplicating by the key returned by key.
+// Later entries with the same key replace earlier entries in place to preserve
+// ordering.
+func mergeByKey[T any](key func(T) string, slices ...[]T) []T {
+	seen := make(map[string]int) // key -> index in result
+	var result []T
+	for _, slice := range slices {
+		for _, item := range slice {
+			if idx, exists := seen[key(item)]; exists {
+				result[idx] = item
+			} else {
+				seen[key(item)] = len(result)
+				result = append(result, item)
+			}
+		}
 	}
 	return result
 }
@@ -50,91 +66,31 @@ func MergeMaps(maps ...map[string]string) map[string]string {
 // MergeEnvVars merges multiple env var slices. Later entries with the same Name
 // replace earlier entries in place to preserve ordering.
 func MergeEnvVars(slices ...[]corev1.EnvVar) []corev1.EnvVar {
-	seen := make(map[string]int) // name -> index in result
-	var result []corev1.EnvVar
-	for _, slice := range slices {
-		for _, env := range slice {
-			if idx, exists := seen[env.Name]; exists {
-				result[idx] = env
-			} else {
-				seen[env.Name] = len(result)
-				result = append(result, env)
-			}
-		}
-	}
-	return result
+	return mergeByKey(func(e corev1.EnvVar) string { return e.Name }, slices...)
 }
 
 // MergeVolumes merges multiple volume slices. Later entries with the same Name
 // replace earlier entries in place to preserve ordering.
 func MergeVolumes(slices ...[]corev1.Volume) []corev1.Volume {
-	seen := make(map[string]int)
-	var result []corev1.Volume
-	for _, slice := range slices {
-		for _, vol := range slice {
-			if idx, exists := seen[vol.Name]; exists {
-				result[idx] = vol
-			} else {
-				seen[vol.Name] = len(result)
-				result = append(result, vol)
-			}
-		}
-	}
-	return result
+	return mergeByKey(func(v corev1.Volume) string { return v.Name }, slices...)
 }
 
 // MergeVolumeMounts merges multiple volume mount slices. Later entries with the
 // same Name replace earlier entries in place to preserve ordering.
 func MergeVolumeMounts(slices ...[]corev1.VolumeMount) []corev1.VolumeMount {
-	seen := make(map[string]int)
-	var result []corev1.VolumeMount
-	for _, slice := range slices {
-		for _, mount := range slice {
-			if idx, exists := seen[mount.Name]; exists {
-				result[idx] = mount
-			} else {
-				seen[mount.Name] = len(result)
-				result = append(result, mount)
-			}
-		}
-	}
-	return result
+	return mergeByKey(func(m corev1.VolumeMount) string { return m.Name }, slices...)
 }
 
 // MergeHostAliases merges multiple host alias slices. Later entries with the
 // same IP replace earlier entries in place to preserve ordering.
 func MergeHostAliases(slices ...[]corev1.HostAlias) []corev1.HostAlias {
-	seen := make(map[string]int)
-	var result []corev1.HostAlias
-	for _, slice := range slices {
-		for _, alias := range slice {
-			if idx, exists := seen[alias.IP]; exists {
-				result[idx] = alias
-			} else {
-				seen[alias.IP] = len(result)
-				result = append(result, alias)
-			}
-		}
-	}
-	return result
+	return mergeByKey(func(a corev1.HostAlias) string { return a.IP }, slices...)
 }
 
 // MergeContainerPorts merges multiple container port slices. Later entries with
 // the same Name replace earlier entries in place to preserve ordering.
 func MergeContainerPorts(slices ...[]corev1.ContainerPort) []corev1.ContainerPort {
-	seen := make(map[string]int)
-	var result []corev1.ContainerPort
-	for _, slice := range slices {
-		for _, port := range slice {
-			if idx, exists := seen[port.Name]; exists {
-				result[idx] = port
-			} else {
-				seen[port.Name] = len(result)
-				result = append(result, port)
-			}
-		}
-	}
-	return result
+	return mergeByKey(func(p corev1.ContainerPort) string { return p.Name }, slices...)
 }
 
 // MergeEnvFromSources concatenates multiple EnvFromSource slices.
@@ -154,26 +110,14 @@ func MergeEnvFromSources(slices ...[]corev1.EnvFromSource) []corev1.EnvFromSourc
 // MergeContainers concatenates multiple container slices (for sidecars/initContainers).
 // Later entries with the same Name replace earlier entries.
 func MergeContainers(slices ...[]corev1.Container) []corev1.Container {
-	seen := make(map[string]int)
-	var result []corev1.Container
-	for _, slice := range slices {
-		for _, c := range slice {
-			if idx, exists := seen[c.Name]; exists {
-				result[idx] = c
-			} else {
-				seen[c.Name] = len(result)
-				result = append(result, c)
-			}
-		}
-	}
-	return result
+	return mergeByKey(func(c corev1.Container) string { return c.Name }, slices...)
 }
 
 // MergeDeploymentTemplate field-level merges two DeploymentTemplates.
 // Only contains Deployment-level fields (no nested PodTemplate).
 func MergeDeploymentTemplate(comp, tl *supersetv1alpha1.DeploymentTemplate) *supersetv1alpha1.DeploymentTemplate {
-	c := safeDeploymentTemplate(comp)
-	t := safeDeploymentTemplate(tl)
+	c := orEmpty(comp)
+	t := orEmpty(tl)
 	result := &supersetv1alpha1.DeploymentTemplate{
 		RevisionHistoryLimit:    ResolveOverridableValue(c.RevisionHistoryLimit, t.RevisionHistoryLimit),
 		MinReadySeconds:         ResolveOverridableValue(c.MinReadySeconds, t.MinReadySeconds),
@@ -193,8 +137,8 @@ func MergeDeploymentTemplate(comp, tl *supersetv1alpha1.DeploymentTemplate) *sup
 // MergePodTemplate field-level merges two PodTemplates and folds in
 // operator-injected values (volumes, init containers, labels).
 func MergePodTemplate(comp, tl *supersetv1alpha1.PodTemplate, operatorLabels map[string]string, op *OperatorInjected) *supersetv1alpha1.PodTemplate {
-	c := safePodTemplate(comp)
-	t := safePodTemplate(tl)
+	c := orEmpty(comp)
+	t := orEmpty(tl)
 
 	return &supersetv1alpha1.PodTemplate{
 		Annotations:                   MergeMaps(t.Annotations, c.Annotations),
@@ -223,8 +167,8 @@ func MergePodTemplate(comp, tl *supersetv1alpha1.PodTemplate, operatorLabels map
 // MergeContainerTemplate field-level merges two ContainerTemplates and folds
 // in operator-injected env vars and volume mounts.
 func MergeContainerTemplate(comp, tl *supersetv1alpha1.ContainerTemplate, op *OperatorInjected) *supersetv1alpha1.ContainerTemplate {
-	c := safeContainerTemplate(comp)
-	t := safeContainerTemplate(tl)
+	c := orEmpty(comp)
+	t := orEmpty(tl)
 
 	result := &supersetv1alpha1.ContainerTemplate{
 		Resources:       ResolveOverridableValue(c.Resources, t.Resources),
@@ -250,23 +194,12 @@ func MergeContainerTemplate(comp, tl *supersetv1alpha1.ContainerTemplate, op *Op
 	return result
 }
 
-func safeDeploymentTemplate(d *supersetv1alpha1.DeploymentTemplate) *supersetv1alpha1.DeploymentTemplate {
-	if d == nil {
-		return &supersetv1alpha1.DeploymentTemplate{}
-	}
-	return d
-}
-
-func safePodTemplate(p *supersetv1alpha1.PodTemplate) *supersetv1alpha1.PodTemplate {
+// orEmpty returns p when non-nil, otherwise a pointer to a zero value of T.
+// It lets merge logic dereference optional template pointers without per-type
+// nil guards.
+func orEmpty[T any](p *T) *T {
 	if p == nil {
-		return &supersetv1alpha1.PodTemplate{}
+		return new(T)
 	}
 	return p
-}
-
-func safeContainerTemplate(ct *supersetv1alpha1.ContainerTemplate) *supersetv1alpha1.ContainerTemplate {
-	if ct == nil {
-		return &supersetv1alpha1.ContainerTemplate{}
-	}
-	return ct
 }

--- a/internal/resolution/resolver.go
+++ b/internal/resolution/resolver.go
@@ -86,9 +86,9 @@ func ResolveComponentSpec(
 	operatorLabels map[string]string,
 	operator *OperatorInjected,
 ) *FlatSpec {
-	tl := safeSharedInput(topLevel)
-	comp := safeComponentInput(component)
-	op := safeOperatorInjected(operator)
+	tl := orEmpty(topLevel)
+	comp := orEmpty(component)
+	op := orEmpty(operator)
 
 	result := &FlatSpec{}
 
@@ -104,28 +104,4 @@ func ResolveComponentSpec(
 	result.PodDisruptionBudget = ResolveOverridableValue(comp.PodDisruptionBudget, tl.PodDisruptionBudget)
 
 	return result
-}
-
-// safeSharedInput returns a non-nil SharedInput.
-func safeSharedInput(s *SharedInput) *SharedInput {
-	if s == nil {
-		return &SharedInput{}
-	}
-	return s
-}
-
-// safeComponentInput returns a non-nil ComponentInput.
-func safeComponentInput(c *ComponentInput) *ComponentInput {
-	if c == nil {
-		return &ComponentInput{}
-	}
-	return c
-}
-
-// safeOperatorInjected returns a non-nil OperatorInjected.
-func safeOperatorInjected(o *OperatorInjected) *OperatorInjected {
-	if o == nil {
-		return &OperatorInjected{}
-	}
-	return o
 }


### PR DESCRIPTION
## Summary

This is the first of three sequential, escalating-risk PRs from a codebase idiomaticity sweep. It targets the **pure, controller-runtime-free packages** (`internal/resolution/`, `internal/config/`), which are covered by extensive unit + fuzz tests, so regression risk is minimal.

The packages had accumulated several blocks of copy-pasted logic differing only in type or in a single field. This collapses them behind small generic helpers so the intent is expressed once — making the merge and config-rendering code easier to read and extend without per-type variants that can silently drift apart. **All changes are behavior-preserving.**

## Details

- **`internal/resolution/merge.go`**: the six name/IP-keyed merge functions (`MergeEnvVars`, `MergeVolumes`, `MergeVolumeMounts`, `MergeHostAliases`, `MergeContainerPorts`, `MergeContainers`) now delegate to a single generic `mergeByKey`; the three identical `safe*Template` helpers (plus the matching `safe*Input` helpers in `resolver.go`) collapse into one generic `orEmpty`. `MergeMaps` uses `maps.Copy` and drops a dead empty-result check (unreachable once `size == 0` returns early).
- **`internal/config`**: a generic `setIf` collapses the ~20 repeated `if spec.X != nil { r.X = *spec.X }` overrides across `gunicorn.go`, `celery.go`, and `engine_options.go`; `writeConfigSection` deduplicates the two identical config-block writers in `renderer.go`; `renderEngineOptions` is flattened with an early-return guard; and the celery worker command uses an `appendIntFlag` helper for its conditional flags.

Net ~137 fewer lines.
