### PR TITLE
chore: bump golang to 1.26.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.26.4@sha256:f96cc555eb8db430159a3aa6797cd5bae561945b7b0fe7d0e284c63a3b291609 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5@sha256:63f132d58c1f589f0dcda584933a9bb44bfda1150f1506377f5a902f34d86033 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/apache/superset-kubernetes-operator
 
 go 1.26.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/onsi/ginkgo/v2 v2.32.0


### PR DESCRIPTION
## Summary

Bump Golang to 1.26.5 to unblock CI checks that flag 1.26.4 for CVEs.
