### PR TITLE
fix(controller): preserve HPA-managed deployment replicas

### DIFF
--- a/internal/controller/component_reconciler.go
+++ b/internal/controller/component_reconciler.go
@@ -122,7 +122,9 @@ func reconcileComponentDeployment(
 		// cannot be overridden by user-supplied deployment labels.
 		deploy.Labels = mergeLabels(dt.Labels, labels)
 		deploy.Annotations = mergeAnnotations(deploy.Annotations, dt.Annotations)
-		deploy.Spec = buildDeploymentSpec(spec, cfg, checksumAnnotations, labels)
+		desiredSpec := buildDeploymentSpec(spec, cfg, checksumAnnotations, labels)
+		preserveDeploymentReplicasWhenUnmanaged(&desiredSpec, deploy.Spec)
+		deploy.Spec = desiredSpec
 		return nil
 	})
 	if err != nil {
@@ -136,6 +138,22 @@ func reconcileComponentDeployment(
 			"component", componentName, "name", resourceBaseName, "operation", op)
 	}
 	return nil
+}
+
+// preserveDeploymentReplicasWhenUnmanaged keeps Deployment.spec.replicas out of
+// the operator's control when buildDeploymentSpec decides replicas are
+// unmanaged. The API server defaults an omitted Deployment replicas field to 1
+// on update, so a full-spec update with Replicas=nil would otherwise fight the
+// HPA and continuously scale down.
+func preserveDeploymentReplicasWhenUnmanaged(
+	desired *appsv1.DeploymentSpec,
+	existing appsv1.DeploymentSpec,
+) {
+	if desired.Replicas != nil || existing.Replicas == nil {
+		return
+	}
+	replicas := *existing.Replicas
+	desired.Replicas = &replicas
 }
 
 // reconcileComponentService creates or updates a Service for the component.

--- a/internal/controller/component_reconciler_test.go
+++ b/internal/controller/component_reconciler_test.go
@@ -166,6 +166,93 @@ func TestReconcileComponentResources_CreatesDeploymentAndService(t *testing.T) {
 	assert.Equal(t, common.PortCeleryFlower, svc.Spec.Ports[0].Port)
 }
 
+func TestPreserveDeploymentReplicasWhenUnmanaged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		desiredReplicas  *int32
+		existingReplicas *int32
+		wantReplicas     *int32
+	}{
+		{
+			name:             "unmanaged desired preserves existing replicas",
+			desiredReplicas:  nil,
+			existingReplicas: int32Ptr(3),
+			wantReplicas:     int32Ptr(3),
+		},
+		{
+			name:             "unmanaged desired remains nil on create path",
+			desiredReplicas:  nil,
+			existingReplicas: nil,
+			wantReplicas:     nil,
+		},
+		{
+			name:             "managed desired ignores existing drift",
+			desiredReplicas:  int32Ptr(2),
+			existingReplicas: int32Ptr(3),
+			wantReplicas:     int32Ptr(2),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			desired := appsv1.DeploymentSpec{Replicas: tt.desiredReplicas}
+			existing := appsv1.DeploymentSpec{Replicas: tt.existingReplicas}
+
+			preserveDeploymentReplicasWhenUnmanaged(&desired, existing)
+
+			if tt.wantReplicas == nil {
+				assert.Nil(t, desired.Replicas)
+				return
+			}
+			require.NotNil(t, desired.Replicas)
+			assert.Equal(t, *tt.wantReplicas, *desired.Replicas)
+		})
+	}
+}
+
+func TestReconcileComponentDeployment_PreservesReplicasWhenAutoscaling(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+	owner := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "uid-1"},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(owner).Build()
+	recorder := events.NewFakeRecorder(20)
+
+	one := int32(1)
+	minReplicas := int32(2)
+	autoscaling := &supersetv1alpha1.AutoscalingSpec{
+		MinReplicas: &minReplicas,
+		MaxReplicas: 5,
+	}
+	spec := &supersetv1alpha1.FlatComponentSpec{
+		Image:       supersetv1alpha1.ImageSpec{Repository: "apache/superset", Tag: "latest"},
+		Replicas:    &one,
+		Autoscaling: autoscaling,
+	}
+	cfg, ok := componentResourceConfig(common.ComponentWebServer)
+	require.True(t, ok)
+
+	resourceBaseName := common.ResourceBaseName("test", common.ComponentWebServer)
+	require.NoError(t, reconcileComponentResources(ctx, c, scheme, recorder, owner, spec, cfg, "", nil, autoscaling, nil))
+
+	deploy := &appsv1.Deployment{}
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: resourceBaseName, Namespace: "default"}, deploy))
+
+	// Simulate the HPA scaling the target Deployment above the CR's replica value.
+	three := int32(3)
+	deploy.Spec.Replicas = &three
+	require.NoError(t, c.Update(ctx, deploy))
+
+	require.NoError(t, reconcileComponentResources(ctx, c, scheme, recorder, owner, spec, cfg, "", nil, autoscaling, nil))
+
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: resourceBaseName, Namespace: "default"}, deploy))
+	require.NotNil(t, deploy.Spec.Replicas)
+	assert.Equal(t, int32(3), *deploy.Spec.Replicas)
+}
+
 func TestDeleteByLabels_KeepsNamedAndDeletesRest(t *testing.T) {
 	ctx := context.Background()
 	scheme := testScheme(t)


### PR DESCRIPTION
## Summary

This PR prevents the Superset operator from resetting `Deployment.spec.replicas` when HPA autoscaling is enabled for a component. Although the deployment builder already omits `replicas` when `autoscaling` is configured, the operator performs full Deployment spec updates during reconciliation, and the Kubernetes API server defaults an omitted Deployment replica count back to `1`. As a result, the operator can continuously overwrite the replica count set by HPA, causing HPA-created pods to be immediately terminated. With this change, HPA remains responsible for scaling while the operator continues reconciling the rest of the Deployment spec.

Fixes #151

## Details

- Preserves the existing live `Deployment.spec.replicas` value when component `autoscaling` is enabled.
- Keeps `ForceReplicas` behavior unchanged for singleton-style components.
- Adds a regression test that simulates HPA scaling a Deployment above the CR/default replica value and verifies that a subsequent reconcile does not scale it back down.
- Validated with:

```console
go test ./internal/controller
```