### PR TITLE
chore: add Artifact Hub repository ID

### DIFF
--- a/charts/superset-operator/artifacthub-repo.yml
+++ b/charts/superset-operator/artifacthub-repo.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+repositoryID: fcfdbf05-a72d-4e1a-934e-d5257c56f9f9
 owners:
   - name: Apache Superset
     email: dev@superset.apache.org


### PR DESCRIPTION
## Summary

Adds the Artifact Hub repository ID to the Helm chart repository metadata.

## Details

Artifact Hub uses `repositoryID` in `artifacthub-repo.yml` to verify that the publisher controls the repository. This adds the ID generated when the GHCR OCI Helm repository was added to Artifact Hub.