### PR TITLE
fix(ci): stop Renovate corrupting helm/yq tool checksums

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,6 +139,8 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
+      - name: Verify Helm checksum pin
+        run: make verify-helm-checksum
       - name: Install Helm
         run: bash scripts/install-helm.sh
       - name: Install helm-unittest plugin

--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,14 @@ verify-supported-versions: ## Verify supported-k8s.json matches the pinned kind 
 		exit 1; \
 	fi
 
+.PHONY: sync-helm-checksum
+sync-helm-checksum: ## Sync the pinned Helm tarball SHA-256 in install-helm.sh with the published checksum for HELM_VERSION.
+	./scripts/sync-helm-checksum.sh --write
+
+.PHONY: verify-helm-checksum
+verify-helm-checksum: ## Verify install-helm.sh pins the correct Helm tarball SHA-256 for its HELM_VERSION.
+	./scripts/sync-helm-checksum.sh --check
+
 ##@ Helm
 
 HELM_CHART_DIR ?= charts/superset-operator

--- a/docs/contributing/development-setup.md
+++ b/docs/contributing/development-setup.md
@@ -149,6 +149,8 @@ kind delete cluster --name superset
 | `make make-commands` | Regenerate the make-commands tables in the contributing docs. |
 | `make sync-supported-versions` | Sync .github/supported-k8s.json with the pinned kind release's node images. |
 | `make verify-supported-versions` | Verify supported-k8s.json matches the pinned kind release and docs are up to date. |
+| `make sync-helm-checksum` | Sync the pinned Helm tarball SHA-256 in install-helm.sh with the published checksum for HELM_VERSION. |
+| `make verify-helm-checksum` | Verify install-helm.sh pins the correct Helm tarball SHA-256 for its HELM_VERSION. |
 
 ### Helm
 

--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,15 @@
         "config/manager/manager.yaml"
       ],
       "enabled": false
+    },
+    {
+      "description": "Helm publishes tarballs (and their checksums) on get.helm.sh, not as GitHub release attachments, so Renovate can only bump the version — the pinned SHA-256 must be resynced separately.",
+      "matchDepNames": ["helm/helm"],
+      "matchFileNames": ["scripts/install-helm.sh"],
+      "addLabels": ["review:helm-checksum"],
+      "prBodyNotes": [
+        ":warning: After bumping Helm, run `make sync-helm-checksum` and commit the result to update the pinned `HELM_SHA256` in `scripts/install-helm.sh`. The `Verify helm checksum` CI check will fail until this is done."
+      ]
     }
   ],
   "customManagers": [
@@ -61,10 +70,22 @@
     },
     {
       "customType": "regex",
-      "description": "Track hand-pinned GitHub release helper binaries in install scripts",
-      "managerFilePatterns": ["/^scripts\\/install-[a-z0-9-]+\\.sh$/"],
+      "description": "Track hand-pinned GitHub release-attachment helper binaries in install scripts (version + SHA-256 of the attachment, computed by Renovate)",
+      "managerFilePatterns": [
+        "/^scripts\\/install-yq\\.sh$/",
+        "/^scripts\\/install-oras\\.sh$/"
+      ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\s+\\S+_VERSION=\"\\$\\{\\S+_VERSION:-(?<currentValue>[^\\\"]+)\\}\"[\\s\\S]*?\\S+_SHA256=\"\\$\\{\\S+_SHA256:-(?<currentDigest>[a-f0-9]+)\\}\""
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Track the version-only Helm pin in install-helm.sh (tarballs live on get.helm.sh, not GitHub; the checksum is resynced via `make sync-helm-checksum`)",
+      "managerFilePatterns": ["/^scripts\\/install-helm\\.sh$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\s+\\S+_VERSION=\"\\$\\{\\S+_VERSION:-(?<currentValue>[^\\\"]+)\\}\""
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"
     },

--- a/scripts/install-yq.sh
+++ b/scripts/install-yq.sh
@@ -20,7 +20,7 @@
 
 set -euo pipefail
 
-# renovate: datasource=github-releases depName=mikefarah/yq
+# renovate: datasource=github-release-attachments depName=mikefarah/yq
 YQ_VERSION="${YQ_VERSION:-v4.53.3}"
 YQ_SHA256="${YQ_SHA256:-fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4}"
 YQ_PLATFORM="${YQ_PLATFORM:-linux_amd64}"

--- a/scripts/sync-helm-checksum.sh
+++ b/scripts/sync-helm-checksum.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Sync the Helm tarball SHA-256 pinned in scripts/install-helm.sh with the
+# checksum that Helm publishes for the pinned HELM_VERSION / HELM_PLATFORM.
+#
+# Helm does not attach its release tarballs to GitHub releases (only detached
+# signatures live there); the tarballs and their checksums are served from
+# get.helm.sh. Renovate therefore tracks only HELM_VERSION, and this script
+# keeps HELM_SHA256 in sync — mirroring scripts/sync-supported-versions.sh.
+#
+# Usage:
+#   sync-helm-checksum.sh [--check|--write]
+#
+# --check (default): exit non-zero with a diff if the pinned SHA is out of sync.
+# --write:           rewrite the SHA in scripts/install-helm.sh in place.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/install-helm.sh"
+
+mode="${1:---check}"
+case "${mode}" in --check|--write) ;; *) echo "usage: $0 [--check|--write]" >&2; exit 2 ;; esac
+
+command -v curl >/dev/null || { echo "curl required" >&2; exit 1; }
+
+# Read the shell defaults out of install-helm.sh (VAR="${VAR:-default}").
+read_default() {
+  sed -nE "s/^$1=\"\\\$\{$1:-([^}]*)\}\"$/\1/p" "${SCRIPT}" | head -n1
+}
+
+HELM_VERSION="$(read_default HELM_VERSION)"
+HELM_PLATFORM="$(read_default HELM_PLATFORM)"
+CURRENT_SHA="$(read_default HELM_SHA256)"
+[ -n "${HELM_VERSION}" ]  || { echo "could not read HELM_VERSION from ${SCRIPT}" >&2; exit 1; }
+[ -n "${HELM_PLATFORM}" ] || { echo "could not read HELM_PLATFORM from ${SCRIPT}" >&2; exit 1; }
+
+# get.helm.sh publishes "<sha>  <filename>" alongside each tarball. awk pulls the
+# first field, which also handles a bare-hash ".sha256" file if the suffix moves.
+sha_url="https://get.helm.sh/helm-${HELM_VERSION}-${HELM_PLATFORM}.tar.gz.sha256sum"
+NEW_SHA="$(curl -fsSL "${sha_url}" | awk '{print $1; exit}')"
+printf '%s' "${NEW_SHA}" | grep -Eq '^[a-f0-9]{64}$' \
+  || { echo "unexpected checksum content from ${sha_url}: ${NEW_SHA}" >&2; exit 1; }
+
+case "${mode}" in
+  --write)
+    if [ "${CURRENT_SHA}" = "${NEW_SHA}" ]; then
+      echo "install-helm.sh already pins the correct SHA-256 for Helm ${HELM_VERSION}"
+    else
+      sed -i.bak -E "s|^(HELM_SHA256=\"\\\$\{HELM_SHA256:-)[a-f0-9]*(\}\")|\1${NEW_SHA}\2|" "${SCRIPT}"
+      rm -f "${SCRIPT}.bak"
+      echo "updated HELM_SHA256 to ${NEW_SHA} for Helm ${HELM_VERSION}"
+    fi
+    ;;
+  --check)
+    if [ "${CURRENT_SHA}" != "${NEW_SHA}" ]; then
+      echo "install-helm.sh HELM_SHA256 is out of sync with Helm ${HELM_VERSION} (${HELM_PLATFORM})." >&2
+      echo "  pinned:    ${CURRENT_SHA}" >&2
+      echo "  published: ${NEW_SHA}" >&2
+      echo "Run 'make sync-helm-checksum' to update." >&2
+      exit 1
+    fi
+    ;;
+esac


### PR DESCRIPTION
## Summary

Renovate PRs #228 (helm) and #229 (yq) fail the **Helm lint & test** CI job because they corrupt the pinned checksums. The install-script custom manager in `renovate.json` captured the `_SHA256=` value as `currentDigest`. For the `github-releases` datasource, a "digest" is the **git commit SHA of the release tag** (40 hex chars) — not the release asset's SHA-256 (64 hex chars). So Renovate happily rewrote real checksums into git commit SHAs (`e9b88b4…` → `43e8b7f…` for helm, `fa52a4e…` → `1b9b4ac…` for yq), and the subsequent `sha256sum -c` in `install-*.sh` fails.

This PR fixes the root cause. The correct approach differs per tool because their assets live in different places:

- **yq** attaches the exact downloaded asset (`yq_linux_amd64`) to its GitHub release, so its `# renovate:` comment now uses the `github-release-attachments` datasource — the same one `install-oras.sh` already uses correctly — which downloads-and-hashes the attachment. The custom manager passes `datasource` through, and the committed `YQ_SHA256` is already the correct attachment digest, so nothing else changes for yq.
- **oras** was already correct — no change.
- **helm** does *not* attach tarballs to GitHub (only detached `.asc`/`.sha256sum.asc` signatures); the tarballs and their checksums live on `get.helm.sh`. Renovate cannot compute that checksum, so helm is now tracked **version-only**, and `HELM_SHA256` is kept in sync by a CI-enforced script.

Once this lands, Renovate re-evaluates cleanly, so #228 and #229 will be closed as superseded.

## Details

- **`renovate.json`** — split the single install-script custom manager into an attachment-digest manager (`install-yq.sh`, `install-oras.sh`, keeps `currentDigest`) and a version-only manager (`install-helm.sh`, no digest capture). Added a `helm/helm` packageRule with a `prBodyNotes` reminder to run `make sync-helm-checksum` after a bump, mirroring the existing `kubernetes-sigs/kind` rule.
- **`scripts/install-yq.sh`** — `datasource=github-releases` → `datasource=github-release-attachments`.
- **`scripts/sync-helm-checksum.sh`** (new) — reads `HELM_VERSION`/`HELM_PLATFORM` from `install-helm.sh`, fetches the published checksum from `get.helm.sh`, and rewrites `HELM_SHA256`. `--check` (default) / `--write` modes, mirroring `scripts/sync-supported-versions.sh`.
- **`Makefile`** — `sync-helm-checksum` / `verify-helm-checksum` targets.
- **`.github/workflows/ci.yaml`** — a `Verify Helm checksum pin` step in the `helm-lint` job makes drift a hard failure.
- **`docs/contributing/development-setup.md`** — regenerated make-commands table (`make make-commands`).

Verified locally: `renovate-config-validator` passes, the sync-script extraction/rewrite logic and `shellcheck` are clean, and the published `get.helm.sh` `.sha256sum` matches the committed SHA.