### PR TITLE
docs(controller): clarify helper and builder patterns

### DIFF
--- a/docs/contributing/development-guidelines.md
+++ b/docs/contributing/development-guidelines.md
@@ -293,6 +293,7 @@ the `#`-comment form:
 - **Use `componentLabels(component, instance)`** for consistent label generation
 - **Stamp `parentLabels(parentName)` on all parent-owned resources** (ServiceAccount, Ingress, HTTPRoute, ServiceMonitor) — this enables label-based cleanup
 - **Use `controllerutil.CreateOrUpdate`** for idempotent reconciliation
+- **Keep spec builders pure**: `build*Spec` helpers should construct desired Kubernetes specs from resolved CR/operator inputs only, not from live Kubernetes objects. Preserve API-server allocated/defaulted fields, or fields owned by another controller, at the `CreateOrUpdate` boundary: build the desired spec, copy the live field when appropriate, then assign. Examples include Service `ClusterIP`/`HealthCheckNodePort` and Deployment `replicas` when HPA manages scaling.
 - **Set OwnerReferences** via `controllerutil.SetControllerReference`
 - **Record events** via `r.Recorder.Eventf()` for errors and state changes
 - **Add Go doc comments** to all exported types — they become CRD descriptions

--- a/docs/contributing/development-guidelines.md
+++ b/docs/contributing/development-guidelines.md
@@ -111,7 +111,7 @@ validation, CRD defaulting, multi-controller interaction).
 ### Test granularity
 
 - **Prefer broad happy-path tests** that cover critical assertions in a single test function. For example, one comprehensive test that creates all components and verifies config, env vars, and status is better than 10 separate tests each checking one field.
-- **Use granular tests only for complex utilities** with many edge cases (e.g., merge functions, backoff calculation, condition management). These benefit from table-driven tests covering boundary conditions.
+- **Use granular table tests for helpers with their own semantic contract** (e.g., merge functions, backoff calculation, condition management, field-preservation helpers). When a regression spans both reconciliation flow and helper semantics, pair one behavior-level happy-path test with a focused helper table. Keep simple glue covered through the behavior it supports.
 - **Every assertion should protect against a plausible regression.** If you can't name the scenario where removing it would let a bug through, it doesn't belong. Avoid adding narrow standalone tests when the assertion fits naturally in an existing comprehensive test.
 - **When fixing a regression, always add a test that would have caught it.** Regressions that broke silently indicate a gap in test coverage — close the gap as part of the fix.
 - **Use subtests (`t.Run`)** to group related scenarios within a single test function instead of creating separate top-level tests.
@@ -292,8 +292,7 @@ the `#`-comment form:
 - **Use shared helpers** from `component_reconciler.go` (`reconcileComponentDeployment`, `reconcileComponentService`, `reconcileScaling`, `buildChecksumAnnotations`). ConfigMaps are owned by the parent — use `reconcileParentOwnedConfigMap` from `superset_controller.go`.
 - **Use `componentLabels(component, instance)`** for consistent label generation
 - **Stamp `parentLabels(parentName)` on all parent-owned resources** (ServiceAccount, Ingress, HTTPRoute, ServiceMonitor) — this enables label-based cleanup
-- **Use `controllerutil.CreateOrUpdate`** for idempotent reconciliation
-- **Keep spec builders pure**: `build*Spec` helpers should construct desired Kubernetes specs from resolved CR/operator inputs only, not from live Kubernetes objects. Preserve API-server allocated/defaulted fields, or fields owned by another controller, at the `CreateOrUpdate` boundary: build the desired spec, copy the live field when appropriate, then assign. Examples include Service `ClusterIP`/`HealthCheckNodePort` and Deployment `replicas` when HPA manages scaling.
+- **Use `controllerutil.CreateOrUpdate` as the live-object boundary**: keep `build*Spec` helpers pure, build desired specs from resolved CR/operator inputs, then preserve API-server/defaulted or other-controller-owned fields before assignment. Examples include Service `ClusterIP`/`HealthCheckNodePort` and HPA-managed Deployment `replicas`.
 - **Set OwnerReferences** via `controllerutil.SetControllerReference`
 - **Record events** via `r.Recorder.Eventf()` for errors and state changes
 - **Add Go doc comments** to all exported types — they become CRD descriptions

--- a/internal/controller/component_descriptors_test.go
+++ b/internal/controller/component_descriptors_test.go
@@ -163,6 +163,56 @@ func TestWarnEnvVarOverrides(t *testing.T) {
 	})
 }
 
+func TestInjectCeleryCommand(t *testing.T) {
+	cmd := []string{"celery", "worker"}
+
+	t.Run("nil component is a no-op", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			injectCeleryCommand(nil, cmd)
+		})
+	})
+
+	t.Run("creates missing pod and container templates", func(t *testing.T) {
+		comp := &resolution.ComponentInput{}
+
+		injectCeleryCommand(comp, cmd)
+
+		require.NotNil(t, comp.PodTemplate)
+		require.NotNil(t, comp.PodTemplate.Container)
+		assert.Equal(t, cmd, comp.PodTemplate.Container.Command)
+	})
+
+	t.Run("creates missing container template", func(t *testing.T) {
+		comp := &resolution.ComponentInput{
+			SharedInput: resolution.SharedInput{
+				PodTemplate: &supersetv1alpha1.PodTemplate{},
+			},
+		}
+
+		injectCeleryCommand(comp, cmd)
+
+		require.NotNil(t, comp.PodTemplate.Container)
+		assert.Equal(t, cmd, comp.PodTemplate.Container.Command)
+	})
+
+	t.Run("preserves explicit command", func(t *testing.T) {
+		existing := []string{"custom", "worker"}
+		comp := &resolution.ComponentInput{
+			SharedInput: resolution.SharedInput{
+				PodTemplate: &supersetv1alpha1.PodTemplate{
+					Container: &supersetv1alpha1.ContainerTemplate{
+						Command: existing,
+					},
+				},
+			},
+		}
+
+		injectCeleryCommand(comp, cmd)
+
+		assert.Equal(t, existing, comp.PodTemplate.Container.Command)
+	})
+}
+
 func TestDeleteComponentResources(t *testing.T) {
 	scheme := testScheme(t)
 	superset := &supersetv1alpha1.Superset{

--- a/internal/controller/component_reconciler_test.go
+++ b/internal/controller/component_reconciler_test.go
@@ -36,24 +36,75 @@ import (
 	"github.com/apache/superset-kubernetes-operator/internal/common"
 )
 
-func TestPreserveServiceAllocatedFields_ExternalNameAndHealthCheck(t *testing.T) {
-	t.Run("preserves HealthCheckNodePort", func(t *testing.T) {
-		existing := corev1.ServiceSpec{HealthCheckNodePort: 31000}
-		desired := corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP}
-		preserveServiceAllocatedFields(&desired, existing)
-		assert.Equal(t, int32(31000), desired.HealthCheckNodePort)
-	})
+func TestPreserveServiceAllocatedFields(t *testing.T) {
+	t.Parallel()
 
-	t.Run("clears ClusterIP for ExternalName services", func(t *testing.T) {
-		existing := corev1.ServiceSpec{ClusterIP: "10.0.0.5", ClusterIPs: []string{"10.0.0.5"}}
-		desired := corev1.ServiceSpec{Type: corev1.ServiceTypeExternalName}
-		preserveServiceAllocatedFields(&desired, existing)
+	familyPolicy := corev1.IPFamilyPolicySingleStack
+	tests := []struct {
+		name     string
+		desired  corev1.ServiceSpec
+		existing corev1.ServiceSpec
+		want     corev1.ServiceSpec
+	}{
+		{
+			name: "preserves cluster allocation fields",
+			desired: corev1.ServiceSpec{
+				Type:  corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{{Port: 9090}},
+			},
+			existing: corev1.ServiceSpec{
+				ClusterIP:      "10.0.0.12",
+				ClusterIPs:     []string{"10.0.0.12"},
+				IPFamilies:     []corev1.IPFamily{corev1.IPv4Protocol},
+				IPFamilyPolicy: &familyPolicy,
+			},
+			want: corev1.ServiceSpec{
+				Type:           corev1.ServiceTypeClusterIP,
+				Ports:          []corev1.ServicePort{{Port: 9090}},
+				ClusterIP:      "10.0.0.12",
+				ClusterIPs:     []string{"10.0.0.12"},
+				IPFamilies:     []corev1.IPFamily{corev1.IPv4Protocol},
+				IPFamilyPolicy: &familyPolicy,
+			},
+		},
+		{
+			name: "preserves health check node port",
+			desired: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+			},
+			existing: corev1.ServiceSpec{
+				HealthCheckNodePort: 31000,
+			},
+			want: corev1.ServiceSpec{
+				Type:                corev1.ServiceTypeLoadBalancer,
+				HealthCheckNodePort: 31000,
+			},
+		},
+		{
+			name: "clears cluster allocation fields for ExternalName",
+			desired: corev1.ServiceSpec{
+				Type:         corev1.ServiceTypeExternalName,
+				ExternalName: "superset.example.com",
+			},
+			existing: corev1.ServiceSpec{
+				ClusterIP:      "10.0.0.5",
+				ClusterIPs:     []string{"10.0.0.5"},
+				IPFamilies:     []corev1.IPFamily{corev1.IPv4Protocol},
+				IPFamilyPolicy: &familyPolicy,
+			},
+			want: corev1.ServiceSpec{
+				Type:         corev1.ServiceTypeExternalName,
+				ExternalName: "superset.example.com",
+			},
+		},
+	}
 
-		assert.Empty(t, desired.ClusterIP)
-		assert.Nil(t, desired.ClusterIPs)
-		assert.Nil(t, desired.IPFamilies)
-		assert.Nil(t, desired.IPFamilyPolicy)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			preserveServiceAllocatedFields(&tt.desired, tt.existing)
+			assert.Equal(t, tt.want, tt.desired)
+		})
+	}
 }
 
 func TestReconcileComponentResources_NoServiceNoScaling(t *testing.T) {

--- a/internal/controller/deployment_builder_test.go
+++ b/internal/controller/deployment_builder_test.go
@@ -478,30 +478,3 @@ func TestBuildServiceSpec(t *testing.T) {
 		}
 	})
 }
-
-func TestPreserveServiceAllocatedFields(t *testing.T) {
-	familyPolicy := corev1.IPFamilyPolicySingleStack
-	desired := corev1.ServiceSpec{
-		Type:  corev1.ServiceTypeClusterIP,
-		Ports: []corev1.ServicePort{{Port: 9090}},
-	}
-	existing := corev1.ServiceSpec{
-		Type:           corev1.ServiceTypeClusterIP,
-		ClusterIP:      "10.0.0.12",
-		ClusterIPs:     []string{"10.0.0.12"},
-		IPFamilies:     []corev1.IPFamily{corev1.IPv4Protocol},
-		IPFamilyPolicy: &familyPolicy,
-	}
-
-	preserveServiceAllocatedFields(&desired, existing)
-
-	if desired.ClusterIP != existing.ClusterIP {
-		t.Errorf("expected ClusterIP to be preserved, got %q", desired.ClusterIP)
-	}
-	if len(desired.ClusterIPs) != 1 || desired.ClusterIPs[0] != "10.0.0.12" {
-		t.Errorf("expected ClusterIPs to be preserved, got %v", desired.ClusterIPs)
-	}
-	if desired.IPFamilyPolicy == nil || *desired.IPFamilyPolicy != familyPolicy {
-		t.Errorf("expected IPFamilyPolicy to be preserved, got %v", desired.IPFamilyPolicy)
-	}
-}


### PR DESCRIPTION
## Summary

Clarifies controller development guidance around spec builders, live Kubernetes state, and focused helper
  tests.

This codifies the pattern used by #152: keep builders pure, preserve live/defaulted fields at the `CreateOrUpdate` boundary, and pair a behavior-level regression test with a focused helper table when a helper has its own semantic contract.

## Details

- Documents `CreateOrUpdate` as the live-object boundary.
- Clarifies that `build*Spec` helpers should use resolved CR/operator inputs, not live Kubernetes objects.
- Updates test granularity guidance for semantic helpers.
- Consolidates `preserveServiceAllocatedFields` tests into a table.
- Adds focused coverage for `injectCeleryCommand`.