### PR TITLE
ci: annotate image index metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,11 +52,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels)
+      - name: Extract metadata (tags, labels, annotations)
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/apache/superset-kubernetes-operator
+            org.opencontainers.image.description=Kubernetes operator for deploying and managing Apache Superset
+            org.opencontainers.image.licenses=Apache-2.0
+          annotations: |
+            org.opencontainers.image.source=https://github.com/apache/superset-kubernetes-operator
+            org.opencontainers.image.description=Kubernetes operator for deploying and managing Apache Superset
+            org.opencontainers.image.licenses=Apache-2.0
           tags: |
             # On every build (main + tags): full commit SHA, immutably pinnable
             type=sha,prefix=sha-,format=long
@@ -66,6 +74,8 @@ jobs:
             type=semver,pattern={{version}}
             # On non-prerelease tag push: latest
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
 
       - name: Build and push
         id: build-push
@@ -76,6 +86,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           sbom: true
           provenance: mode=max
           cache-from: type=gha


### PR DESCRIPTION
## Summary

Adds explicit OCI metadata for the published operator image so GHCR can display a package description, license, and source information for the multi-arch image.

## Details

The release workflow now emits OCI labels and annotations from `docker/metadata-action`, including `org.opencontainers.image.description`, and passes the generated annotations into `docker/build-push-action`. Annotations are written at both manifest and image-index levels so GHCR can read them for the multi-arch image.