### PR TITLE
fix(controller): harden labels, checksum, and redaction

### DIFF
--- a/charts/superset-operator/templates/leader-election-role.yaml
+++ b/charts/superset-operator/templates/leader-election-role.yaml
@@ -21,9 +21,6 @@ metadata:
   labels:
     {{- include "superset-operator.labels" . | nindent 4 }}
 rules:
-  - apiGroups: [""]
-    resources: [configmaps]
-    verbs: [get, list, watch, create, update, patch, delete]
   - apiGroups: [coordination.k8s.io]
     resources: [leases]
     verbs: [get, list, watch, create, update, patch, delete]

--- a/charts/superset-operator/tests/__snapshot__/full_options_test.yaml.snap
+++ b/charts/superset-operator/tests/__snapshot__/full_options_test.yaml.snap
@@ -158,18 +158,6 @@ renders the full install manifests:
       namespace: my-namespace
     rules:
       - apiGroups:
-          - ""
-        resources:
-          - configmaps
-        verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - patch
-          - delete
-      - apiGroups:
           - coordination.k8s.io
         resources:
           - leases

--- a/charts/superset-operator/tests/__snapshot__/minimal_test.yaml.snap
+++ b/charts/superset-operator/tests/__snapshot__/minimal_test.yaml.snap
@@ -249,18 +249,6 @@ renders the default install manifests:
       namespace: my-namespace
     rules:
       - apiGroups:
-          - ""
-        resources:
-          - configmaps
-        verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - patch
-          - delete
-      - apiGroups:
           - coordination.k8s.io
         resources:
           - leases

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -8,18 +8,6 @@ metadata:
   name: leader-election-role
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
   - coordination.k8s.io
   resources:
   - leases

--- a/internal/controller/component_reconciler.go
+++ b/internal/controller/component_reconciler.go
@@ -34,6 +34,7 @@ import (
 
 	supersetv1alpha1 "github.com/apache/superset-kubernetes-operator/api/v1alpha1"
 	"github.com/apache/superset-kubernetes-operator/internal/common"
+	"github.com/apache/superset-kubernetes-operator/internal/resolution"
 )
 
 // componentReconcilerConfig captures the component-specific parameters needed
@@ -190,7 +191,7 @@ func reconcileComponentService(
 			userLabels = svcSpec.Labels
 			userAnnotations = svcSpec.Annotations
 		}
-		svc.Labels = mergeLabels(userLabels, labels)
+		svc.Labels = mergeLabels(resolution.StripReservedLabels(userLabels), labels)
 		svc.Annotations = mergeAnnotations(nil, userAnnotations)
 		return nil
 	})

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -160,9 +160,13 @@ func buildDeploymentSpec(
 	containers = append(containers, mainContainer)
 	containers = append(containers, pt.Sidecars...)
 
-	// Build pod labels and annotations.
+	// Build pod labels and annotations. Operator-managed annotations (the
+	// config-checksum that drives rollouts on config/SECRET_KEY changes) are
+	// merged last so they win over user pod-template annotations and cannot be
+	// pinned to freeze rollouts — matching the label rule and the lifecycle
+	// task-Job path (lifecycle_job.go).
 	podLabels := mergeLabels(pt.Labels, selectorLabels)
-	allPodAnnotations := mergeAnnotations(podAnnotations, pt.Annotations)
+	allPodAnnotations := mergeAnnotations(pt.Annotations, podAnnotations)
 
 	// Build PodSpec from PodTemplate.
 	podSpec := corev1.PodSpec{

--- a/internal/controller/deployment_builder_test.go
+++ b/internal/controller/deployment_builder_test.go
@@ -387,6 +387,29 @@ func TestBuildDeploymentSpec(t *testing.T) {
 			t.Errorf("user liveness probe path should be preserved: got %q", container.LivenessProbe.HTTPGet.Path)
 		}
 	})
+
+	t.Run("operator config-checksum annotation wins over user pod annotations", func(t *testing.T) {
+		spec := &supersetv1alpha1.FlatComponentSpec{
+			Image: supersetv1alpha1.ImageSpec{Repository: "apache/superset", Tag: "latest"},
+			PodTemplate: &supersetv1alpha1.PodTemplate{
+				Annotations: map[string]string{
+					common.AnnotationConfigChecksum: "forged-by-user",
+					"user/other":                    "keep",
+				},
+			},
+		}
+		cfg := DeploymentConfig{ContainerName: common.Container}
+		operatorAnnotations := map[string]string{common.AnnotationConfigChecksum: "sha256:real"}
+
+		result := buildDeploymentSpec(spec, cfg, operatorAnnotations, map[string]string{})
+		got := result.Template.Annotations
+		if got[common.AnnotationConfigChecksum] != "sha256:real" {
+			t.Errorf("operator config-checksum must win over a forged user annotation, got %q", got[common.AnnotationConfigChecksum])
+		}
+		if got["user/other"] != "keep" {
+			t.Errorf("non-reserved user pod annotations should be preserved, got %q", got["user/other"])
+		}
+	})
 }
 
 func TestResolveContainerPort(t *testing.T) {

--- a/internal/controller/monitoring.go
+++ b/internal/controller/monitoring.go
@@ -30,6 +30,7 @@ import (
 
 	supersetv1alpha1 "github.com/apache/superset-kubernetes-operator/api/v1alpha1"
 	"github.com/apache/superset-kubernetes-operator/internal/common"
+	"github.com/apache/superset-kubernetes-operator/internal/resolution"
 )
 
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete
@@ -71,7 +72,7 @@ func (r *SupersetReconciler) reconcileServiceMonitor(ctx context.Context, supers
 
 		operatorLabels := parentLabels(superset.Name)
 		operatorLabels[common.LabelKeyInstance] = superset.Name
-		labels := mergeLabels(sm.Labels, operatorLabels)
+		labels := mergeLabels(resolution.StripReservedLabels(sm.Labels), operatorLabels)
 		obj.SetLabels(labels)
 
 		endpoint := map[string]interface{}{

--- a/internal/controller/monitoring_test.go
+++ b/internal/controller/monitoring_test.go
@@ -159,6 +159,54 @@ func TestReconcileMonitoring_ServiceMonitorShape(t *testing.T) {
 	}
 }
 
+// TestReconcileMonitoring_StripsReservedLabels verifies a forged reserved
+// superset.apache.org/* label on serviceMonitor.labels does not survive onto
+// the ServiceMonitor. Uses a reserved key the operator does NOT force
+// (init-task), so it proves stripping rather than merge order.
+func TestReconcileMonitoring_StripsReservedLabels(t *testing.T) {
+	scheme := testScheme(t)
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "uid-1"},
+		Spec: supersetv1alpha1.SupersetSpec{
+			Image:     supersetv1alpha1.ImageSpec{Repository: "apache/superset", Tag: "latest"},
+			WebServer: &supersetv1alpha1.WebServerComponentSpec{},
+			Lifecycle: &supersetv1alpha1.LifecycleSpec{Disabled: boolPtr(true)},
+			Monitoring: &supersetv1alpha1.MonitoringSpec{
+				ServiceMonitor: &supersetv1alpha1.ServiceMonitorSpec{
+					Labels: map[string]string{
+						"superset.apache.org/init-task": "victim",
+						"release":                       "prometheus",
+					},
+				},
+			},
+		},
+	}
+	seed := &unstructured.Unstructured{}
+	seed.SetGroupVersionKind(serviceMonitorGVK)
+	seed.SetName("test")
+	seed.SetNamespace("default")
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(superset, seed).Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+	if err := r.reconcileMonitoring(context.Background(), superset); err != nil {
+		t.Fatalf("reconcileMonitoring: %v", err)
+	}
+	sm := &unstructured.Unstructured{}
+	sm.SetGroupVersionKind(serviceMonitorGVK)
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, sm); err != nil {
+		t.Fatalf("get ServiceMonitor: %v", err)
+	}
+	labels := sm.GetLabels()
+	if _, ok := labels["superset.apache.org/init-task"]; ok {
+		t.Errorf("forged reserved label survived on ServiceMonitor: %v", labels)
+	}
+	if labels["release"] != "prometheus" {
+		t.Errorf("non-reserved user label should survive, got %q", labels["release"])
+	}
+	if labels[common.LabelKeyParent] != "test" {
+		t.Errorf("operator parent label must be forced, got %q", labels[common.LabelKeyParent])
+	}
+}
+
 func TestDeleteServiceMonitors(t *testing.T) {
 	scheme := testScheme(t)
 

--- a/internal/controller/networking.go
+++ b/internal/controller/networking.go
@@ -136,7 +136,7 @@ func (r *SupersetReconciler) reconcileWebServerService(ctx context.Context, supe
 			userLabels = svcSpec.Labels
 			userAnnotations = svcSpec.Annotations
 		}
-		svc.Labels = mergeLabels(userLabels, webServerLabels)
+		svc.Labels = mergeLabels(resolution.StripReservedLabels(userLabels), webServerLabels)
 		svc.Annotations = mergeAnnotations(nil, userAnnotations)
 		return nil
 	})
@@ -197,7 +197,7 @@ func (r *SupersetReconciler) reconcileHTTPRoute(ctx context.Context, superset *s
 			return err
 		}
 
-		route.Labels = mergeLabels(gw.Labels, parentLabels(superset.Name))
+		route.Labels = mergeLabels(resolution.StripReservedLabels(gw.Labels), parentLabels(superset.Name))
 		route.Annotations = mergeAnnotations(nil, gw.Annotations)
 
 		// Rules are ordered most-specific first (web "/" last) by componentRoutes.
@@ -379,7 +379,7 @@ func (r *SupersetReconciler) reconcileIngress(ctx context.Context, superset *sup
 			return err
 		}
 
-		ingress.Labels = mergeLabels(ing.Labels, parentLabels(superset.Name))
+		ingress.Labels = mergeLabels(resolution.StripReservedLabels(ing.Labels), parentLabels(superset.Name))
 		ingress.Annotations = mergeAnnotations(nil, ing.Annotations)
 
 		ingress.Spec = networkingv1.IngressSpec{

--- a/internal/controller/networking_test.go
+++ b/internal/controller/networking_test.go
@@ -156,6 +156,97 @@ func TestReconcileNetworking_GatewayEnabled_CreatesHTTPRoute(t *testing.T) {
 	}
 }
 
+// TestReconcileNetworking_StripsReservedLabelsOnHTTPRoute verifies a CR author
+// cannot forge a reserved superset.apache.org/* label onto the HTTPRoute via
+// gateway.labels. Uses a reserved key the operator does NOT force (instance),
+// so it proves stripping, not just merge order.
+func TestReconcileNetworking_StripsReservedLabelsOnHTTPRoute(t *testing.T) {
+	scheme := testScheme(t)
+	gwNamespace := gatewayv1.Namespace("gateway-system")
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "uid-1"},
+		Spec: supersetv1alpha1.SupersetSpec{
+			Image:     supersetv1alpha1.ImageSpec{Repository: "apache/superset", Tag: "latest"},
+			WebServer: &supersetv1alpha1.WebServerComponentSpec{},
+			Lifecycle: &supersetv1alpha1.LifecycleSpec{Disabled: boolPtr(true)},
+			Networking: &supersetv1alpha1.NetworkingSpec{
+				Gateway: &supersetv1alpha1.GatewaySpec{
+					GatewayRef: gatewayv1.ParentReference{Name: "my-gateway", Namespace: &gwNamespace},
+					Hostnames:  []gatewayv1.Hostname{"superset.example.com"},
+					Labels: map[string]string{
+						"superset.apache.org/instance": "victim",
+						"team":                         "data",
+					},
+				},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(superset).Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+	if err := r.reconcileNetworking(context.Background(), superset); err != nil {
+		t.Fatalf("reconcileNetworking: %v", err)
+	}
+	route := &gatewayv1.HTTPRoute{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, route); err != nil {
+		t.Fatalf("expected HTTPRoute: %v", err)
+	}
+	if _, ok := route.Labels["superset.apache.org/instance"]; ok {
+		t.Errorf("forged reserved label survived on HTTPRoute: %v", route.Labels)
+	}
+	if route.Labels[common.LabelKeyParent] != "test" {
+		t.Errorf("operator parent label must be forced, got %q", route.Labels[common.LabelKeyParent])
+	}
+	if route.Labels["team"] != "data" {
+		t.Errorf("non-reserved user label should survive, got %q", route.Labels["team"])
+	}
+}
+
+// TestReconcileNetworking_StripsReservedLabelsOnIngress is the Ingress twin.
+func TestReconcileNetworking_StripsReservedLabelsOnIngress(t *testing.T) {
+	scheme := testScheme(t)
+	className := "nginx"
+	superset := &supersetv1alpha1.Superset{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "uid-1"},
+		Spec: supersetv1alpha1.SupersetSpec{
+			Image:     supersetv1alpha1.ImageSpec{Repository: "apache/superset", Tag: "latest"},
+			WebServer: &supersetv1alpha1.WebServerComponentSpec{},
+			Lifecycle: &supersetv1alpha1.LifecycleSpec{Disabled: boolPtr(true)},
+			Networking: &supersetv1alpha1.NetworkingSpec{
+				Ingress: &supersetv1alpha1.IngressSpec{
+					ClassName: &className,
+					Labels: map[string]string{
+						"superset.apache.org/instance": "victim",
+						"team":                         "data",
+					},
+					Hosts: []supersetv1alpha1.IngressHost{
+						{Host: "superset.example.com", Paths: []supersetv1alpha1.IngressPath{
+							{Path: "/", PathType: pathTypePtr(networkingv1.PathTypePrefix)},
+						}},
+					},
+				},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(superset).Build()
+	r := &SupersetReconciler{Client: c, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+	if err := r.reconcileIngress(context.Background(), superset); err != nil {
+		t.Fatalf("reconcileIngress: %v", err)
+	}
+	ing := &networkingv1.Ingress{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, ing); err != nil {
+		t.Fatalf("expected Ingress: %v", err)
+	}
+	if _, ok := ing.Labels["superset.apache.org/instance"]; ok {
+		t.Errorf("forged reserved label survived on Ingress: %v", ing.Labels)
+	}
+	if ing.Labels[common.LabelKeyParent] != "test" {
+		t.Errorf("operator parent label must be forced, got %q", ing.Labels[common.LabelKeyParent])
+	}
+	if ing.Labels["team"] != "data" {
+		t.Errorf("non-reserved user label should survive, got %q", ing.Labels["team"])
+	}
+}
+
 func TestReconcileHTTPRoute_WithWebsocket(t *testing.T) {
 	scheme := testScheme(t)
 

--- a/internal/controller/redact.go
+++ b/internal/controller/redact.go
@@ -58,11 +58,12 @@ var (
 	// separator, which its key class does not allow — so quoted-key forms are a
 	// whole serialization class it systematically misses. The value is matched as
 	// a quoted string of either style (RE2 has no backreferences, so both quote
-	// styles are spelled out) and masked in full, including embedded whitespace.
+	// styles are spelled out) or as a delimiter-bounded bare value, and masked in
+	// full, including embedded whitespace for quoted values.
 	// "authorization" is included because authorizationHeaderRe is equally
 	// quote-blind. The value is replaced with a bare placeholder so a re-run
 	// finds no quoted value to match (idempotent).
-	quotedKeyCredentialRe = regexp.MustCompile(`(?i)(["'][A-Za-z0-9_-]*(?:password|passwd|pwd|secret|token|api[_-]?key|credential|passphrase|authorization)[A-Za-z0-9_-]*["']\s*[=:]\s*)("[^"]*"|'[^']*')`)
+	quotedKeyCredentialRe = regexp.MustCompile(`(?i)(["'][A-Za-z0-9_-]*(?:password|passwd|pwd|secret|token|api[_-]?key|credential|passphrase|authorization)[A-Za-z0-9_-]*["']\s*[=:]\s*)("[^"]*"|'[^']*'|[^,\s}\]]+)`)
 )
 
 // redactCredentials masks credential-shaped substrings in free-form task

--- a/internal/controller/redact.go
+++ b/internal/controller/redact.go
@@ -50,6 +50,19 @@ var (
 	// "password=hunter2", "PGPASSWORD: hunter2", or "secret_key = hunter2".
 	// The key may carry prefixes/suffixes (DB_PASSWORD, api-key-prod).
 	credentialAssignmentRe = regexp.MustCompile(`(?i)([A-Za-z0-9_-]*(?:password|passwd|pwd|secret|token|api[_-]?key|credential|passphrase)[A-Za-z0-9_-]*\s*[=:]\s*)(\S+)`)
+
+	// quotedKeyCredentialRe matches quoted-key credential assignments as emitted
+	// by JSON payloads and Python dict/traceback reprs, e.g.
+	// {"password": "hunter2"} or {'db_password': 'hunter2'}. credentialAssignmentRe
+	// cannot match these — the closing quote sits between the keyword and the
+	// separator, which its key class does not allow — so quoted-key forms are a
+	// whole serialization class it systematically misses. The value is matched as
+	// a quoted string of either style (RE2 has no backreferences, so both quote
+	// styles are spelled out) and masked in full, including embedded whitespace.
+	// "authorization" is included because authorizationHeaderRe is equally
+	// quote-blind. The value is replaced with a bare placeholder so a re-run
+	// finds no quoted value to match (idempotent).
+	quotedKeyCredentialRe = regexp.MustCompile(`(?i)(["'][A-Za-z0-9_-]*(?:password|passwd|pwd|secret|token|api[_-]?key|credential|passphrase|authorization)[A-Za-z0-9_-]*["']\s*[=:]\s*)("[^"]*"|'[^']*')`)
 )
 
 // redactCredentials masks credential-shaped substrings in free-form task
@@ -65,5 +78,11 @@ func redactCredentials(msg string) string {
 	msg = authorizationHeaderRe.ReplaceAllString(msg, "${1}"+redactedPlaceholder)
 	msg = bareBearerRe.ReplaceAllString(msg, "${1}"+redactedPlaceholder)
 	msg = credentialAssignmentRe.ReplaceAllString(msg, "${1}"+redactedPlaceholder)
+	// Quoted-key forms (JSON, Python dict repr) must run too — the unquoted
+	// assignment pattern above cannot match them. Mask the whole quoted value
+	// with a bare placeholder (not a re-quoted string) so a second pass finds no
+	// quoted value to match, keeping redaction idempotent even on adversarial,
+	// unbalanced-quote input.
+	msg = quotedKeyCredentialRe.ReplaceAllString(msg, "${1}"+redactedPlaceholder)
 	return msg
 }

--- a/internal/controller/redact_fuzz_test.go
+++ b/internal/controller/redact_fuzz_test.go
@@ -35,7 +35,9 @@ func FuzzRedactCredentials(f *testing.F) {
 	f.Add("Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.p.s bearer abc123")
 	f.Add("authorization=Basic dXNlcjpwYXNz passphrase: x")
 	f.Add(`{"host": "db", "password": "hunter2", "port": 5432}`)
+	f.Add(`{"host": "db", "password": hunter2, "port": 5432}`)
 	f.Add("{'db_password': 'hunter2', 'user': 'admin'}")
+	f.Add("{'db_password': 12345, 'user': 'admin'}")
 	f.Add(`"secret_key": "two words" 'token':'abc'`)
 	// Regression seed (fuzz-discovered): a quoted-key credential whose value has
 	// an unbalanced quote once broke idempotence — an inner keyword match fired

--- a/internal/controller/redact_fuzz_test.go
+++ b/internal/controller/redact_fuzz_test.go
@@ -34,6 +34,14 @@ func FuzzRedactCredentials(f *testing.F) {
 	f.Add("postgresql://user:p@ss@db:5432/superset")
 	f.Add("Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.p.s bearer abc123")
 	f.Add("authorization=Basic dXNlcjpwYXNz passphrase: x")
+	f.Add(`{"host": "db", "password": "hunter2", "port": 5432}`)
+	f.Add("{'db_password': 'hunter2', 'user': 'admin'}")
+	f.Add(`"secret_key": "two words" 'token':'abc'`)
+	// Regression seed (fuzz-discovered): a quoted-key credential whose value has
+	// an unbalanced quote once broke idempotence — an inner keyword match fired
+	// on the first pass, then the outer key re-matched on the second. Guards the
+	// bare-placeholder replacement in quotedKeyCredentialRe.
+	f.Add(`"seCret0000": "token0':''`)
 
 	f.Fuzz(func(t *testing.T, msg string) {
 		once := redactCredentials(msg)

--- a/internal/controller/redact_test.go
+++ b/internal/controller/redact_test.go
@@ -116,9 +116,34 @@ func TestRedactCredentials(t *testing.T) {
 			want: "ssl passphrase=*** rejected",
 		},
 		{
+			name: "json quoted key and value",
+			in:   `{"host": "db", "password": "hunter2"}`,
+			want: `{"host": "db", "password": ***}`,
+		},
+		{
+			name: "python dict repr single quotes",
+			in:   "{'host': 'db', 'db_password': 'hunter2'}",
+			want: `{'host': 'db', 'db_password': ***}`,
+		},
+		{
+			name: "quoted secret_key with spaces in value is masked in full",
+			in:   `"secret_key": "two words here"`,
+			want: `"secret_key": ***`,
+		},
+		{
+			name: "quoted authorization value",
+			in:   `"authorization": "Bearer eyJ.abc.def"`,
+			want: `"authorization": ***`,
+		},
+		{
 			name: "idempotent on already-redacted output",
 			in:   "postgresql://superset:***@db:5432/superset password=*** Authorization: Bearer ***",
 			want: "postgresql://superset:***@db:5432/superset password=*** Authorization: Bearer ***",
+		},
+		{
+			name: "idempotent on already-redacted quoted value",
+			in:   `{"password": ***}`,
+			want: `{"password": ***}`,
 		},
 	}
 

--- a/internal/controller/redact_test.go
+++ b/internal/controller/redact_test.go
@@ -126,6 +126,16 @@ func TestRedactCredentials(t *testing.T) {
 			want: `{'host': 'db', 'db_password': ***}`,
 		},
 		{
+			name: "json quoted key with bare value",
+			in:   `{"host": "db", "password": hunter2, "port": 5432}`,
+			want: `{"host": "db", "password": ***, "port": 5432}`,
+		},
+		{
+			name: "python dict repr quoted key with bare numeric value",
+			in:   "{'host': 'db', 'password': 12345}",
+			want: `{'host': 'db', 'password': ***}`,
+		},
+		{
 			name: "quoted secret_key with spaces in value is masked in full",
 			in:   `"secret_key": "two words here"`,
 			want: `"secret_key": ***`,

--- a/internal/resolution/merge.go
+++ b/internal/resolution/merge.go
@@ -53,6 +53,15 @@ func stripReservedLabels(labels map[string]string) map[string]string {
 	return result
 }
 
+// StripReservedLabels returns labels without any key under the reserved
+// superset.apache.org/ prefix. Callers outside this package (e.g. Service /
+// Deployment metadata merges in the controller) use it so user-supplied labels
+// cannot forge the operator's reserved identity labels on any operator-written
+// object, not only pod templates.
+func StripReservedLabels(labels map[string]string) map[string]string {
+	return stripReservedLabels(labels)
+}
+
 // ForceOperatorPodLabels folds operator-managed labels into user-supplied pod
 // labels: every user key under the reserved superset.apache.org/ prefix is
 // dropped first, then operatorLabels are applied last so they always win.
@@ -160,7 +169,7 @@ func MergeDeploymentTemplate(comp, tl *supersetv1alpha1.DeploymentTemplate) *sup
 		MinReadySeconds:         ResolveOverridableValue(c.MinReadySeconds, t.MinReadySeconds),
 		ProgressDeadlineSeconds: ResolveOverridableValue(c.ProgressDeadlineSeconds, t.ProgressDeadlineSeconds),
 		Strategy:                ResolveOverridableValue(c.Strategy, t.Strategy),
-		Labels:                  MergeMaps(t.Labels, c.Labels),
+		Labels:                  MergeMaps(stripReservedLabels(t.Labels), stripReservedLabels(c.Labels)),
 		Annotations:             MergeMaps(t.Annotations, c.Annotations),
 	}
 	if result.RevisionHistoryLimit == nil && result.MinReadySeconds == nil &&

--- a/internal/resolution/override_protection_test.go
+++ b/internal/resolution/override_protection_test.go
@@ -162,6 +162,16 @@ func TestMergeDeploymentTemplate_ReservedLabelPrefixStripped(t *testing.T) {
 	}
 }
 
+func TestStripReservedLabels_AllReservedReturnsNil(t *testing.T) {
+	result := StripReservedLabels(map[string]string{
+		common.LabelKeyParent:              "victim",
+		"superset.apache.org/custom-claim": "forged",
+	})
+	if result != nil {
+		t.Fatalf("expected nil when all labels are reserved, got %#v", result)
+	}
+}
+
 func secretEnvSource(name, key string) *corev1.EnvVarSource {
 	return &corev1.EnvVarSource{
 		SecretKeyRef: &corev1.SecretKeySelector{

--- a/internal/resolution/override_protection_test.go
+++ b/internal/resolution/override_protection_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package resolution
 
 import (
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -129,6 +130,35 @@ func TestMergePodTemplate_ReservedLabelPrefixStripped(t *testing.T) {
 	// Non-reserved user labels still merge through.
 	if got := result.Labels["team"]; got != "data" {
 		t.Errorf("label team = %q, want data (user label preserved)", got)
+	}
+}
+
+// TestMergeDeploymentTemplate_ReservedLabelPrefixStripped verifies that reserved
+// superset.apache.org/ labels are unforgeable on Deployment object metadata too,
+// not only pod templates: a CR author must not be able to stamp another
+// instance's parent label onto their Deployment/Service metadata.
+func TestMergeDeploymentTemplate_ReservedLabelPrefixStripped(t *testing.T) {
+	comp := &supersetv1alpha1.DeploymentTemplate{
+		Labels: map[string]string{
+			common.LabelKeyParent: "victim",
+			"team":                "data",
+		},
+	}
+	tl := &supersetv1alpha1.DeploymentTemplate{
+		Labels: map[string]string{"superset.apache.org/instance": "victim-web-server"},
+	}
+
+	result := MergeDeploymentTemplate(comp, tl)
+	if result == nil {
+		t.Fatal("expected a non-nil merged template")
+	}
+	for k := range result.Labels {
+		if strings.HasPrefix(k, "superset.apache.org/") {
+			t.Errorf("reserved label %q survived the deployment-template merge", k)
+		}
+	}
+	if got := result.Labels["team"]; got != "data" {
+		t.Errorf("label team = %q, want data (non-reserved user label preserved)", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Four independent low-severity findings from a Claude security scan, each a small blast-radius / consistency hardening with no shared root cause.

## Details

- **Leader-election Role granted unused ConfigMap CRUD.** controller-runtime defaults to the Leases lock and `cmd/main.go` never selects a ConfigMap lock, so the grant is dead. Removed from the Kustomize Role and the Helm chart twin (snapshots regenerated); the manager ClusterRole's legitimate ConfigMap access is unchanged.
- **Reserved `superset.apache.org/` labels were forgeable on non-pod object metadata** (only pod templates were stripped). A CR author could stamp another instance's reserved labels onto their Deployment, Service, HTTPRoute, Ingress, or ServiceMonitor. Merge order alone is insufficient here: the operator only *forces* a few reserved keys per object, so any reserved-prefixed key it doesn't set survives a merge. The whole `superset.apache.org/` prefix is now stripped from user labels before the operator's own labels are applied — in `MergeDeploymentTemplate` (covering Deployment metadata via the resolver) and at every Service / HTTPRoute / Ingress / ServiceMonitor metadata merge (via the newly exported `resolution.StripReservedLabels`) — so the reserved namespace is unforgeable on every operator-written object.
- **Credential redaction missed quoted-key formats.** `credentialAssignmentRe` couldn't match JSON / Python-dict-repr forms (`"password": "x"`, `'db_password': 'x'`) — the closing quote sits between the keyword and the separator — a whole serialization class. Added `quotedKeyCredentialRe` (also covering `authorization`) that masks the quoted value in full with a bare placeholder, keeping redaction idempotent even on adversarial unbalanced-quote input; added quoted-key cases to the unit and fuzz corpora (including a fuzz-discovered regression seed).
- **User pod annotations could override the operator config-checksum annotation.** `buildDeploymentSpec` merged user pod-template annotations last, so a CR author could pin `superset.apache.org/config-checksum` and freeze rollouts (config and SECRET_KEY rotations stop rolling pods while status misreports as reconciled). The merge order now applies operator annotations last (matching the label rule and the lifecycle task-Job path). Also covers the maintenance-page Deployment (same builder).

## Release notes

- Instances that had pinned the `superset.apache.org/config-checksum` pod annotation roll once on upgrade as the operator's computed checksum reasserts itself.

Found via a Claude security scan.