### PR TITLE
chore: temporarily disable Helm lint requirement

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -62,7 +62,6 @@ github:
           - Verify codegen
           - Verify supported-versions table
           - Docker build
-          - Helm lint
           - Unit & Integration
           - Apache Rat
       required_signatures: false


### PR DESCRIPTION
## Summary

Temporarily disable "Helm lint" requirement to unblock #217
