### PR TITLE
chore(renovate): track indirect Go modules at latest

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,12 @@
       "groupName": "Go dependencies"
     },
     {
+      "description": "Renovate disables indirect (transitive) Go modules by default, so minimal-version-selection floats them up only when a direct parent bumps — leaving them below their latest supported SemVer and behind version-based advisories (OpenSSF Scorecard / OSV) that reachability-based govulncheck never flags. Track indirect deps at latest; every bump is gated by CI (build, tests, govulncheck, Trivy), so a breaking transitive update fails its PR rather than merging. To hold a specific module below latest after a genuine breakage, add a per-package rule pinning it via allowedVersions or enabled:false.",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": true
+    },
+    {
       "description": "Keep the Go toolchain in lockstep: the go.mod `go` directive (gomod manager), the golang base image (dockerfile manager), and the devcontainer golang image (devcontainer manager) are separate deps that would otherwise open separate PRs. Group them so a Go release bumps all together in one PR.",
       "matchManagers": ["gomod", "dockerfile", "devcontainer"],
       "matchDepNames": ["go", "golang"],


### PR DESCRIPTION
## Summary

Renovate disables indirect (transitive) `gomod` dependencies by default, and `config:best-practices` doesn't change that. As a result Go's minimal-version-selection only floats an indirect module up when a *direct* parent requires a newer version, leaving transitive deps pinned below their latest supported SemVer. That is the root cause of the four OpenSSF Scorecard **Vulnerabilities** advisories addressed by the manual bump in #290 (cel-go, otel, x/mod): the versions were flagged by Scorecard's version-based OSV scan even though our reachability-based `govulncheck` gate stayed green.

This enables indirect deps so they track latest going forward, closing the loop so we don't rely on manual bumps or the weekly Scorecard run to notice transitive drift.

## Details

Adds a single `packageRule` (`matchManagers: ["gomod"]`, `matchDepTypes: ["indirect"]`, `enabled: true`). Indirect updates fold into the existing "Go dependencies" group and keep the 7-day `minimumReleaseAge` soak, so this doesn't create a flood of separate PRs.

Every bump is still gated by the existing CI suite — build, unit/integration/e2e, `govulncheck`, and Trivy — so a breaking transitive update fails its PR rather than merging. This matches the desired policy: **be on the latest supported indirect SemVer at all times, unless something actually breaks.** If a module genuinely breaks at latest, hold it lower with a per-package rule (`allowedVersions` or `enabled: false`), as documented in the rule's `description`.

Validated with `renovate-config-validator` (config validated successfully).