### PR TITLE
chore(renovate): track golangci-lint via github-releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -385,7 +385,7 @@ CONTROLLER_TOOLS_VERSION ?= v0.21.0
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
-# renovate: datasource=go depName=github.com/golangci/golangci-lint/v2
+# renovate: datasource=github-releases depName=golangci/golangci-lint
 GOLANGCI_LINT_VERSION ?= v2.12.2
 # renovate: datasource=go depName=github.com/elastic/crd-ref-docs
 CRD_REF_DOCS_VERSION ?= v0.3.0


### PR DESCRIPTION
## Summary

The Renovate dependency dashboard reports:

> Failed to look up go package `github.com/golangci/golangci-lint/v2`: no-result. Files affected: `Makefile`

so golangci-lint version bumps are being missed. The Makefile annotation is correct for the `go` datasource, and that datasource resolves fine for every other Go-installed tool here (`kustomize/v5`, `controller-tools`, `crd-ref-docs`, `helm-docs`, `x/vuln`) — the failure is specific to golangci-lint, which is a long-standing problem case for the Go module-proxy lookup and tends to persist rather than clear on its own.

## Change

Track golangci-lint via the `github-releases` datasource against `golangci/golangci-lint`, which reads the GitHub release tags (`v2.12.2`, …) directly — the same approach already used for `operator-sdk` and `rumdl`:

```make
-# renovate: datasource=go depName=github.com/golangci/golangci-lint/v2
+# renovate: datasource=github-releases depName=golangci/golangci-lint
 GOLANGCI_LINT_VERSION ?= v2.12.2
```

The `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)` recipe is unchanged; only the version-discovery datasource changes.

## Testing

- `make lint-go` still resolves and runs golangci-lint (v2.12.2) clean
- Version discovery is verifiable once merged: the dashboard error should clear and golangci-lint should resume getting update PRs
