### PR TITLE
feat(helm): add extraManifests value with tpl support

### DIFF
--- a/charts/superset-operator/templates/extra-manifests.yaml
+++ b/charts/superset-operator/templates/extra-manifests.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- range .Values.extraObjects }}
+{{- range .Values.extraManifests }}
 ---
 {{- if typeIs "string" . }}
 {{ tpl . $ }}

--- a/charts/superset-operator/templates/extra-objects.yaml
+++ b/charts/superset-operator/templates/extra-objects.yaml
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- range .Values.extraObjects }}
+---
+{{- if typeIs "string" . }}
+{{ tpl . $ }}
+{{- else }}
+{{ tpl (toYaml .) $ }}
+{{- end }}
+{{- end }}

--- a/charts/superset-operator/values.schema.json
+++ b/charts/superset-operator/values.schema.json
@@ -102,6 +102,16 @@
           "items": { "type": "string" }
         }
       }
+    },
+    "extraObjects": {
+      "description": "Additional Kubernetes manifests rendered with the chart. Entries are YAML objects or strings; both are passed through tpl.",
+      "type": "array",
+      "items": {
+        "oneOf": [
+          { "type": "object" },
+          { "type": "string" }
+        ]
+      }
     }
   }
 }

--- a/charts/superset-operator/values.schema.json
+++ b/charts/superset-operator/values.schema.json
@@ -103,7 +103,7 @@
         }
       }
     },
-    "extraObjects": {
+    "extraManifests": {
       "description": "Additional Kubernetes manifests rendered with the chart. Entries are YAML objects or strings; both are passed through tpl.",
       "type": "array",
       "items": {

--- a/charts/superset-operator/values.yaml
+++ b/charts/superset-operator/values.yaml
@@ -127,3 +127,27 @@ podLabels: {}
 watch:
   scope: cluster
   namespaces: []
+
+# extraObjects renders additional Kubernetes manifests alongside the chart's
+# own resources. Each list entry is either a YAML object or a string; both
+# are passed through Helm's tpl function, so template expressions such as
+# {{ .Release.Namespace }} or {{ include "superset-operator.fullname" . }}
+# are resolved. Use strings when the manifest itself must contain literal
+# template syntax that only renders at install time.
+#
+# Example:
+#   extraObjects:
+#     - apiVersion: v1
+#       kind: ConfigMap
+#       metadata:
+#         name: '{{ include "superset-operator.fullname" . }}-extra'
+#       data:
+#         namespace: '{{ .Release.Namespace }}'
+#     - |
+#       apiVersion: v1
+#       kind: Secret
+#       metadata:
+#         name: {{ include "superset-operator.fullname" . }}-extra-secret
+#       stringData:
+#         key: value
+extraObjects: []

--- a/charts/superset-operator/values.yaml
+++ b/charts/superset-operator/values.yaml
@@ -128,15 +128,23 @@ watch:
   scope: cluster
   namespaces: []
 
-# extraObjects renders additional Kubernetes manifests alongside the chart's
+# extraManifests renders additional Kubernetes manifests alongside the chart's
 # own resources. Each list entry is either a YAML object or a string; both
 # are passed through Helm's tpl function, so template expressions such as
 # {{ .Release.Namespace }} or {{ include "superset-operator.fullname" . }}
 # are resolved. Use strings when the manifest itself must contain literal
 # template syntax that only renders at install time.
 #
+# Use it for trusted, release-scoped companion resources owned by the
+# operator release — e.g. a cert-manager Certificate backing
+# metrics.certSecretName, a NetworkPolicy for the manager pod, or an
+# ExternalSecret. Do not use it for shared cluster infrastructure such as
+# Gateway API controllers, CRDs, or shared Gateways: those have their own
+# lifecycle and should not be upgraded or garbage-collected with this
+# release.
+#
 # Example:
-#   extraObjects:
+#   extraManifests:
 #     - apiVersion: v1
 #       kind: ConfigMap
 #       metadata:
@@ -150,4 +158,4 @@ watch:
 #         name: {{ include "superset-operator.fullname" . }}-extra-secret
 #       stringData:
 #         key: value
-extraObjects: []
+extraManifests: []

--- a/docs/reference/releases.md
+++ b/docs/reference/releases.md
@@ -23,6 +23,10 @@ This page tracks notable changes in Apache Superset Kubernetes Operator releases
 
 ## Unreleased
 
+### Added
+
+- **Helm extra manifests.** The Helm chart now supports `extraManifests` for rendering trusted, release-scoped Kubernetes manifests with Helm `tpl`. Use it for companion resources owned by the operator release, not shared cluster infrastructure such as Gateway API controllers, CRDs, or shared Gateways ([#196](https://github.com/apache/superset-kubernetes-operator/pull/196), [@younsl](https://github.com/younsl)).
+
 ### Changed
 
 - **Breaking:** renamed the "version" status fields to "tag". `status.version` → `status.tag` (the `kubectl get` column is renamed **Version** → **Tag**), and `status.lifecycle.upgrade.fromVersion`/`toVersion` → `fromTag`/`toTag`. No behavior change.

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -66,6 +66,10 @@ helm install superset-operator \
 
 See `charts/superset-operator/values.yaml` for all available Helm values and [Downloads](../reference/downloads.md) for published images and tag conventions.
 
+### Extra manifests
+
+The chart's `extraManifests` value renders additional Kubernetes manifests as part of the release. Each entry is passed through Helm's [`tpl` function](https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function), so template expressions like `{{ .Release.Namespace }}` resolve at install time. Use it for trusted, release-scoped companion resources owned by the operator release — a cert-manager `Certificate` backing `metrics.certSecretName`, a `NetworkPolicy` for the manager pod, or an `ExternalSecret`. Do not use it for shared cluster infrastructure such as Gateway API controllers, CRDs, or shared Gateways — those have their own lifecycle and should not be upgraded or garbage-collected with this release. See the `extraManifests` examples in `charts/superset-operator/values.yaml` for both entry forms (YAML objects and raw strings).
+
 ### Namespace-scoped install
 
 By default the operator installs cluster-scoped (watches all namespaces and binds a `ClusterRole`). For restricted clusters that forbid cluster-scoped RBAC, or for single-tenant hardening, switch to namespace-scoped mode.


### PR DESCRIPTION
## Summary

This PR adds an extraManifests list to the Helm chart that renders arbitrary additional Kubernetes manifests alongside the chart's own resources. Operators commonly need small companion objects deployed together with the operator — a cert-manager Certificate backing metrics.certSecretName, a NetworkPolicy for the manager pod, or an ExternalSecret — and today that requires either a separate wrapper chart or a manual kubectl apply step outside the Helm release. With extraManifests, those manifests live in the same release and are upgraded and garbage-collected with it. Every entry is passed through Helm's [tpl function](https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function), so template expressions such as {{ .Release.Namespace }} and {{ include "superset-operator.fullname" . }} resolve at install time.

The value is intended for trusted, release-scoped companion resources owned by the operator release — not shared cluster infrastructure such as Gateway API controllers, CRDs, or shared Gateways, which have their own lifecycle. This guidance is documented next to the examples in values.yaml and in the installation guide.

Requests like apache/superset#41073 (adding a dedicated Gateway API HTTPRoute template to the Superset application chart) illustrate the recurring demand for shipping companion resources with a release; an extraManifests escape hatch covers such needs for this chart without requiring a dedicated template and review cycle for each resource type.

This mirrors the extraObjects/extraManifests convention established by widely used community charts:

- [argo-cd](https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/values.yaml) (extraObjects)
- [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml) (extraManifests)
- [traefik](https://github.com/traefik/traefik-helm-chart/blob/master/traefik/values.yaml) (extraObjects)
- [velero](https://github.com/vmware-tanzu/helm-charts/blob/main/charts/velero/values.yaml) (extraObjects)
- [external-secrets](https://github.com/external-secrets/external-secrets/blob/main/deploy/charts/external-secrets/values.yaml) (extraObjects)

## Details

- templates/extra-manifests.yaml iterates .Values.extraManifests. Entries may be YAML objects (rendered via toYaml then tpl) or raw strings (passed to tpl directly, for manifests that must carry literal template syntax).
- values.yaml documents both entry forms with examples, plus a note on when extraManifests is and is not appropriate; docs/user-guide/installation.md gains a matching "Extra manifests" section.
- values.schema.json gains a matching extraManifests entry (array of object-or-string). Required because the schema declares additionalProperties: false — without it, setting the value fails installation.
- docs/reference/releases.md gains an "Added" entry under "Unreleased".
- No Chart.yaml version bump: the chart version stays 0.0.0-dev on main and is stamped by scripts/release-rc.sh at release time, consistent with prior chart changes.
- Verified with make helm-lint and helm template for the object form, the string form, and the empty default.
