### PR TITLE
chore: cover helpers from the merge/render refactor

### DIFF
--- a/internal/config/celery_test.go
+++ b/internal/config/celery_test.go
@@ -98,3 +98,22 @@ func TestResolveCelery_CommandWithOptionalFlags(t *testing.T) {
 	assert.Contains(t, cmd, "--soft-time-limit=300")
 	assert.Contains(t, cmd, "--time-limit=600")
 }
+
+// TestAppendIntFlag documents that appendIntFlag formats and appends a flag only
+// when the value is positive, leaving the command untouched otherwise.
+func TestAppendIntFlag(t *testing.T) {
+	t.Run("positive value appends formatted flag", func(t *testing.T) {
+		got := appendIntFlag([]string{"worker"}, "--time-limit=%d", 600)
+		assert.Equal(t, []string{"worker", "--time-limit=600"}, got)
+	})
+
+	t.Run("zero value is a no-op", func(t *testing.T) {
+		got := appendIntFlag([]string{"worker"}, "--time-limit=%d", 0)
+		assert.Equal(t, []string{"worker"}, got)
+	})
+
+	t.Run("negative value is a no-op", func(t *testing.T) {
+		got := appendIntFlag([]string{"worker"}, "--time-limit=%d", -1)
+		assert.Equal(t, []string{"worker"}, got)
+	})
+}

--- a/internal/config/renderer_test.go
+++ b/internal/config/renderer_test.go
@@ -466,6 +466,47 @@ func assertContains(t *testing.T, s, substr string) {
 	}
 }
 
+// TestWriteConfigSection documents that writeConfigSection skips empty content
+// and otherwise emits a labeled comment followed by the content with exactly one
+// trailing blank line, regardless of whether the content already ends in "\n".
+func TestWriteConfigSection(t *testing.T) {
+	tests := []struct {
+		name    string
+		label   string
+		content string
+		expect  string
+	}{
+		{
+			name:    "empty content is a no-op",
+			label:   "Base config",
+			content: "",
+			expect:  "",
+		},
+		{
+			name:    "content without trailing newline",
+			label:   "Base config",
+			content: "X = 1",
+			expect:  "# Base config\nX = 1\n\n",
+		},
+		{
+			name:    "content with trailing newline is not double-padded",
+			label:   "Component config",
+			content: "Y = 2\n",
+			expect:  "# Component config\nY = 2\n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b strings.Builder
+			writeConfigSection(&b, tt.label, tt.content)
+			if got := b.String(); got != tt.expect {
+				t.Errorf("writeConfigSection() = %q, want %q", got, tt.expect)
+			}
+		})
+	}
+}
+
 func assertNotContains(t *testing.T, s, substr string) {
 	t.Helper()
 	if strings.Contains(s, substr) {

--- a/internal/config/util_test.go
+++ b/internal/config/util_test.go
@@ -1,0 +1,49 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSetIf documents that setIf overwrites the destination only when the
+// source pointer is non-nil, leaving the existing value untouched otherwise.
+func TestSetIf(t *testing.T) {
+	t.Run("nil source leaves dst unchanged", func(t *testing.T) {
+		dst := int32(7)
+		setIf(&dst, nil)
+		assert.Equal(t, int32(7), dst)
+	})
+
+	t.Run("non-nil source overwrites dst", func(t *testing.T) {
+		dst := int32(7)
+		setIf(&dst, ptr(int32(42)))
+		assert.Equal(t, int32(42), dst)
+	})
+
+	t.Run("generic over string", func(t *testing.T) {
+		dst := "default"
+		setIf(&dst, nil)
+		assert.Equal(t, "default", dst)
+		setIf(&dst, ptr("override"))
+		assert.Equal(t, "override", dst)
+	})
+}

--- a/internal/resolution/merge_test.go
+++ b/internal/resolution/merge_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package resolution
 
 import (
+	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -531,6 +532,94 @@ func TestMergeDeploymentTemplate(t *testing.T) {
 		got := MergeDeploymentTemplate(&supersetv1alpha1.DeploymentTemplate{}, &supersetv1alpha1.DeploymentTemplate{})
 		if got != nil {
 			t.Errorf("expected nil for empty inputs, got %+v", got)
+		}
+	})
+}
+
+// TestMergeByKey exercises the generic merge directly with a plain struct so the
+// type-agnostic dedup/ordering contract is documented independently of the
+// corev1-typed Merge* wrappers that delegate to it.
+func TestMergeByKey(t *testing.T) {
+	type kv struct {
+		k string
+		v string
+	}
+	key := func(x kv) string { return x.k }
+
+	tests := []struct {
+		name   string
+		slices [][]kv
+		expect []kv
+	}{
+		{
+			name:   "no slices",
+			slices: nil,
+			expect: nil,
+		},
+		{
+			name:   "all empty",
+			slices: [][]kv{nil, {}},
+			expect: nil,
+		},
+		{
+			name:   "single slice preserves order",
+			slices: [][]kv{{{"a", "1"}, {"b", "2"}}},
+			expect: []kv{{"a", "1"}, {"b", "2"}},
+		},
+		{
+			name:   "duplicate within one slice replaces in place",
+			slices: [][]kv{{{"a", "1"}, {"b", "2"}, {"a", "3"}}},
+			expect: []kv{{"a", "3"}, {"b", "2"}},
+		},
+		{
+			name:   "duplicate across slices later wins keeping position",
+			slices: [][]kv{{{"a", "1"}, {"b", "2"}}, {{"a", "9"}}},
+			expect: []kv{{"a", "9"}, {"b", "2"}},
+		},
+		{
+			name:   "distinct keys across slices append in order",
+			slices: [][]kv{{{"a", "1"}}, {{"b", "2"}}, {{"c", "3"}}},
+			expect: []kv{{"a", "1"}, {"b", "2"}, {"c", "3"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeByKey(key, tt.slices...)
+			if !reflect.DeepEqual(got, tt.expect) {
+				t.Errorf("mergeByKey() = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}
+
+// TestOrEmpty documents that orEmpty returns the input pointer unchanged when
+// non-nil and a fresh pointer to a zero value when nil, for any type.
+func TestOrEmpty(t *testing.T) {
+	t.Run("nil returns non-nil zero value", func(t *testing.T) {
+		got := orEmpty[supersetv1alpha1.PodTemplate](nil)
+		if got == nil {
+			t.Fatal("orEmpty(nil) returned nil pointer")
+		}
+		if !reflect.DeepEqual(*got, supersetv1alpha1.PodTemplate{}) {
+			t.Errorf("orEmpty(nil) = %+v, want zero value", *got)
+		}
+	})
+
+	t.Run("non-nil returns same pointer", func(t *testing.T) {
+		in := &supersetv1alpha1.PodTemplate{Labels: map[string]string{"a": "b"}}
+		if got := orEmpty(in); got != in {
+			t.Errorf("orEmpty(in) returned a different pointer; want identity")
+		}
+	})
+
+	t.Run("generic over other types", func(t *testing.T) {
+		if got := orEmpty[int](nil); got == nil || *got != 0 {
+			t.Errorf("orEmpty[int](nil) = %v, want pointer to 0", got)
+		}
+		n := 42
+		if got := orEmpty(&n); got != &n {
+			t.Errorf("orEmpty(&n) returned a different pointer; want identity")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Add explicit unit tests for new helpers introduced in #136