### PR TITLE
fix(controller): gate resource adoption and cleanup on ownership

### DIFF
--- a/internal/controller/component_descriptors.go
+++ b/internal/controller/component_descriptors.go
@@ -333,7 +333,7 @@ func (r *SupersetReconciler) deleteComponentResources(ctx context.Context, super
 	deleteNamed := func(obj client.Object) error {
 		obj.SetName(resourceBaseName)
 		obj.SetNamespace(superset.Namespace)
-		return client.IgnoreNotFound(r.Delete(ctx, obj))
+		return deleteIfNotForeignOwned(ctx, r.Client, superset, obj)
 	}
 
 	if err := deleteNamed(&appsv1.Deployment{}); err != nil {

--- a/internal/controller/drain.go
+++ b/internal/controller/drain.go
@@ -165,7 +165,7 @@ func (r *SupersetReconciler) drainComponents(ctx context.Context, superset *supe
 		deleteNamed := func(obj client.Object) error {
 			obj.SetName(resourceBaseName)
 			obj.SetNamespace(superset.Namespace)
-			return client.IgnoreNotFound(r.Delete(ctx, obj))
+			return deleteIfNotForeignOwned(ctx, r.Client, superset, obj)
 		}
 		if err := deleteNamed(&appsv1.Deployment{}); err != nil {
 			return false, fmt.Errorf("deleting Deployment for drain %s: %w", desc.componentType, err)

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -21,9 +21,11 @@ package controller
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/apache/superset-kubernetes-operator/internal/common"
 	"github.com/apache/superset-kubernetes-operator/internal/resolution"
@@ -53,6 +55,33 @@ func createOrUpdateWithRetry(
 		return innerErr
 	})
 	return op, err
+}
+
+// deleteIfNotForeignOwned deletes the object whose name/namespace are already
+// populated on obj, unless the live object is controller-owned by an owner
+// other than the given parent Superset CR. Cleanup paths derive resource names
+// purely from the CR name, so a resource that belongs to another controller
+// can collide with a managed name; deleting it would turn the operator's
+// namespace-wide delete RBAC into a deletion oracle for resources the CR
+// author holds no permissions over. Per the documented adoption/cleanup
+// semantics (docs/reference/security.md, "Managed resource adoption and
+// cleanup"), only resources owned by this CR or unowned resources at a managed
+// name may be deleted. A missing object is not an error.
+func deleteIfNotForeignOwned(ctx context.Context, c client.Client, owner client.Object, obj client.Object, opts ...client.DeleteOption) error {
+	if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if ref := metav1.GetControllerOf(obj); ref != nil && ref.UID != owner.GetUID() {
+		logf.FromContext(ctx).Info("Skipping cleanup of resource controller-owned by a foreign owner",
+			"name", obj.GetName(), "namespace", obj.GetNamespace(),
+			"ownerKind", ref.Kind, "ownerName", ref.Name)
+		return nil
+	}
+	// Precondition on the observed UID so an object recreated by its
+	// legitimate owner between the Get and the Delete is not deleted.
+	uid := obj.GetUID()
+	opts = append(opts, client.Preconditions{UID: &uid})
+	return client.IgnoreNotFound(c.Delete(ctx, obj, opts...))
 }
 
 // parentLabels returns the operator-managed labels for parent-owned resources

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -19,8 +19,16 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	supersetv1alpha1 "github.com/apache/superset-kubernetes-operator/api/v1alpha1"
 	"github.com/apache/superset-kubernetes-operator/internal/common"
 )
 
@@ -82,4 +90,78 @@ func TestMergeAnnotations(t *testing.T) {
 	if mergeAnnotations(nil, nil) != nil {
 		t.Error("expected nil for both-nil input")
 	}
+}
+
+func TestDeleteIfNotForeignOwned(t *testing.T) {
+	// Regression test: name-derived cleanup must never delete a resource that
+	// is controller-owned by a foreign owner, even when it collides with a
+	// managed name. Unowned and CR-owned resources are still cleaned up.
+	ctx := context.Background()
+	scheme := testScheme(t)
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "uid-1"},
+	}
+	name := common.ResourceBaseName("test", common.ComponentWebServer)
+
+	newDeploy := func(refs []metav1.OwnerReference) *appsv1.Deployment {
+		return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: "default", OwnerReferences: refs,
+		}}
+	}
+	get := func(c client.Client) error {
+		return c.Get(ctx, client.ObjectKey{Name: name, Namespace: "default"}, &appsv1.Deployment{})
+	}
+
+	t.Run("deletes unowned resource at managed name", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(newDeploy(nil)).Build()
+		if err := deleteIfNotForeignOwned(ctx, c, superset, &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		}); err != nil {
+			t.Fatalf("deleteIfNotForeignOwned: %v", err)
+		}
+		if err := get(c); !errors.IsNotFound(err) {
+			t.Errorf("expected unowned Deployment deleted, got %v", err)
+		}
+	})
+
+	t.Run("deletes resource owned by the CR", func(t *testing.T) {
+		owned := newDeploy([]metav1.OwnerReference{{
+			APIVersion: supersetv1alpha1.GroupVersion.String(), Kind: "Superset",
+			Name: "test", UID: "uid-1", Controller: boolPtr(true),
+		}})
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(owned).Build()
+		if err := deleteIfNotForeignOwned(ctx, c, superset, &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		}); err != nil {
+			t.Fatalf("deleteIfNotForeignOwned: %v", err)
+		}
+		if err := get(c); !errors.IsNotFound(err) {
+			t.Errorf("expected CR-owned Deployment deleted, got %v", err)
+		}
+	})
+
+	t.Run("skips resource controller-owned by a foreign owner", func(t *testing.T) {
+		foreign := newDeploy([]metav1.OwnerReference{{
+			APIVersion: "apps.example.com/v1", Kind: "ForeignApp",
+			Name: "billing", UID: "foreign-uid", Controller: boolPtr(true),
+		}})
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(foreign).Build()
+		if err := deleteIfNotForeignOwned(ctx, c, superset, &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		}); err != nil {
+			t.Fatalf("deleteIfNotForeignOwned: %v", err)
+		}
+		if err := get(c); err != nil {
+			t.Errorf("expected foreign controller-owned Deployment preserved, got %v", err)
+		}
+	})
+
+	t.Run("missing object is not an error", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+		if err := deleteIfNotForeignOwned(ctx, c, superset, &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		}); err != nil {
+			t.Fatalf("deleteIfNotForeignOwned: %v", err)
+		}
+	})
 }

--- a/internal/controller/lifecycle_job.go
+++ b/internal/controller/lifecycle_job.go
@@ -469,15 +469,19 @@ func (r *SupersetReconciler) deleteTaskJobs(ctx context.Context, superset *super
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{Name: taskName, Namespace: superset.Namespace},
 	}
-	if err := r.deleteLifecycleJob(ctx, job); err != nil {
+	if err := r.deleteLifecycleJob(ctx, superset, job); err != nil {
 		return fmt.Errorf("deleting lifecycle task job: %w", err)
 	}
 	return nil
 }
 
-func (r *SupersetReconciler) deleteLifecycleJob(ctx context.Context, job *batchv1.Job) error {
-	err := r.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationForeground))
-	return client.IgnoreNotFound(err)
+// deleteLifecycleJob foreground-deletes a lifecycle task Job, but only when
+// the live Job is not controller-owned by a foreign owner: task Job names are
+// derived from the CR name, so a colliding Job belonging to someone else
+// (e.g. a CronJob-owned Job named {cr}-init) must not be deleted.
+func (r *SupersetReconciler) deleteLifecycleJob(ctx context.Context, superset *supersetv1alpha1.Superset, job *batchv1.Job) error {
+	return deleteIfNotForeignOwned(ctx, r.Client, superset, job,
+		client.PropagationPolicy(metav1.DeletePropagationForeground))
 }
 
 func (r *SupersetReconciler) cleanupLifecycleTaskJobsByRetention(ctx context.Context, superset *supersetv1alpha1.Superset) error {
@@ -512,7 +516,7 @@ func (r *SupersetReconciler) cleanupTaskJobsByRetention(ctx context.Context, sup
 			continue
 		}
 		if ShouldDeletePod(policy, phase) {
-			if err := r.deleteLifecycleJob(ctx, job); err != nil {
+			if err := r.deleteLifecycleJob(ctx, superset, job); err != nil {
 				return fmt.Errorf("deleting retained lifecycle task job %s: %w", job.Name, err)
 			}
 		}

--- a/internal/controller/maintenance.go
+++ b/internal/controller/maintenance.go
@@ -247,7 +247,7 @@ func (r *SupersetReconciler) deleteMaintenanceResources(ctx context.Context, sup
 			Namespace: superset.Namespace,
 		},
 	}
-	if err := r.Delete(ctx, deploy); err != nil && !errors.IsNotFound(err) {
+	if err := deleteIfNotForeignOwned(ctx, r.Client, superset, deploy); err != nil {
 		return fmt.Errorf("deleting maintenance Deployment: %w", err)
 	}
 
@@ -257,7 +257,7 @@ func (r *SupersetReconciler) deleteMaintenanceResources(ctx context.Context, sup
 			Namespace: superset.Namespace,
 		},
 	}
-	if err := r.Delete(ctx, cm); err != nil && !errors.IsNotFound(err) {
+	if err := deleteIfNotForeignOwned(ctx, r.Client, superset, cm); err != nil {
 		return fmt.Errorf("deleting maintenance ConfigMap: %w", err)
 	}
 	return nil

--- a/internal/controller/networking.go
+++ b/internal/controller/networking.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -96,7 +97,7 @@ func (r *SupersetReconciler) reconcileWebServerService(ctx context.Context, supe
 		svc := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: superset.Namespace},
 		}
-		if err := r.Delete(ctx, svc); err != nil && !errors.IsNotFound(err) {
+		if err := deleteIfNotForeignOwned(ctx, r.Client, superset, svc); err != nil && !errors.IsNotFound(err) {
 			return fmt.Errorf("deleting web-server Service: %w", err)
 		}
 		return nil
@@ -122,9 +123,7 @@ func (r *SupersetReconciler) reconcileWebServerService(ctx context.Context, supe
 	webServerLabels := componentLabels(string(common.ComponentWebServer), superset.Name)
 
 	_, err := createOrUpdateWithRetry(ctx, r.Client, svc, func() error {
-		// Clear existing owner references to handle upgrades from earlier
-		// versions where the Service may have been owned by another controller.
-		svc.OwnerReferences = nil
+		svc.OwnerReferences = stripLegacySupersetOwnerRefs(svc.OwnerReferences)
 		if err := controllerutil.SetControllerReference(superset, svc, r.Scheme); err != nil {
 			return err
 		}
@@ -142,6 +141,24 @@ func (r *SupersetReconciler) reconcileWebServerService(ctx context.Context, supe
 		return nil
 	})
 	return err
+}
+
+// stripLegacySupersetOwnerRefs removes ownerReferences that belong to this
+// operator's API group (left behind by earlier operator versions that owned
+// the web-server Service through a different Superset-operator resource) while
+// preserving every other ownerReference. Keeping foreign references intact is
+// load-bearing: it is what lets SetControllerReference reject adoption of a
+// Service that is controller-owned by a different controller.
+func stripLegacySupersetOwnerRefs(refs []metav1.OwnerReference) []metav1.OwnerReference {
+	var kept []metav1.OwnerReference
+	for _, ref := range refs {
+		gv, err := schema.ParseGroupVersion(ref.APIVersion)
+		if err == nil && gv.Group == supersetv1alpha1.GroupVersion.Group {
+			continue
+		}
+		kept = append(kept, ref)
+	}
+	return kept
 }
 
 // resolveWebServerPort returns the resolved web-server container port, taking

--- a/internal/controller/networking_test.go
+++ b/internal/controller/networking_test.go
@@ -835,3 +835,149 @@ func TestReconcileWebServerService_DeletesWhenWebServerRemoved(t *testing.T) {
 		t.Fatalf("reconcileWebServerService (absent): %v", err)
 	}
 }
+
+func TestReconcileWebServerService_DoesNotSeizeForeignOwnedService(t *testing.T) {
+	// Regression test: a Service that happens to sit at the derived
+	// {name}-web-server name but is controller-owned by a different controller
+	// must never be adopted or rewritten. The reconcile must surface
+	// AlreadyOwnedError and leave the foreign Service untouched.
+	ctx := context.Background()
+	scheme := testScheme(t)
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "billing", Namespace: "default", UID: "uid-1"},
+		Spec: supersetv1alpha1.SupersetSpec{
+			WebServer: &supersetv1alpha1.WebServerComponentSpec{},
+		},
+	}
+	svcName, _ := webServerServiceRef(superset)
+	foreign := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svcName,
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "billing-web-server",
+				UID:        "foreign-uid",
+				Controller: boolPtr(true),
+			}},
+		},
+		Spec: corev1.ServiceSpec{Selector: map[string]string{"app": "billing"}},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(superset, foreign).Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+
+	if err := r.reconcileWebServerService(ctx, superset); err == nil {
+		t.Fatal("expected error adopting a foreign controller-owned Service, got nil")
+	}
+
+	svc := &corev1.Service{}
+	if err := c.Get(ctx, client.ObjectKey{Name: svcName, Namespace: "default"}, svc); err != nil {
+		t.Fatalf("get service: %v", err)
+	}
+	if len(svc.OwnerReferences) != 1 || svc.OwnerReferences[0].UID != "foreign-uid" {
+		t.Errorf("expected foreign ownerReference preserved, got %+v", svc.OwnerReferences)
+	}
+	if svc.Spec.Selector["app"] != "billing" {
+		t.Errorf("expected foreign selector preserved, got %v", svc.Spec.Selector)
+	}
+}
+
+func TestReconcileWebServerService_AdoptsLegacySupersetOwnedService(t *testing.T) {
+	// Upgrade path: ownerReferences left behind by earlier Superset-operator
+	// versions (same API group) are stripped and the Service is re-owned by
+	// the current parent CR without an AlreadyOwnedError.
+	ctx := context.Background()
+	scheme := testScheme(t)
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "uid-1"},
+		Spec: supersetv1alpha1.SupersetSpec{
+			WebServer: &supersetv1alpha1.WebServerComponentSpec{},
+		},
+	}
+	svcName, _ := webServerServiceRef(superset)
+	legacy := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svcName,
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: supersetv1alpha1.GroupVersion.String(),
+				Kind:       "Superset",
+				Name:       "test",
+				UID:        "legacy-uid",
+				Controller: boolPtr(true),
+			}},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(superset, legacy).Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+
+	if err := r.reconcileWebServerService(ctx, superset); err != nil {
+		t.Fatalf("reconcileWebServerService (legacy owner): %v", err)
+	}
+
+	svc := &corev1.Service{}
+	if err := c.Get(ctx, client.ObjectKey{Name: svcName, Namespace: "default"}, svc); err != nil {
+		t.Fatalf("get service: %v", err)
+	}
+	if !isOwnedBy(svc, superset) {
+		t.Error("expected legacy Service re-owned by current parent CR")
+	}
+	for _, ref := range svc.OwnerReferences {
+		if ref.UID == "legacy-uid" {
+			t.Errorf("expected legacy ownerReference stripped, got %+v", svc.OwnerReferences)
+		}
+	}
+}
+
+func TestStripLegacySupersetOwnerRefs(t *testing.T) {
+	// Selectivity is the security-critical property: only ownerReferences in the
+	// operator's own API group (left by earlier operator versions) may be
+	// stripped so the Service can be re-adopted; every other reference — a
+	// foreign controller's, or one with an unparseable apiVersion — must survive
+	// so SetControllerReference still rejects adoption via AlreadyOwnedError.
+	supersetRef := metav1.OwnerReference{
+		APIVersion: supersetv1alpha1.GroupVersion.String(), Kind: "Superset",
+		Name: "legacy", UID: "legacy-uid", Controller: boolPtr(true),
+	}
+	// Same operator group, different (hypothetical) version — still ours.
+	supersetOtherVersion := metav1.OwnerReference{
+		APIVersion: supersetv1alpha1.GroupVersion.Group + "/v1beta1", Kind: "Superset",
+		Name: "legacy2", UID: "legacy2-uid",
+	}
+	foreignRef := metav1.OwnerReference{
+		APIVersion: "apps/v1", Kind: "Deployment",
+		Name: "billing", UID: "foreign-uid", Controller: boolPtr(true),
+	}
+	coreRef := metav1.OwnerReference{APIVersion: "v1", Kind: "ConfigMap", Name: "cm", UID: "cm-uid"}
+
+	uids := func(refs []metav1.OwnerReference) []string {
+		out := make([]string, 0, len(refs))
+		for _, r := range refs {
+			out = append(out, string(r.UID))
+		}
+		return out
+	}
+
+	tests := []struct {
+		name     string
+		in       []metav1.OwnerReference
+		wantUIDs []string
+	}{
+		{"nil is nil", nil, []string{}},
+		{"only legacy stripped to empty", []metav1.OwnerReference{supersetRef}, []string{}},
+		{"foreign preserved", []metav1.OwnerReference{foreignRef}, []string{"foreign-uid"}},
+		{
+			"mixed: only foreign survives",
+			[]metav1.OwnerReference{supersetRef, foreignRef, coreRef, supersetOtherVersion},
+			[]string{"foreign-uid", "cm-uid"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := uids(stripLegacySupersetOwnerRefs(tt.in)); !reflect.DeepEqual(got, tt.wantUIDs) {
+				t.Errorf("stripLegacySupersetOwnerRefs() UIDs = %v, want %v", got, tt.wantUIDs)
+			}
+		})
+	}
+}

--- a/internal/controller/superset_controller.go
+++ b/internal/controller/superset_controller.go
@@ -448,7 +448,7 @@ func reconcileParentOwnedConfigMap(
 		cm := &corev1.ConfigMap{}
 		cm.Name = cmName
 		cm.Namespace = parent.Namespace
-		return client.IgnoreNotFound(c.Delete(ctx, cm))
+		return deleteIfNotForeignOwned(ctx, c, parent, cm)
 	}
 
 	cm := &corev1.ConfigMap{

--- a/internal/controller/websocket_config.go
+++ b/internal/controller/websocket_config.go
@@ -72,7 +72,7 @@ func reconcileParentOwnedWebsocketConfigMap(
 		cm := &corev1.ConfigMap{}
 		cm.Name = cmName
 		cm.Namespace = parent.Namespace
-		return client.IgnoreNotFound(c.Delete(ctx, cm))
+		return deleteIfNotForeignOwned(ctx, c, parent, cm)
 	}
 
 	cm := &corev1.ConfigMap{


### PR DESCRIPTION
## Summary

Fixes two related access-control gaps that let a user holding only `supersets` create/update turn the operator's namespace-wide RBAC against resources owned by *other* controllers. Both contradict guarantees already documented in `docs/reference/security.md` ("controller-owner semantics prevent adopting resources already controlled by another controller", and the cleanup semantics that permit deleting only unowned same-name or operator-labeled resources), so this brings the code in line with the documented threat model rather than changing it.

## Details

**Web-server Service owner-reference wipe.** `reconcileWebServerService` set `svc.OwnerReferences = nil` inside the CreateOrUpdate mutate function before `controllerutil.SetControllerReference`, defeating the `AlreadyOwnedError` guard (the only site in the package that did this). A CR named to collide with a foreign controller-owned Service `{name}-web-server` would seize it — selector/ports rewritten to the attacker's pods — and garbage-collect it when the CR is deleted. The wipe is now scoped to legacy `superset.apache.org`-group owner refs (the actual upgrade case) via `stripLegacySupersetOwnerRefs`; foreign controller refs are preserved so `SetControllerReference` fails with `AlreadyOwnedError` and surfaces the conflict.

**Name-derived deletes ignored ownership.** Several cleanup paths (`deleteComponentResources`, `drainComponents`, `deleteMaintenanceResources`, `deleteLifecycleJob`, and the empty-config ConfigMap branches) deleted purely by CR-derived name with only `IgnoreNotFound`, so a foreign controller-owned resource at a colliding managed name was deleted on every reconcile — a persistent DoS the victim controller cannot win. A new `deleteIfNotForeignOwned` helper `Get`s the live object, skips it when it is controller-owned by a different owner, and otherwise deletes with a UID precondition (closing the Get/Delete race). All by-name delete sites route through it. Unowned same-name resources are still deleted, matching the documented cleanup contract.

Adds regression tests: foreign-owner preservation + reconcile error, legacy same-group owner adoption, and the ownership-gated delete predicate (unowned/CR-owned deleted, foreign preserved, missing tolerated).

## Testing

- `go build ./...`, `gofmt`, `golangci-lint run` clean
- `go test ./internal/controller/...` passes, including the new `TestDeleteIfNotForeignOwned`, `TestReconcileWebServerService_DoesNotSeizeForeignOwnedService`, and `TestReconcileWebServerService_AdoptsLegacySupersetOwnedService`

---
Found via a Claude security scan. Part of a series of security follow-ups; opened as a draft.