### PR TITLE
chore(asf): require one approving review to merge to main

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -67,8 +67,6 @@ github:
           - Apache Rat
       required_pull_request_reviews:
         dismiss_stale_reviews: false
-        # No CODEOWNERS file in this repo, so code-owner review is not required;
-        # any one committer's approval satisfies the gate.
         require_code_owner_reviews: false
         required_approving_review_count: 1
       required_signatures: false

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -65,5 +65,11 @@ github:
           - Helm lint & test
           - Unit & Integration
           - Apache Rat
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        # No CODEOWNERS file in this repo, so code-owner review is not required;
+        # any one committer's approval satisfies the gate.
+        require_code_owner_reviews: false
+        required_approving_review_count: 1
       required_signatures: false
 


### PR DESCRIPTION
## Summary

Adds `required_pull_request_reviews` to the `main` branch protection in `.asf.yaml` so a PR needs **at least one approving review** before it can be merged — matching the policy on the main [apache/superset](https://github.com/apache/superset) repo. Today `main` requires status checks but no review, so a committer can self-merge. This adds a second-set-of-eyes gate.

```yaml
      required_pull_request_reviews:
        dismiss_stale_reviews: false
        require_code_owner_reviews: false
        required_approving_review_count: 1
```

## Details

- **One approval required.** GitHub does not let an author approve their own PR, so this guarantees another committer signs off before merge. It stacks on top of the existing `required_status_checks` (both must be satisfied).
- **`require_code_owner_reviews: false`.** This repo has no `CODEOWNERS` file, so code-owner review would be a no-op; any committer's approval satisfies the gate. (The apache/superset repo sets this `true` because it *has* a CODEOWNERS.)

## Notes

- `.asf.yaml` takes effect once merged to the default branch (ASF infra reads it from `main`).
- YAML validated locally.
