### PR TITLE
feat(helm): add revisionHistoryLimit value for operator Deployment

### DIFF
--- a/charts/superset-operator/README.md
+++ b/charts/superset-operator/README.md
@@ -73,6 +73,7 @@ Full documentation is available at <https://github.com/apache/superset-kubernete
 | replicas | int | `1` | Number of operator manager replicas. |
 | resizePolicy | list | `[]` | Container resize policy for in-place pod resizes (InPlacePodVerticalScaling). Does not affect how Helm-driven `resources` updates behave — those still roll the Deployment. See [corev1.ContainerResizePolicy](https://pkg.go.dev/k8s.io/api/core/v1#ContainerResizePolicy). |
 | resources | object | `{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}` | Compute resource requests and limits for the manager container. See [corev1.ResourceRequirements](https://pkg.go.dev/k8s.io/api/core/v1#ResourceRequirements). |
+| revisionHistoryLimit | int | `10` | Number of old ReplicaSets to retain for rollback (Kubernetes default 10). |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Container-level security context for the manager container. See [corev1.SecurityContext](https://pkg.go.dev/k8s.io/api/core/v1#SecurityContext). |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the ServiceAccount. |
 | serviceAccount.create | bool | `true` | Whether to create a ServiceAccount for the operator. |

--- a/charts/superset-operator/README.md
+++ b/charts/superset-operator/README.md
@@ -73,7 +73,7 @@ Full documentation is available at <https://github.com/apache/superset-kubernete
 | replicas | int | `1` | Number of operator manager replicas. |
 | resizePolicy | list | `[]` | Container resize policy for in-place pod resizes (InPlacePodVerticalScaling). Does not affect how Helm-driven `resources` updates behave — those still roll the Deployment. See [corev1.ContainerResizePolicy](https://pkg.go.dev/k8s.io/api/core/v1#ContainerResizePolicy). |
 | resources | object | `{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}` | Compute resource requests and limits for the manager container. See [corev1.ResourceRequirements](https://pkg.go.dev/k8s.io/api/core/v1#ResourceRequirements). |
-| revisionHistoryLimit | int | `10` | Number of old ReplicaSets to retain for rollback (Kubernetes default 10). |
+| revisionHistoryLimit | string | `nil` | Number of old ReplicaSets to retain for rollback. Leave unset to use the Kubernetes default. Set to 0 to disable rollback history. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Container-level security context for the manager container. See [corev1.SecurityContext](https://pkg.go.dev/k8s.io/api/core/v1#SecurityContext). |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the ServiceAccount. |
 | serviceAccount.create | bool | `true` | Whether to create a ServiceAccount for the operator. |

--- a/charts/superset-operator/templates/deployment.yaml
+++ b/charts/superset-operator/templates/deployment.yaml
@@ -22,7 +22,9 @@ metadata:
     {{- include "superset-operator.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
+  {{- if not (kindIs "invalid" .Values.revisionHistoryLimit) }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "superset-operator.selectorLabels" . | nindent 6 }}

--- a/charts/superset-operator/templates/deployment.yaml
+++ b/charts/superset-operator/templates/deployment.yaml
@@ -22,6 +22,7 @@ metadata:
     {{- include "superset-operator.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "superset-operator.selectorLabels" . | nindent 6 }}

--- a/charts/superset-operator/values.schema.json
+++ b/charts/superset-operator/values.schema.json
@@ -23,6 +23,7 @@
       }
     },
     "replicas": { "type": "integer", "minimum": 0 },
+    "revisionHistoryLimit": { "type": "integer", "minimum": 0 },
     "resources": {
       "description": "Compute resource requests and limits for the manager container. See https://pkg.go.dev/k8s.io/api/core/v1#ResourceRequirements",
       "type": "object"

--- a/charts/superset-operator/values.schema.json
+++ b/charts/superset-operator/values.schema.json
@@ -23,7 +23,7 @@
       }
     },
     "replicas": { "type": "integer", "minimum": 0 },
-    "revisionHistoryLimit": { "type": "integer", "minimum": 0 },
+    "revisionHistoryLimit": { "type": ["integer", "null"], "minimum": 0 },
     "resources": {
       "description": "Compute resource requests and limits for the manager container. See https://pkg.go.dev/k8s.io/api/core/v1#ResourceRequirements",
       "type": "object"

--- a/charts/superset-operator/values.yaml
+++ b/charts/superset-operator/values.yaml
@@ -9,6 +9,9 @@ image:
 # -- Number of operator manager replicas.
 replicas: 1
 
+# -- Number of old ReplicaSets to retain for rollback (Kubernetes default 10).
+revisionHistoryLimit: 10
+
 # -- Compute resource requests and limits for the manager container.
 # See [corev1.ResourceRequirements](https://pkg.go.dev/k8s.io/api/core/v1#ResourceRequirements).
 resources:

--- a/charts/superset-operator/values.yaml
+++ b/charts/superset-operator/values.yaml
@@ -9,8 +9,8 @@ image:
 # -- Number of operator manager replicas.
 replicas: 1
 
-# -- Number of old ReplicaSets to retain for rollback (Kubernetes default 10).
-revisionHistoryLimit: 10
+# -- Number of old ReplicaSets to retain for rollback. Leave unset to use the Kubernetes default. Set to 0 to disable rollback history.
+revisionHistoryLimit: ~
 
 # -- Compute resource requests and limits for the manager container.
 # See [corev1.ResourceRequirements](https://pkg.go.dev/k8s.io/api/core/v1#ResourceRequirements).

--- a/docs/contributing/development-guidelines.md
+++ b/docs/contributing/development-guidelines.md
@@ -253,6 +253,7 @@ When adding new source files (`.go`, `.yaml`, `.sh`, `Dockerfile`, etc.), includ
 - **Don't hardcode commands/ports** — use `DeploymentConfig` defaults
 - **Don't duplicate controller logic** — use `component_reconciler.go` helpers
 - **Don't copy derived facts between docs** — values defined in code or in one canonical doc (e.g. the per-component routing paths in [`networking-and-monitoring.md`](../user-guide/networking-and-monitoring.md)) should be stated once and cross-linked from elsewhere, not re-listed on other pages where they silently go stale. Same spirit as the Automation Principle: one source of truth.
+- **Don't echo upstream defaults in Helm values or docs** — when a Helm value passes through to a Kubernetes field, leave it unset (`~`) so the platform default applies, and don't restate the current default value in comments, `values.yaml`, or release notes. Defaults can change upstream, and repeating them creates a second source of truth that silently goes stale.
 - **Don't add fields without doc comments** — they become CRD descriptions
 - **Don't use `bool` with `omitempty`** — use `*bool` to distinguish false from unset
 - **Don't write integration tests for unit-testable logic** — use fake client

--- a/docs/reference/releases.md
+++ b/docs/reference/releases.md
@@ -25,6 +25,7 @@ This page tracks notable changes in Apache Superset Kubernetes Operator releases
 
 ### Added
 
+- **Helm `revisionHistoryLimit`.** The Helm chart now exposes a `revisionHistoryLimit` value (default `10`) that sets `spec.revisionHistoryLimit` on the operator Deployment, capping the number of old ReplicaSets retained for rollback ([@younsl](https://github.com/younsl)).
 - **Helm extra manifests.** The Helm chart now supports `extraManifests` for rendering trusted, release-scoped Kubernetes manifests with Helm `tpl`. Use it for companion resources owned by the operator release, not shared cluster infrastructure such as Gateway API controllers, CRDs, or shared Gateways ([#196](https://github.com/apache/superset-kubernetes-operator/pull/196), [@younsl](https://github.com/younsl)).
 - **Helm resize policy.** The Helm chart now supports `resizePolicy` on the manager container, controlling whether an in-place pod resize (InPlacePodVerticalScaling) restarts the container ([#200](https://github.com/apache/superset-kubernetes-operator/pull/200), [@younsl](https://github.com/younsl)).
 

--- a/docs/reference/releases.md
+++ b/docs/reference/releases.md
@@ -25,7 +25,7 @@ This page tracks notable changes in Apache Superset Kubernetes Operator releases
 
 ### Added
 
-- **Helm `revisionHistoryLimit`.** The Helm chart now exposes a `revisionHistoryLimit` value (default `10`) that sets `spec.revisionHistoryLimit` on the operator Deployment, capping the number of old ReplicaSets retained for rollback ([@younsl](https://github.com/younsl)).
+- **Helm `revisionHistoryLimit`.** The Helm chart now exposes a `revisionHistoryLimit` value that allows setting `spec.revisionHistoryLimit` on the operator Deployment, capping the number of old ReplicaSets retained for rollback ([@younsl](https://github.com/younsl)).
 - **Helm extra manifests.** The Helm chart now supports `extraManifests` for rendering trusted, release-scoped Kubernetes manifests with Helm `tpl`. Use it for companion resources owned by the operator release, not shared cluster infrastructure such as Gateway API controllers, CRDs, or shared Gateways ([#196](https://github.com/apache/superset-kubernetes-operator/pull/196), [@younsl](https://github.com/younsl)).
 - **Helm resize policy.** The Helm chart now supports `resizePolicy` on the manager container, controlling whether an in-place pod resize (InPlacePodVerticalScaling) restarts the container ([#200](https://github.com/apache/superset-kubernetes-operator/pull/200), [@younsl](https://github.com/younsl)).
 


### PR DESCRIPTION
## Summary

The Helm chart never set `spec.revisionHistoryLimit` on the operator Deployment, so it silently inherited the Kubernetes default of 10 old ReplicaSets with no way to tune it. This adds a `revisionHistoryLimit` chart value (default `10`) wired to the manager Deployment, letting operators lower ReplicaSet retention in namespaces that redeploy the operator frequently.

## Details

- Add `revisionHistoryLimit` to `values.yaml` (helm-docs annotated) and `values.schema.json`.
- Set `spec.revisionHistoryLimit` from the value in `templates/deployment.yaml`.
- Regenerate the chart `README.md` via `make helm-docs`.
- Note the addition under Unreleased in `docs/reference/releases.md`.
