### PR TITLE
chore: post-0.1.0 release tooling and docs cleanup

### DIFF
--- a/docs/contributing/development-guidelines.md
+++ b/docs/contributing/development-guidelines.md
@@ -560,7 +560,7 @@ The PR template (`PULL_REQUEST_TEMPLATE.md`) pre-fills these sections.
 
 ### Changelog entry
 
-Add a bullet under `## [Unreleased]` in
+Add a bullet under `## Unreleased` in
 [`docs/reference/releases.md`](../reference/releases.md)
 for noteworthy changes — new features,
 new CRD fields, behavior changes, breaking changes, deprecations, and
@@ -574,7 +574,7 @@ create the subheading on first use. Lead each bullet with the user-facing
 effect, not the implementation:
 
 ```markdown
-## [Unreleased]
+## Unreleased
 
 ### Added
 - New `webServer.gunicorn.keepAlive` field for tuning Gunicorn keepalive timeouts.
@@ -584,7 +584,7 @@ effect, not the implementation:
   rejects credentials; the parent surfaces an `AuthenticationFailed` reason.
 ```
 
-The release manager does a final review pass over `## [Unreleased]` before
+The release manager does a final review pass over `## Unreleased` before
 tagging — see [Releasing](releasing.md#reviewing-the-changelog) — so it's
 fine to err on the side of including an entry; missing or duplicate ones can
 be cleaned up there.

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -119,7 +119,7 @@ Before creating the first RC for a minor release, run or verify:
 
 ## Reviewing the Changelog
 
-Contributors add bullets to `## [Unreleased]` in
+Contributors add bullets to `## Unreleased` in
 [`docs/reference/releases.md`](../reference/releases.md) as PRs land (see the
 [changelog convention](development-guidelines.md#changelog-entry)). Before
 tagging the RC, the release manager does one review pass to make sure the
@@ -136,10 +136,9 @@ section accurately reflects the release:
 4. Group bullets under the standard Keep a Changelog subheadings — `Added`,
    `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security` — dropping any
    that end up empty.
-5. Rename the section header from `## [Unreleased]` to `## [<version>]` and add
-   a fresh empty `## [Unreleased]` above it. Add the final release date after
-   the vote passes and the release has been promoted. Update the comparison
-   links at the bottom of the file.
+5. Rename the section header from `## Unreleased` to `## <version>` and add
+   a fresh empty `## Unreleased` above it. Add the final release date after
+   the vote passes and the release has been promoted (`## <version> - <date>`).
 
 Two flows depending on whether the minor release branch already exists:
 
@@ -190,9 +189,9 @@ A release candidate therefore needs three artifacts staged on
 
 | Artifact | Filename pattern | Notes |
 |---|---|---|
-| Source archive | `apache-superset-kubernetes-operator-<version>-rc<n>-source.tar.gz` | A `git archive` of the RC tag, prefixed with the project directory. |
-| Detached PGP signature | `apache-superset-kubernetes-operator-<version>-rc<n>-source.tar.gz.asc` | Generated with a key in [`KEYS`](https://dist.apache.org/repos/dist/release/superset/KEYS). |
-| SHA-512 checksum | `apache-superset-kubernetes-operator-<version>-rc<n>-source.tar.gz.sha512` | `shasum -a 512` output, with a bare filename so verifiers can run `shasum -c` after a plain download. |
+| Source archive | `apache-superset-kubernetes-operator-<version>-rc<n>.tar.gz` | A `git archive` of the RC tag, prefixed with the project directory. |
+| Detached PGP signature | `apache-superset-kubernetes-operator-<version>-rc<n>.tar.gz.asc` | Generated with a key in [`KEYS`](https://dist.apache.org/repos/dist/release/superset/KEYS). |
+| SHA-512 checksum | `apache-superset-kubernetes-operator-<version>-rc<n>.tar.gz.sha512` | `shasum -a 512` output, with a bare filename so verifiers can run `shasum -c` after a plain download. |
 
 ### Pre-requisites for the release manager
 
@@ -219,7 +218,7 @@ has an `@apache.org` UID:
 
 ```sh
 scripts/release-source.sh
-# → dist/0.2.0-rc1/apache-superset-kubernetes-operator-0.2.0-rc1-source.tar.gz{,.asc,.sha512}
+# → dist/0.2.0-rc1/apache-superset-kubernetes-operator-0.2.0-rc1.tar.gz{,.asc,.sha512}
 ```
 
 Pass `--gpg-key <id>` to pick a specific signing key, and `--out-dir <path>` to
@@ -241,7 +240,7 @@ write the artifacts somewhere other than `dist/<version>-rc<n>/`.
 ```sh
 cd ~/asf/dev-superset
 mkdir kubernetes-operator-${VERSION}-rc${RC}
-cp /path/to/dist/${VERSION}-rc${RC}/apache-superset-kubernetes-operator-${VERSION}-rc${RC}-source.tar.gz{,.asc,.sha512} \
+cp /path/to/dist/${VERSION}-rc${RC}/apache-superset-kubernetes-operator-${VERSION}-rc${RC}.tar.gz{,.asc,.sha512} \
    kubernetes-operator-${VERSION}-rc${RC}/
 svn add kubernetes-operator-${VERSION}-rc${RC}
 svn commit -m "Stage Superset Kubernetes Operator ${VERSION}-rc${RC}"
@@ -288,8 +287,9 @@ git push origin v0.2.0
 The release workflow pushes the `0.2.0` and `latest` images to GHCR.
 
 After the final tag is pushed, add the final release date to
-`docs/reference/releases.md` in a normal follow-up commit and merge or
-cherry-pick that release metadata back to `main`.
+`docs/reference/releases.md` on `main` only (the docs site builds from `main`).
+Leave the release-branch changelog undated so it continues to match the voted
+source.
 
 After the binary release workflow finishes, promote the source artifacts.
 `release-source.sh` sees the final tag on `HEAD`, requires a matching RC tag on
@@ -298,19 +298,14 @@ stays valid), and regenerates the SHA-512 file under the final filename:
 
 ```sh
 scripts/release-source.sh
-# → dist/0.2.0/apache-superset-kubernetes-operator-0.2.0-source.tar.gz{,.asc,.sha512}
+# → dist/0.2.0/apache-superset-kubernetes-operator-0.2.0.tar.gz{,.asc,.sha512}
 
 cd ~/asf/release-superset
 mkdir kubernetes-operator-0.2.0
-cp /path/to/dist/0.2.0/apache-superset-kubernetes-operator-0.2.0-source.tar.gz{,.asc,.sha512} \
+cp /path/to/dist/0.2.0/apache-superset-kubernetes-operator-0.2.0.tar.gz{,.asc,.sha512} \
    kubernetes-operator-0.2.0/
 svn add kubernetes-operator-0.2.0
 svn commit -m "Release Apache Superset Kubernetes Operator 0.2.0"
-
-# Clean up the dev/ staging area (and any earlier RCs).
-cd ~/asf/dev-superset
-svn rm kubernetes-operator-0.2.0-rc*
-svn commit -m "Clean up Superset Kubernetes Operator 0.2.0 release candidates"
 ```
 
 Generate the release announcement after the artifacts have propagated to the ASF

--- a/docs/reference/downloads.md
+++ b/docs/reference/downloads.md
@@ -20,11 +20,11 @@ under the License.
 # Downloads
 
 !!! note
-    No final release has been cut yet. Development builds (`dev` /
-    `sha-<commit>` image tags and the `0.0.0-dev` Helm chart) are always available,
-    and release candidates (`<version>-rc<N>` tags) may be published for testing
-    ahead of a vote. Signed final artifacts are published once a release passes
-    the ASF vote.
+    The **signed source archive is the official Apache release**. The operator
+    image and Helm chart are convenience binaries published to the GitHub
+    Container Registry: `dev` / `sha-<commit>` tags and the `0.0.0-dev` chart on
+    every merge to `main`, `<version>-rc<N>` tags for release candidates, and
+    `<version>` + `latest` for final releases.
 
 ## Source Release
 
@@ -32,8 +32,28 @@ Per the [ASF Release Policy](https://www.apache.org/legal/release-policy.html),
 the **signed source archive is the official Apache release**; the operator image
 and Helm chart below are convenience binaries built from it.
 
-Source archives, signatures, and checksums — along with verification
-instructions — will be published here once the first release is staged.
+Signed source archives, detached PGP signatures, and SHA-512 checksums are
+published to the ASF distribution site under
+`https://downloads.apache.org/superset/kubernetes-operator-<version>/`, for
+example `kubernetes-operator-0.1.0/`:
+
+| File | Description |
+|------|-------------|
+| `apache-superset-kubernetes-operator-<version>.tar.gz` | Source archive (a `git archive` of the release tag). |
+| `apache-superset-kubernetes-operator-<version>.tar.gz.asc` | Detached PGP signature. |
+| `apache-superset-kubernetes-operator-<version>.tar.gz.sha512` | SHA-512 checksum. |
+
+### Verifying the Source Release
+
+```bash
+VERSION=0.1.0
+BASE=https://downloads.apache.org/superset/kubernetes-operator-${VERSION}
+curl -O ${BASE}/apache-superset-kubernetes-operator-${VERSION}.tar.gz{,.asc,.sha512}
+curl -O https://downloads.apache.org/superset/KEYS
+gpg --import KEYS
+gpg --verify apache-superset-kubernetes-operator-${VERSION}.tar.gz{.asc,}
+shasum -a 512 -c apache-superset-kubernetes-operator-${VERSION}.tar.gz.sha512
+```
 
 ## Operator Image
 

--- a/docs/reference/releases.md
+++ b/docs/reference/releases.md
@@ -22,9 +22,9 @@ under the License.
 This page tracks notable changes in Apache Superset Kubernetes Operator
 releases.
 
-## [Unreleased]
+## Unreleased
 
-## [0.1.0]
+## 0.1.0 - 2026-06-10
 
 ### Added
 
@@ -43,6 +43,3 @@ releases.
 - **Task failure messages may include credential fragments.** Lifecycle task
   failure output is truncated into `status` and could contain fragments of task
   stdout, including credentials. See [security.md](security.md).
-
-[Unreleased]: https://github.com/apache/superset-kubernetes-operator/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/apache/superset-kubernetes-operator/releases/tag/v0.1.0

--- a/scripts/release-email.sh
+++ b/scripts/release-email.sh
@@ -43,7 +43,8 @@ DISPLAY_NAME="Apache Superset Kubernetes Operator"
 DIST_DEV_BASE="https://dist.apache.org/repos/dist/dev/superset"
 DIST_RELEASE_BASE="https://dist.apache.org/repos/dist/release/superset"
 GITHUB_BASE="https://github.com/apache/superset-kubernetes-operator"
-DOWNLOADS_BASE="https://superset.apache.org/downloads/"
+DOCS_BASE="https://apache.github.io/superset-kubernetes-operator"
+DOWNLOADS_URL="${DOCS_BASE}/reference/downloads/"
 
 version_re() {
   printf "%s" "$1" | sed 's/[.]/\\./g'
@@ -102,12 +103,12 @@ PGP keys used for signing are listed in:
 To verify the candidate (Go 1.26+, Helm, and Apache Rat must be installed
 locally; make will fetch additional Go modules and tools on first use):
 
-  curl --remote-name-all ${DIST_DEV_BASE}/kubernetes-operator-${VERSION}-rc${RC}/${PROJECT}-${VERSION}-rc${RC}-source.tar.gz{,.asc,.sha512}
+  curl --remote-name-all ${DIST_DEV_BASE}/kubernetes-operator-${VERSION}-rc${RC}/${PROJECT}-${VERSION}-rc${RC}.tar.gz{,.asc,.sha512}
   curl -O ${DIST_RELEASE_BASE}/KEYS
   gpg --import KEYS
-  gpg --verify ${PROJECT}-${VERSION}-rc${RC}-source.tar.gz{.asc,}
-  shasum -a 512 -c ${PROJECT}-${VERSION}-rc${RC}-source.tar.gz.sha512
-  tar -xzf ${PROJECT}-${VERSION}-rc${RC}-source.tar.gz
+  gpg --verify ${PROJECT}-${VERSION}-rc${RC}.tar.gz{.asc,}
+  shasum -a 512 -c ${PROJECT}-${VERSION}-rc${RC}.tar.gz.sha512
+  tar -xzf ${PROJECT}-${VERSION}-rc${RC}.tar.gz
   cd ${PROJECT}-${VERSION}/
   make test-unit helm-lint check-license
 
@@ -170,10 +171,10 @@ The signed source release is available at:
   ${DIST_RELEASE_BASE}/kubernetes-operator-${VERSION}/
 
 Downloads and verification instructions are available at:
-  ${DOWNLOADS_BASE}
+  ${DOWNLOADS_URL}
 
 Release notes are available at:
-  ${GITHUB_BASE}/blob/v${VERSION}/docs/reference/releases.md
+  ${DOCS_BASE}/reference/releases/
 
 Thanks to everyone who contributed to this release.
 

--- a/scripts/release-rc.sh
+++ b/scripts/release-rc.sh
@@ -71,8 +71,8 @@ command -v helm >/dev/null 2>&1 || die "helm is required but not installed"
 [[ -f Makefile ]] || die "must be run from the repository root"
 CHANGELOG_FILE="docs/reference/releases.md"
 [[ -f "$CHANGELOG_FILE" ]] || die "release notes file is missing: ${CHANGELOG_FILE}"
-grep -Eq "^##[[:space:]]+\\[${VERSION//./\\.}\\]([[:space:]]|$)" "$CHANGELOG_FILE" \
-  || die "${CHANGELOG_FILE} must contain a release heading for ${VERSION} (expected: ## [${VERSION}])"
+grep -Eq "^##[[:space:]]+${VERSION//./\\.}([[:space:]]|$)" "$CHANGELOG_FILE" \
+  || die "${CHANGELOG_FILE} must contain a release heading for ${VERSION} (expected: ## ${VERSION})"
 
 if [[ -n "$(git status --porcelain)" ]]; then
   die "working tree is not clean — commit or stash changes first"

--- a/scripts/release-source.sh
+++ b/scripts/release-source.sh
@@ -24,7 +24,7 @@
 #
 # In RC mode the script:
 #   1. Archives the v<version>-rc<n> git tag into
-#      apache-superset-kubernetes-operator-<version>-rc<n>-source.tar.gz
+#      apache-superset-kubernetes-operator-<version>-rc<n>.tar.gz
 #   2. Detached-signs it with the newest usable local apache.org secret key
 #      (override with --gpg-key <id>)
 #   3. Writes a SHA-512 checksum file with a *bare* filename so verifiers can
@@ -236,7 +236,7 @@ case "$MODE" in
     [[ "$RC" =~ ^[1-9][0-9]*$ ]] || die "rc must be a positive integer"
 
     TAG="v${VERSION}-rc${RC}"
-    BASE="${PROJECT}-${VERSION}-rc${RC}-source.tar.gz"
+    BASE="${PROJECT}-${VERSION}-rc${RC}.tar.gz"
     : "${OUT_DIR:=dist/${VERSION}-rc${RC}}"
     mkdir -p "$OUT_DIR"
     OUT="${OUT_DIR}/${BASE}"
@@ -282,14 +282,17 @@ case "$MODE" in
     mkdir -p "$OUT_DIR"
 
     # Locate the RC tarball and derive the final filename from the version arg.
+    # The glob matches both the current naming (`-rc<n>.tar.gz`) and the legacy
+    # `-rc<n>-source.tar.gz` used before the `-source` suffix was dropped, so a
+    # final can still be promoted from a pre-existing RC artifact.
     RC_TARBALL=$(find "$RC_DIR" -maxdepth 1 -type f \
-                  -name "${PROJECT}-${VERSION}-rc*-source.tar.gz" | head -1)
+                  -name "${PROJECT}-${VERSION}-rc*.tar.gz" | head -1)
     [[ -n "$RC_TARBALL" ]] || die "no RC tarball found in ${RC_DIR}"
     RC_BASE=$(basename "$RC_TARBALL")
     [[ -f "${RC_TARBALL}.asc" ]]    || die "missing detached signature: ${RC_BASE}.asc"
     [[ -f "${RC_TARBALL}.sha512" ]] || die "missing checksum file: ${RC_BASE}.sha512"
 
-    FINAL_BASE="${PROJECT}-${VERSION}-source.tar.gz"
+    FINAL_BASE="${PROJECT}-${VERSION}.tar.gz"
     FINAL_OUT="${OUT_DIR}/${FINAL_BASE}"
 
     info "Copying ${RC_BASE} → ${FINAL_BASE} (bytes preserved)"


### PR DESCRIPTION
## Summary

A set of refinements to the release tooling and release-related docs, surfaced while finalizing 0.1.0. The signed source artifact is renamed to drop the redundant `-source` suffix, the announce-email and downloads links are corrected to point at real pages, the changelog drops its hand-maintained version-link scaffolding, and a couple of finalize-step instructions are brought in line with how we actually release. These are process/docs only — no operator behavior changes.

The `-source` suffix added nothing: the ASF `release/superset/` dist area only ever holds the source tarball (images and the Helm chart live on GHCR), so there was nothing to disambiguate against. The artifact is now `apache-superset-kubernetes-operator-<version>.tar.gz`. This takes effect from 0.1.0 onward; the already-voted `0.1.0-rc1` keeps its original name, and the finalize flow still promotes its bytes unchanged.

## Details

- **Drop `-source` from source artifacts.** `release-source.sh` produces `…-<version>.tar.gz` (final) and `…-rc<n>.tar.gz` (RC); the finalize glob matches both the new and legacy `-rc<n>-source.tar.gz` names so an already-staged RC still promotes. `release-email.sh` and `releasing.md` updated to match.
- **Fix announce-email links.** Introduce `DOCS_BASE` (`https://apache.github.io/superset-kubernetes-operator`); point downloads and release-notes at the rendered docs site (`/reference/downloads/`, `/reference/releases/`) instead of a non-existent page and the raw GitHub markdown source. Rename `DOWNLOADS_BASE` → `DOWNLOADS_URL` (it's a full URL, not a base). The vote email keeps its tag-pinned source link by design.
- **Fill in the downloads page.** `docs/reference/downloads.md` replaces the "no final release has been cut yet" placeholder with a version-templated Source Release section and gpg/shasum verification steps.
- **Simplify the changelog.** Drop the `[version]` bracket link syntax and the `[Unreleased]`/version compare-link definitions (a manual drift point); the `Added`/`Changed`/… bullets carry the signal. `release-rc.sh`'s changelog validation and the contributor/release docs are updated to the bracket-free heading. 0.1.0 is dated `2026-06-10`.
- **Correct finalize instructions.** Stop instructing removal of RC artifacts from the dev dist area, and document the release date as a `main`-only edit (the docs site builds from `main`).