### PR TITLE
ci: check Go formatter output in lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,11 +293,13 @@ lint-fix: lint-go-fix lint-md-fix ## Auto-fix all linters that support it (Go, M
 
 .PHONY: lint-go
 lint-go: golangci-lint ## Run the Go linter (golangci-lint).
+	$(GOLANGCI_LINT) fmt --diff
 	$(GOLANGCI_LINT) run
 
 .PHONY: lint-go-fix
 lint-go-fix: golangci-lint ## Run the Go linter and apply fixes.
 	$(GOLANGCI_LINT) run --fix
+	$(GOLANGCI_LINT) fmt
 
 .PHONY: lint-go-config
 lint-go-config: golangci-lint ## Verify the golangci-lint configuration.


### PR DESCRIPTION
## Summary

`make lint-go` previously only ran `golangci-lint run`, which checks linters but does not run golangci-lint v2 formatters.

In golangci-lint v2, formatter checks such as `gofmt` and `goimports` moved out of the linter configuration and into the dedicated `formatters:` section. The upstream migration guide documents this change: https://golangci-lint.run/docs/product/migration-guide/#lintersenableformatter_name

Because this repository enables `gofmt` and `goimports` under `formatters:`, CI must call `golangci-lint fmt --diff` explicitly. Without that separate formatter check, Go files can pass `make lint` even when they still need gofmt/goimports cleanup.

## Details

- Runs `golangci-lint fmt --diff` before `golangci-lint run` in `make lint-go`, so formatting/import drift fails quickly before the heavier analyzer pass.
- Keeps `golangci-lint fmt` after `golangci-lint run --fix` in `make lint-go-fix`, because analyzer autofixes may rewrite code and the formatter should normalize the final result.
- Leaves the existing analyzer configuration unchanged, including the intentional test-file exclusions for selected production-oriented linters.

## Verification

- `make lint-go`
