### PR TITLE
chore(deps): align go directive to 1.27 and auto-track it

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/superset-kubernetes-operator
 
-go 1.26.6
+go 1.27.0
 
 require (
 	github.com/adhocore/gronx v1.20.3

--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,12 @@
       "minimumReleaseAge": "0"
     },
     {
+      "description": "Renovate parses the go.mod `go` directive with go-mod-directive versioning, which treats `go 1.27.0` as a `>=1.27.0` minimum constraint rather than an exact pin. Under the default `replace` rangeStrategy Renovate only rewrites a range when the new version falls outside it, so every newer Go still satisfies the constraint and the directive never moves — drifting behind the golang image/devcontainer pins (which are exact and bump freely). Use `bump` so a Go release raises the directive to the latest in lockstep; the Go-toolchain group above then carries it in the same PR as the image bumps.",
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["go"],
+      "rangeStrategy": "bump"
+    },
+    {
       "matchPackageNames": ["kubernetes-sigs/kind"],
       "addLabels": ["review:supported-k8s"],
       "prBodyNotes": [


### PR DESCRIPTION
## Summary

PR #299 bumped the `golang` builder image to `1.27.0`, but the go.mod `go` directive stayed at `1.26.6`. Because Go's language level is gated by the `go` directive (not the toolchain that compiles it), the release image built
with 1.27 while the language level — and CI, which resolves `go-version-file: go.mod` — remained on 1.26. This bumps the directive to `1.27.0` so the language level, CI, and the builder/devcontainer images are all aligned on 1.27, and fixes the Renovate config so the directive never drifts again.

The drift was not intentional: #295 grouped the three golang pins with the stated intent that "1.27 will come through later as a grouped bump." It didn't, because Renovate parses the `go` directive with `go-mod-directive` versioning, treating `go 1.26.6` as a `>=1.26.6` minimum constraint. Under the default `replace` rangeStrategy, a range is only rewritten when the new version falls outside it — every newer Go still satisfied `>=1.26.6`, so the directive never moved while the exact-pinned image tags advanced freely.

## Details

- **go.mod**: `go 1.26.6` → `go 1.27.0` (no `toolchain` directive — 1.27 throughout). `go mod tidy` is a no-op; `go build`, `go vet`, the unit tests, and `golangci-lint` all pass under Go 1.27.
- **renovate.json**: add a rule scoping `rangeStrategy: bump` to the `go` directive (`matchManagers: ["gomod"], matchDepNames: ["go"]`). `bump` raises the constraint to the latest satisfying version even when the range still matches, so a Go release lifts the directive in lockstep. The rule sets only `rangeStrategy` — no `groupName` — so the directive rides in the existing "Go toolchain" group PR alongside the Dockerfile and devcontainer image bumps.