### PR TITLE
build(deps): track Makefile-pinned CLI tool versions with Renovate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
+# renovate: datasource=github-releases depName=operator-framework/operator-sdk
 OPERATOR_SDK_VERSION ?= v1.42.1
 # Image URL to use all building/pushing image targets
 IMG ?= ghcr.io/apache/superset-kubernetes-operator:latest
@@ -340,14 +341,19 @@ CRD_REF_DOCS = $(LOCALBIN)/crd-ref-docs
 GOVULNCHECK = $(LOCALBIN)/govulncheck
 
 ## Tool Versions
+# renovate: datasource=go depName=sigs.k8s.io/kustomize/kustomize/v5
 KUSTOMIZE_VERSION ?= v5.6.0
+# renovate: datasource=go depName=sigs.k8s.io/controller-tools
 CONTROLLER_TOOLS_VERSION ?= v0.20.1
 #ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
+# renovate: datasource=go depName=github.com/golangci/golangci-lint/v2
 GOLANGCI_LINT_VERSION ?= v2.1.0
+# renovate: datasource=go depName=github.com/elastic/crd-ref-docs
 CRD_REF_DOCS_VERSION ?= v0.3.0
+# renovate: datasource=go depName=golang.org/x/vuln
 GOVULNCHECK_VERSION ?= v1.3.0
 
 .PHONY: kustomize

--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,14 @@
         "// renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+curlImage = getEnvOrDefault\\(\\s+\"E2E_CURL_IMAGE\",\\s+\"\\S+:(?<currentValue>[^@\\\"]+)@(?<currentDigest>sha256:[a-f0-9]+)\""
       ],
       "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Track hand-pinned CLI tool versions in the Makefile",
+      "managerFilePatterns": ["/^Makefile$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\s+\\S+_VERSION \\?= (?<currentValue>\\S+)"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Operator SDK 1.42.3 (and .2) shipped but Renovate never opened a PR for it. The version is pinned as a bare Makefile variable (`OPERATOR_SDK_VERSION ?= v1.42.1`), and `operator-sdk` is a CLI binary fetched via `curl` rather than a `go.mod` dependency — so none of Renovate's built-in managers (gomod, dockerfile, GitHub Actions) ever inspect it. The dependency was simply invisible to Renovate.

The same gap affects every other hand-pinned CLI tool version in the Makefile (kustomize, controller-tools, golangci-lint, crd-ref-docs, govulncheck). This PR closes the whole gap using the annotation-driven `customManagers` pattern already established in `renovate.json` (for the kind pin and the e2e curl image), in line with the repo's "automate everything that can drift" principle.

## Details

- **`Makefile`** — added `# renovate:` annotation comments above the six tracked pins:
  - `OPERATOR_SDK_VERSION` → `datasource=github-releases`, `operator-framework/operator-sdk`
  - `KUSTOMIZE_VERSION`, `CONTROLLER_TOOLS_VERSION`, `GOLANGCI_LINT_VERSION`, `CRD_REF_DOCS_VERSION`, `GOVULNCHECK_VERSION` → `datasource=go` with their respective module paths.
- **`renovate.json`** — one generic regex `customManager` that reads the annotation format from the Makefile (covers all six pins).
- **Not tracked:** `ENVTEST_VERSION` and `ENVTEST_K8S_VERSION` are computed at runtime from `sigs.k8s.io/controller-runtime` / `k8s.io/api`, which Renovate already bumps via the gomod manager — they follow those modules automatically.