### PR TITLE
ci: relax PR title scopes

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -44,15 +44,5 @@ jobs:
             style
             test
           requireScope: false
-          scopes: |
-            api
-            controller
-            lifecycle
-            resolution
-            config
-            helm
-            ci
-            docs
-            deps
           subjectPattern: ^.+$
           subjectPatternError: "PR title must have a description after the type prefix."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,10 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           sed -i "s/^version:.*/version: ${VERSION}/" charts/superset-operator/Chart.yaml
           sed -i "s/^appVersion:.*/appVersion: \"${VERSION}\"/" charts/superset-operator/Chart.yaml
+          sed -i '/^[[:space:]]*artifacthub.io\/prerelease:/d' charts/superset-operator/Chart.yaml
+          if [[ "${VERSION}" =~ -rc[0-9]+$ ]]; then
+            sed -i '/artifacthub.io\/license:/a\  artifacthub.io/prerelease: "true"' charts/superset-operator/Chart.yaml
+          fi
 
       - name: Package Helm chart
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,8 +161,8 @@ The bar: every new "remember to also update X when Y changes" instruction is a b
 
 ## PR Conventions
 
-- **Title format**: `type(scope): description` or `type: description` — enforced by CI (`amannn/action-semantic-pull-request`). Scope is optional but encouraged. Aim for 50 characters when practical, and avoid exceeding 72 characters because GitHub wraps longer titles in common views.
-- **Allowed types and scopes**: defined canonically in [`.github/workflows/pr.yaml`](.github/workflows/pr.yaml) (the `types`/`scopes` inputs to the semantic-PR action) and enforced by CI — consult that file rather than copying the lists here, where they would silently go stale. Types follow the conventional-commit set; scopes name the affected area of the codebase.
+- **Title format**: `type(scope): description` or `type: description` — enforced by CI (`amannn/action-semantic-pull-request`). Scope is optional but encouraged; any scope is accepted, but short repository-area scopes are preferred. Aim for 50 characters when practical, and avoid exceeding 72 characters because GitHub wraps longer titles in common views.
+- **Allowed types**: defined canonically in [`.github/workflows/pr.yaml`](.github/workflows/pr.yaml) (the `types` input to the semantic-PR action) and enforced by CI — consult that file rather than copying the list here, where it would silently go stale. Types follow the conventional-commit set.
 - **Description**: Every PR must have a Summary section with at least one paragraph explaining what and why. Use the Details section for implementation notes. PR template pre-fills these sections.
 - **Code coverage**: Codecov reports patch coverage and project delta on every PR (informational, no enforced targets).
 

--- a/docs/contributing/development-guidelines.md
+++ b/docs/contributing/development-guidelines.md
@@ -403,7 +403,7 @@ type(scope): description
 type: description
 ```
 
-Scope is optional but encouraged when the change is scoped to a single area. Keep titles concise: aim for 50 characters when practical, and avoid exceeding 72 characters because GitHub wraps longer titles in common views.
+Scope is optional but encouraged when the change is scoped to a single area. Any scope is accepted, but prefer short, recognizable repository areas such as `api`, `controller`, `helm`, `ci`, `docs`, or `deps`. Keep titles concise: aim for 50 characters when practical, and avoid exceeding 72 characters because GitHub wraps longer titles in common views.
 
 CI validates this on every PR via the `PR / Validate PR title` check.
 
@@ -422,19 +422,6 @@ CI validates this on every PR via the `PR / Validate PR title` check.
 | `perf` | Performance improvements |
 | `style` | Formatting, whitespace, linting |
 | `revert` | Reverting a previous commit |
-
-**Allowed scopes:**
-
-| Scope | Covers |
-|-------|--------|
-| `api` | CRD type definitions (`api/v1alpha1/`) |
-| `controller` | Reconciler logic (`internal/controller/`) |
-| `resolution` | Spec resolution/merge engine (`internal/resolution/`) |
-| `config` | Config rendering (`internal/config/`) |
-| `helm` | Helm chart (`charts/`) |
-| `ci` | CI workflows, tooling (`.github/`, `Makefile`) |
-| `docs` | Documentation (`docs/`) |
-| `deps` | Dependency updates |
 
 **Examples:**
 


### PR DESCRIPTION
## Summary

Relaxes PR title scope validation and marks RC Helm charts as prereleases for Artifact Hub.

## Details

The semantic PR title check still enforces the allowed conventional-commit types and requires a non-empty subject, but it no longer restricts scopes to a fixed allowlist. This avoids valid titles such as `ci(release): ...` failing only because the scope was not predeclared.

The release workflow also now adds `artifacthub.io/prerelease: "true"` to the packaged chart metadata for RC tags matching `-rcN`, so future release candidates are shown correctly as prereleases in Artifact Hub.

Docs and `AGENTS.md` were updated to remove the stale allowed-scope guidance.

## Testing

- YAML parse check for `.github/workflows/pr.yaml` and `.github/workflows/release.yml`
- `git diff --check`
- Simulated chart metadata mutation for RC/final/non-RC suffix versions
- `scripts/validate-actions.sh`
- Commit hook: `golangci-lint run`